### PR TITLE
Productize agent runtime and add TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # Sigma Agent Runtime
 
-A small coding-agent monorepo inspired by Pi with three layers:
+A small coding-agent monorepo inspired by Pi with four layers:
 
 - `packages/agent-ai`: provider-agnostic model interface for DeepSeek and GLM/Zhipu
-- `packages/agent-core`: autonomous loop, extensible tool registry, repo-aware context, benchmark harness, JSONL tracing, session records, MCP bridge, and workspace tools
+- `packages/agent-core`: agent run controller, validation and retry controller, extensible tool registry, repo-aware context, JSONL tracing, session records, MCP bridge, and workspace tools
 - `packages/agent-cli`: plain terminal CLI with `solve`, `chat`, `doctor`, and `replay`
+- `packages/agent-tui`: interactive terminal product entry that drives `agent-core` directly
 
-Sigma keeps the CLI and harness portable while adding repo instructions, deterministic repo maps, live stderr progress, approval-gated mutating tools, and stdio MCP tools. There is intentionally no large web UI, sub-agent system, plugin marketplace, long-term memory, or Docker sandbox in this repo.
+Sigma keeps the product runtime portable while adding repo instructions, deterministic repo maps, live progress, approval-gated mutating tools, and stdio MCP tools. There is intentionally no large web UI, sub-agent system, plugin marketplace, long-term memory, or Docker sandbox in this repo.
 
 ## Install And Build
 
@@ -14,12 +15,21 @@ Sigma keeps the CLI and harness portable while adding repo instructions, determi
 pnpm install
 pnpm build
 pnpm test
+pnpm test:harbor
 ```
+
+`pnpm test` runs the product TypeScript/Vitest suite. `pnpm test:harbor` runs only the external Harbor adapter Python tests, and `pnpm test:all` runs both.
 
 The CLI binary is named `agent` after build:
 
 ```bash
 pnpm --filter agent-cli start -- --help
+```
+
+The TUI entry is named `agent-tui` after build:
+
+```bash
+pnpm --filter agent-tui start -- --help
 ```
 
 ## Local Usage
@@ -47,6 +57,18 @@ DEEPSEEK_API_KEY=... pnpm --filter agent-cli start -- solve \
   --trace-jsonl ./trace.jsonl \
   --summary-json ./summary.json
 ```
+
+Interactive TUI example:
+
+```bash
+pnpm --filter agent-tui start -- \
+  --workspace . \
+  --provider deepseek \
+  --model deepseek-v4-pro \
+  --permission-mode ask
+```
+
+Type a task and press Enter to start one run. TUI commands include `/exit`, `/clear`, `/model`, `/provider`, `/permission`, `/tools`, and `/diff`. The TUI uses `agent-core` directly; it does not shell out to `agent chat` and does not import Harbor or Terminal-Bench scripts.
 
 GLM/Zhipu example:
 
@@ -109,7 +131,9 @@ AGENT_PROVIDER=deepseek pnpm smoke:harbor
 
 The Harbor artifact is a self-contained Linux bundle when built with a Node runtime tarball. Provide `NODE_RUNTIME_TARBALL` or place the pinned Node tarball in `.artifacts/cache/`; task containers do not need system `node` for the preferred tarball install path.
 
-## Benchmark Runs
+## External Benchmark Adapters
+
+Harbor and Terminal-Bench support lives at the edge of the repo in `portable/harbor` and `scripts/bench-*`. Those files are external adapters and reporting tools. They may package and launch Sigma, but product core code must not depend on Harbor task identity, verifier output, benchmark names, or scoring details.
 
 Terminal-Bench benchmark runs use Harbor, package the Sigma CLI first, and save artifacts under `.artifacts/bench/<run-id>/`. The run id is `YYYYMMDD-HHMMSS-provider-model`.
 
@@ -160,13 +184,13 @@ Refresh all reports:
 pnpm bench:tb:report:all
 ```
 
-Each run directory contains `config.json`, `command.sh`, `resolved-job.config.json`, `harbor.stdout.log`, `harbor.stderr.log`, `result.raw.log`, `report.json`, `report.md`, and `tasks/<task-id-or-index>/` when per-task files are available. The Harbor adapter always attempts to download `trace.jsonl`, `summary.json`, and harness attempt artifacts; if Harbor does not expose task context in a predictable way, the report falls back to `harbor-jobs/**/agent/trace.jsonl` and Harbor trial `result.json`.
+Each run directory contains `config.json`, `command.sh`, `resolved-job.config.json`, `harbor.stdout.log`, `harbor.stderr.log`, `result.raw.log`, `report.json`, `report.md`, and `tasks/<task-id-or-index>/` when per-task files are available. The Harbor adapter always attempts to download `trace.jsonl`, `summary.json`, and run attempt artifacts; if Harbor does not expose task context in a predictable way, the report falls back to `harbor-jobs/**/agent/trace.jsonl` and Harbor trial `result.json`.
 
 Failure categories are rule based and intentionally small: `host_proxy_error`, `host_encoding_error`, `harbor_cli_error`, `node_missing`, `agent_setup_failed`, `api_error`, `agent_timeout`, `max_turns`, `tool_timeout`, `verifier_failed`, `agent_crashed`, and `unknown`. Counts in `report.json` group those into `passed`, `failed`, `infra_failed`, `timeout`, `api_error`, and `unknown`.
 
 Benchmark reports include `suggested_owner` for each task to guide follow-up fixes. Unless it points to `portable/harbor` or `scripts/bench`, do not prioritize changes to Harbor adapter plumbing.
 
-Validation, retry, precheck, cleanup, and attempt summaries are owned by `packages/agent-core` and exposed through `agent solve` harness flags. The portable Harbor runtime only forwards benchmark kwargs to the CLI and mirrors artifacts.
+Validation, retry, precheck, cleanup, and attempt summaries are owned by `packages/agent-core` and exposed through `agent solve` run-controller flags. The portable Harbor runtime only forwards explicit adapter kwargs to the CLI and mirrors artifacts; it must not feed verifier failures or benchmark identity back into the solving agent.
 
 Harbor executable resolution is explicit and recorded in `config.json`: set `HARBOR_BIN` to force a specific CLI path; otherwise the runner checks common Windows uv/local install paths before falling back to `harbor` on PATH.
 
@@ -205,7 +229,9 @@ Current limitations:
 --validation-timeout-sec <number>
 --precheck-command <command>
 --precheck-timeout-sec <number>
---pre-verifier-cleanup-globs <comma-separated-globs>
+--validation-command <command>
+--validation-commands <comma-separated-commands>
+--post-run-cleanup-globs <comma-separated-globs>
 --harness-timeout-sec <number>
 --retry-min-budget-sec <number>
 --attempts-dir <path>
@@ -223,11 +249,21 @@ Current limitations:
 
 Config precedence is CLI flags, environment variables, `.agent/config.toml`, `~/.agent/config.toml`, then defaults. TOML support is intentionally minimal for MVP scalar values.
 
-Local `agent solve` defaults to `--validation-mode off`. Benchmark runners pass `--validation-mode auto` plus retry, precheck, cleanup, and attempts settings when those harness behaviors are wanted.
+Local `agent solve` defaults to `--validation-mode off`. Validation commands come only from explicit CLI/config settings or the generic changed-file strategy used by `--validation-mode auto`; assistant final text is never parsed for validation commands. External adapters may pass `--validation-mode auto` plus retry, precheck, cleanup, and attempts settings when those run-controller behaviors are wanted.
 
 Environment variables mirror the new flags:
 
 ```text
+AGENT_VALIDATION_MODE
+AGENT_VALIDATION_COMMAND
+AGENT_VALIDATION_COMMANDS
+AGENT_VALIDATION_RETRY_LIMIT
+AGENT_VALIDATION_TIMEOUT_SEC
+AGENT_PRECHECK_COMMAND
+AGENT_PRECHECK_TIMEOUT_SEC
+AGENT_POST_RUN_CLEANUP_GLOBS
+AGENT_HARNESS_TIMEOUT_SEC
+AGENT_RETRY_MIN_BUDGET_SEC
 AGENT_ALLOWED_TOOLS
 AGENT_DISABLED_TOOLS
 AGENT_NO_PROJECT_INSTRUCTIONS
@@ -261,7 +297,7 @@ The core loop exposes these default tools:
 - `apply_patch`: validates and applies safe unified diffs to workspace-relative files, including quoted paths with spaces. Its `git apply` subprocesses are bounded by the command timeout and return `metadata.timedOut` on timeout.
 - `todo`: maintains run-scoped todo state for the agent.
 
-Paths exposed to tools are resolved inside the workspace and rejected if they escape it. `permission-mode ask` allows read-only tools. Mutating tools require an interactive approval prompt when stdin/stdout are TTY; non-interactive `ask` denies mutating tools conservatively. `permission-mode yolo` allows mutating tools without prompting and remains the expected mode for automated benchmarks.
+Paths exposed to tools are resolved inside the workspace and rejected if they escape it. `permission-mode ask` allows read-only tools. Mutating tools require an interactive approval prompt when stdin/stdout are TTY; non-interactive `ask` denies mutating tools conservatively. `permission-mode yolo` allows mutating tools without prompting and is intended only for trusted unattended automation.
 
 Interactive approval prompt:
 
@@ -355,7 +391,6 @@ When `--enable-mcp` is set, enabled server startup/listing failures are reported
   "model": "deepseek-v4-pro",
   "duration_ms": 123456,
   "last_error": null,
-  "validation_commands": ["python check_cert.py"],
   "tools_available": ["bash", "read", "write"],
   "changed_files": ["src/index.ts"],
   "todo_items": [
@@ -388,18 +423,19 @@ When `--enable-mcp` is set, enabled server startup/listing failures are reported
     "validation_results": [],
     "precheck_results": [],
     "retry_decisions": [],
-    "pre_verifier_cleanup": null
+    "managed_service_finalization": null,
+    "post_run_cleanup": null
   }
 }
 ```
 
-When the harness performs multiple attempts, the top-level count and token fields are aggregated across attempts. Per-attempt summaries and traces are preserved under the configured `attempts` directory.
+When the run controller performs multiple attempts, the top-level count and token fields are aggregated across attempts. Per-attempt summaries and traces are preserved under the configured `attempts` directory.
 
 The newer fields are optional. They appear when relevant and preserve existing summary keys for downstream consumers.
 
 ## Harbor And Terminal-Bench 2.0
 
-The Sigma agent runtime is built from `packages/agent-ai`, `packages/agent-core`, and `packages/agent-cli`. `pnpm package:agent-cli` turns those packages into a portable Linux CLI tarball for task containers. `pnpm package:harbor-runtime` then creates the host-side portable Harbor runtime and JobConfigs in:
+The portable Harbor runtime is built from `packages/agent-ai`, `packages/agent-core`, and `packages/agent-cli`. `packages/agent-tui` is intentionally not included in the Harbor task-container bundle. `pnpm package:agent-cli` turns the CLI packages into a portable Linux tarball for task containers. `pnpm package:harbor-runtime` then creates the host-side portable Harbor runtime and JobConfigs in:
 
 ```text
 .artifacts/harbor-runtime/
@@ -422,7 +458,7 @@ PYTHONPATH="$PWD/.artifacts/harbor-runtime" \
 harbor run --config .artifacts/harbor-runtime/jobconfig.deepseek.k5.json
 ```
 
-Harbor benchmark execution uses the portable runtime generated under `.artifacts/harbor-runtime`. The old in-repo Harbor adapter has been removed. Use `sigma_harbor_agent:SigmaCliHarborAgent`.
+Harbor benchmark execution uses the portable runtime generated under `.artifacts/harbor-runtime` from `portable/harbor/sigma_harbor_agent.py`. Product packages do not import this adapter. Use `sigma_harbor_agent:SigmaCliHarborAgent`.
 
 Generated JobConfigs import `sigma_harbor_agent:SigmaCliHarborAgent` and include an absolute `agent_cli_tarball` path such as `.artifacts/agent-cli-linux-x64.tgz`. They require the portable runtime directory on `PYTHONPATH`; they do not require the repo root.
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ pnpm --filter agent-tui start -- \
 
 Type a task and press Enter to start one run. TUI commands include `/exit`, `/clear`, `/model`, `/provider`, `/permission`, `/tools`, and `/diff`. The TUI uses `agent-core` directly; it does not shell out to `agent chat` and does not import Harbor or Terminal-Bench scripts.
 
+Programmatic product integrations should prefer the run-controller API names:
+
+```ts
+import { runAgentWithController, type AgentRunControllerConfig } from "agent-core";
+```
+
+The older `runAgentHarness` and `AgentHarnessConfig` exports remain available for compatibility with existing adapters and scripts.
+
 GLM/Zhipu example:
 
 ```bash
@@ -232,7 +240,7 @@ Current limitations:
 --validation-command <command>
 --validation-commands <comma-separated-commands>
 --post-run-cleanup-globs <comma-separated-globs>
---harness-timeout-sec <number>
+--harness-timeout-sec <number>      Legacy-compatible spelling for the run-controller timeout
 --retry-min-budget-sec <number>
 --attempts-dir <path>
 --allowed-tools <comma-separated-tools>
@@ -251,7 +259,7 @@ Config precedence is CLI flags, environment variables, `.agent/config.toml`, `~/
 
 Local `agent solve` defaults to `--validation-mode off`. Validation commands come only from explicit CLI/config settings or the generic changed-file strategy used by `--validation-mode auto`; assistant final text is never parsed for validation commands. External adapters may pass `--validation-mode auto` plus retry, precheck, cleanup, and attempts settings when those run-controller behaviors are wanted.
 
-Environment variables mirror the new flags:
+Environment variables mirror the new flags. `AGENT_HARNESS_TIMEOUT_SEC` is the compatibility spelling for the run-controller timeout:
 
 ```text
 AGENT_VALIDATION_MODE
@@ -431,7 +439,7 @@ When `--enable-mcp` is set, enabled server startup/listing failures are reported
 
 When the run controller performs multiple attempts, the top-level count and token fields are aggregated across attempts. Per-attempt summaries and traces are preserved under the configured `attempts` directory.
 
-The newer fields are optional. They appear when relevant and preserve existing summary keys for downstream consumers.
+The newer fields are optional. They appear when relevant and preserve existing summary keys for downstream consumers. The summary object key is still `harness` for compatibility; product code should treat it as run-controller metadata.
 
 ## Harbor And Terminal-Bench 2.0
 

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -6,27 +6,26 @@ Date: 2026-07-07
 
 | Command | Status |
 | --- | --- |
-| `pnpm install` | PASS: refreshed workspace links for `packages/agent-tui` |
 | `pnpm build` | PASS |
 | `pnpm lint` | PASS |
-| `pnpm test` | PASS: Vitest only; Harbor adapter tests are not part of the root test script |
+| `pnpm test` | PASS |
 | `pnpm test:harbor` | PASS: `Ran 8 tests` |
-| `pnpm test:all` | PASS: ordinary tests plus Harbor adapter tests |
 | `pnpm --filter agent-tui build` | PASS |
 | `pnpm --filter agent-tui start -- --help` | PASS: printed TUI usage and commands |
-| `rg -n "evaluator\|verifier\|benchmark\|terminal-bench\|harbor" packages\agent-core packages\agent-tui` | PASS: no matches |
 | `pnpm package:harbor-runtime` | PASS: created `.artifacts\harbor-runtime` |
-| `node -e "const p=require('./package.json'); if(!p.scripts['bench:tb:deepseek:k5']) process.exit(1); console.log(p.scripts['bench:tb:deepseek:k5'])"` | PASS: script still exists |
+| `rg -n "harness validation\|failed harness validation\|previous attempt failed harness\|verifier\|evaluator\|terminal-bench\|harbor" packages/agent-core packages/agent-tui` | PASS: no matches |
+| `rg -n "agent-tui\|packages/agent-tui\|workspacePackages" scripts/package-agent-cli.mjs tests/package-agent-cli.test.ts` | PASS: no matches |
+| `Get-ChildItem scripts -Filter 'bench-*'` | PASS: `bench-common.mjs`, `bench-report.mjs`, and `bench-terminal-bench.mjs` are present |
+| `node -e "const p=require('./package.json'); for (const k of ['bench:tb:smoke','bench:tb:k','bench:tb:task','package:harbor-runtime','test:harbor']) console.log(k+'='+p.scripts[k])"` | PASS: benchmark, packaging, and Harbor test scripts still exist |
 
 ## Coverage Notes
 
-- Product packages no longer expose evaluator/verifier/benchmark/Harbor terms in core prompt, agent loop, run controller, or TUI runtime.
-- Assistant final text is not parsed for validation commands. Validation comes from explicit config/CLI commands and the changed-file strategy.
-- Harbor adapter tests cover canonical kwargs: `validation_mode`, `validation_retry_limit`, `validation_timeout_sec`, `precheck_command`, `precheck_timeout_sec`, `post_run_cleanup_globs`, and `harness_timeout_sec`.
-- Root `pnpm test` is independent from the Harbor adapter suite; `pnpm test:harbor` and `pnpm test:all` cover the adapter path.
-- TUI build and help output verify the new package entrypoint is wired into the workspace.
+- Retry feedback sent to the next model attempt now says "post-run checks" and the agent-core test asserts the generated retry instruction does not contain the old term.
+- `agent-core` exports run-controller aliases while retaining the existing harness-named API for adapters and scripts.
+- Harbor adapter tests cover canonical run-controller kwargs and still assert `/usr/local/bin/agent solve` is used.
+- Product packages do not expose evaluator/verifier/Terminal-Bench/Harbor terms in `packages/agent-core` or `packages/agent-tui`.
+- The Harbor/Terminal-Bench adapter files and benchmark npm scripts remain in place. `package-agent-cli.mjs` still has no `agent-tui` package inclusion.
 
 ## Known Limitations
 
-- TUI updates are event-based at turn/tool granularity. Token delta rendering is future work once `agent-core` emits assistant delta events from provider streaming.
-- `pnpm package:agent-cli` was not rerun in this validation pass; `pnpm package:harbor-runtime` still generated the host-side portable runtime and JobConfig.
+- TUI updates are event-based at turn/tool granularity, not token delta streaming. Token delta rendering is future work once `agent-core` emits assistant delta events from provider streaming.

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -6,51 +6,27 @@ Date: 2026-07-07
 
 | Command | Status |
 | --- | --- |
+| `pnpm install` | PASS: refreshed workspace links for `packages/agent-tui` |
 | `pnpm build` | PASS |
-| `pnpm test` | PASS: Vitest suite and `python -m unittest tests.test_harbor_agent` |
 | `pnpm lint` | PASS |
-| `pnpm smoke:local:fake` | PASS |
-| `pnpm package:agent-cli` | PASS: created `.artifacts\agent-cli-linux-x64.tgz` using `.artifacts\cache\node-v22.16.0-linux-x64.tar.xz` |
-| `node packages\agent-cli\dist\index.js --help` | PASS |
-| `node packages\agent-cli\dist\index.js doctor --workspace .` | PASS: reported local config; `DEEPSEEK_API_KEY=missing` is environmental and not required for this check |
-| `node packages\agent-cli\dist\index.js replay --trace-jsonl .artifacts\smoke-local\create-file\trace.jsonl` | PASS |
+| `pnpm test` | PASS: Vitest only; Harbor adapter tests are not part of the root test script |
+| `pnpm test:harbor` | PASS: `Ran 8 tests` |
+| `pnpm test:all` | PASS: ordinary tests plus Harbor adapter tests |
+| `pnpm --filter agent-tui build` | PASS |
+| `pnpm --filter agent-tui start -- --help` | PASS: printed TUI usage and commands |
+| `rg -n "evaluator\|verifier\|benchmark\|terminal-bench\|harbor" packages\agent-core packages\agent-tui` | PASS: no matches |
+| `pnpm package:harbor-runtime` | PASS: created `.artifacts\harbor-runtime` |
+| `node -e "const p=require('./package.json'); if(!p.scripts['bench:tb:deepseek:k5']) process.exit(1); console.log(p.scripts['bench:tb:deepseek:k5'])"` | PASS: script still exists |
 
-## Smoke Tasks
+## Coverage Notes
 
-`pnpm smoke:local:fake` passed all deterministic local tasks:
-
-| Task | Status |
-| --- | --- |
-| `create-file` | PASS |
-| `edit-file` | PASS |
-| `fix-test` | PASS |
-| `inspect-and-summarize` | PASS |
-
-Artifacts were written under `.artifacts/smoke-local/`.
-
-## Feature Coverage
-
-This validation covers:
-
-- Extensible tool registry injection, merging, filtering, and duplicate-name rejection.
-- New tools: `list`, `glob`, `grep`, `git_status`, `git_diff`, `apply_patch`, and `todo`.
-- `apply_patch` timeout handling for stalled `git apply` subprocesses, including `metadata.timedOut` and stdout/stderr tails.
-- `apply_patch` path parsing for quoted paths with spaces, check-only quoted paths, quoted traversal rejection, and malformed `diff --git` headers.
-- Shared timeout handling for `git_status` and `git_diff`.
-- Permission decider behavior for `ask`, `yolo`, denial, allow, and per-run `always_allow`.
-- Project instruction loading from AGENTS/SIGMA-style files.
-- Deterministic repo-map prompt context.
-- Live stderr stream UI and `--no-stream-ui`.
-- CLI config flags/env/config plumbing for tools, context, MCP, and stream UI.
-- Stdio MCP v0 with fake server lifecycle, tool listing, tool calls, timeouts, filtering, disabled servers, and approval policy.
-- CLI-visible MCP enabled-server errors via redacted `[sigma] mcp_error ...` stderr warnings while preserving non-strict core-tool behavior and summary `mcp_servers` error data.
-- Summary JSON optional fields for tools, changed files, todos, project instruction sources, context mode, repo-map size, and MCP servers.
-- Secret redaction for traces, summaries, stream UI, final output, and approval prompts.
-- Existing Harbor unit tests and fake-provider smoke tasks.
+- Product packages no longer expose evaluator/verifier/benchmark/Harbor terms in core prompt, agent loop, run controller, or TUI runtime.
+- Assistant final text is not parsed for validation commands. Validation comes from explicit config/CLI commands and the changed-file strategy.
+- Harbor adapter tests cover canonical kwargs: `validation_mode`, `validation_retry_limit`, `validation_timeout_sec`, `precheck_command`, `precheck_timeout_sec`, `post_run_cleanup_globs`, and `harness_timeout_sec`.
+- Root `pnpm test` is independent from the Harbor adapter suite; `pnpm test:harbor` and `pnpm test:all` cover the adapter path.
+- TUI build and help output verify the new package entrypoint is wired into the workspace.
 
 ## Known Limitations
 
-- MCP v0 supports local stdio servers only; HTTP/OAuth MCP is future work.
-- Repo maps are static, deterministic context blocks. They do not use embeddings or a vector database.
-- Stream UI is event-based and does not require provider token streaming. Provider SSE streaming remains optional future work.
-- Config TOML parsing remains intentionally minimal: top-level scalar values and comma-separated list strings.
+- TUI updates are event-based at turn/tool granularity. Token delta rendering is future work once `agent-core` emits assistant delta events from provider streaming.
+- `pnpm package:agent-cli` was not rerun in this validation pass; `pnpm package:harbor-runtime` still generated the host-side portable runtime and JobConfig.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "packageManager": "pnpm@11.7.0",
   "scripts": {
     "build": "pnpm -r build",
-    "test": "vitest run && python -m unittest tests.test_harbor_agent",
+    "test": "vitest run",
+    "test:harbor": "python -m unittest tests.test_harbor_agent",
+    "test:all": "pnpm test && pnpm test:harbor",
     "lint": "tsc -b --pretty false",
     "clean": "pnpm -r clean",
     "package:agent-cli": "pnpm build && node scripts/package-agent-cli.mjs",

--- a/packages/agent-cli/src/commands/solve.ts
+++ b/packages/agent-cli/src/commands/solve.ts
@@ -58,9 +58,10 @@ async function resolveInstruction(
 function shouldUseHarness(cliConfig: ReturnType<typeof loadCliConfig>): boolean {
   return (
     cliConfig.validationMode === "auto" ||
+    cliConfig.validationCommands.length > 0 ||
     cliConfig.validationRetryLimit > 0 ||
     Boolean(cliConfig.precheckCommand?.trim()) ||
-    cliConfig.preVerifierCleanupGlobs.length > 0 ||
+    cliConfig.postRunCleanupGlobs.length > 0 ||
     Boolean(cliConfig.harnessTimeoutSec) ||
     Boolean(cliConfig.retryMinBudgetSec) ||
     Boolean(cliConfig.attemptsDir)
@@ -140,11 +141,12 @@ export async function runSolveCommand(argv: string[], deps: SolveCommandDeps = {
       ? await runAgentHarness({
           ...runConfig,
           validationMode: cliConfig.validationMode,
+          validationCommands: cliConfig.validationCommands,
           validationRetryLimit: cliConfig.validationRetryLimit,
           validationTimeoutSec: cliConfig.validationTimeoutSec,
           precheckCommand: cliConfig.precheckCommand,
           precheckTimeoutSec: cliConfig.precheckTimeoutSec,
-          preVerifierCleanupGlobs: cliConfig.preVerifierCleanupGlobs,
+          postRunCleanupGlobs: cliConfig.postRunCleanupGlobs,
           harnessTimeoutSec: cliConfig.harnessTimeoutSec,
           retryMinBudgetSec: cliConfig.retryMinBudgetSec,
           attemptsDir: cliConfig.attemptsDir

--- a/packages/agent-cli/src/config.ts
+++ b/packages/agent-cli/src/config.ts
@@ -25,11 +25,12 @@ export interface CliConfig {
   messageHistoryRetain: number;
   compactionSummaryChars: number;
   validationMode: AgentHarnessValidationMode;
+  validationCommands: string[];
   validationRetryLimit: number;
   validationTimeoutSec?: number;
   precheckCommand?: string;
   precheckTimeoutSec?: number;
-  preVerifierCleanupGlobs: string[];
+  postRunCleanupGlobs: string[];
   harnessTimeoutSec?: number;
   retryMinBudgetSec?: number;
   attemptsDir?: string;
@@ -158,6 +159,25 @@ function stringListValue(value: unknown): string[] {
   return value.split(",").map((item) => item.trim()).filter(Boolean);
 }
 
+function validationCommandList(options: { singleValues: unknown[]; listValues: unknown[] }): string[] {
+  const seen = new Set<string>();
+  const items: string[] = [];
+  const add = (values: string[]) => {
+    for (const item of values.map((value) => value.trim()).filter(Boolean)) {
+      if (seen.has(item)) continue;
+      seen.add(item);
+      items.push(item);
+    }
+  };
+  for (const value of options.singleValues) {
+    if (typeof value === "string") add([value]);
+  }
+  for (const value of options.listValues) {
+    add(stringListValue(value));
+  }
+  return items;
+}
+
 function optionalNumberValue(value: unknown): number | undefined {
   if (value === undefined || value === null || value === true || value === "") return undefined;
   const parsed = Number(value);
@@ -254,6 +274,10 @@ export function loadCliConfig(flags: Record<string, string | boolean>): CliConfi
         stringValue(config.validation_mode) ??
         "off"
     ),
+    validationCommands: validationCommandList({
+      singleValues: [flags["validation-command"], process.env.AGENT_VALIDATION_COMMAND, config.validation_command],
+      listValues: [flags["validation-commands"], process.env.AGENT_VALIDATION_COMMANDS, config.validation_command_list]
+    }),
     validationRetryLimit: Math.max(
       0,
       Math.floor(
@@ -275,10 +299,10 @@ export function loadCliConfig(flags: Record<string, string | boolean>): CliConfi
     precheckTimeoutSec: optionalNumberValue(
       flags["precheck-timeout-sec"] ?? process.env.AGENT_PRECHECK_TIMEOUT_SEC ?? config.precheck_timeout_sec
     ),
-    preVerifierCleanupGlobs: stringListValue(
-      flags["pre-verifier-cleanup-globs"] ??
-        process.env.AGENT_PRE_VERIFIER_CLEANUP_GLOBS ??
-        config.pre_verifier_cleanup_globs
+    postRunCleanupGlobs: stringListValue(
+      flags["post-run-cleanup-globs"] ??
+        process.env.AGENT_POST_RUN_CLEANUP_GLOBS ??
+        config.post_run_cleanup_globs
     ),
     harnessTimeoutSec: optionalNumberValue(
       flags["harness-timeout-sec"] ?? process.env.AGENT_HARNESS_TIMEOUT_SEC ?? config.harness_timeout_sec

--- a/packages/agent-core/src/agent.ts
+++ b/packages/agent-core/src/agent.ts
@@ -30,7 +30,7 @@ const DEFAULT_MESSAGE_HISTORY_RETAIN = 24;
 const DEFAULT_COMPACTION_SUMMARY_CHARS = 30000;
 const DEFAULT_PROJECT_DOC_MAX_BYTES = 32768;
 const DEFAULT_REPO_MAP_MAX_CHARS = 20000;
-const COMPACTION_MARKER = "Previous agent conversation compacted by harness.";
+const COMPACTION_MARKER = "Previous agent conversation compacted by the run controller.";
 
 function nowIso(): string {
   return new Date().toISOString();
@@ -128,35 +128,6 @@ function compactMessagesIfNeeded(
   return [...protectedMessages, summary, ...tailMessages];
 }
 
-function validationCommandsFromValue(value: unknown): string[] {
-  if (!value || typeof value !== "object") return [];
-  const commands = (value as { validation_commands?: unknown; validationCommands?: unknown }).validation_commands ??
-    (value as { validation_commands?: unknown; validationCommands?: unknown }).validationCommands;
-  if (!Array.isArray(commands)) return [];
-  return commands.filter((command): command is string => typeof command === "string" && command.trim().length > 0);
-}
-
-function extractValidationCommands(finalMessage: string | undefined): string[] {
-  if (!finalMessage) return [];
-  const candidates = [finalMessage];
-  const fencedJson = /```(?:json)?\s*([\s\S]*?)```/gi;
-  for (let match = fencedJson.exec(finalMessage); match !== null; match = fencedJson.exec(finalMessage)) {
-    candidates.push(match[1]);
-  }
-
-  const commands: string[] = [];
-  for (const candidate of candidates) {
-    try {
-      for (const command of validationCommandsFromValue(JSON.parse(candidate))) {
-        if (!commands.includes(command)) commands.push(command);
-      }
-    } catch {
-      // Non-JSON final summaries are expected; the harness simply ignores them.
-    }
-  }
-  return commands;
-}
-
 async function resolveRunToolRegistry(config: AgentRunConfig): Promise<ToolRegistry> {
   if (config.toolRegistry && config.toolRegistryFactory) {
     throw new Error("Configure either toolRegistry or toolRegistryFactory, not both.");
@@ -186,10 +157,6 @@ export function summaryJsonFromRunResult(result: AgentRunResult): SummaryJson {
   };
   if (result.finalMessage) {
     summary.final_message = result.finalMessage;
-  }
-  const validationCommands = extractValidationCommands(result.finalMessage);
-  if (validationCommands.length > 0) {
-    summary.validation_commands = validationCommands;
   }
   if (result.toolsAvailable && result.toolsAvailable.length > 0) {
     summary.tools_available = result.toolsAvailable;

--- a/packages/agent-core/src/harness/cleanup.ts
+++ b/packages/agent-core/src/harness/cleanup.ts
@@ -24,7 +24,7 @@ async function pathsForPattern(pattern: string): Promise<string[]> {
   }
 }
 
-export async function runPreVerifierCleanup(patterns: string[]): Promise<HarnessCleanupResult | null> {
+export async function runPostRunCleanup(patterns: string[]): Promise<HarnessCleanupResult | null> {
   if (patterns.length === 0) return null;
   const removed: string[] = [];
   const skipped: string[] = [];

--- a/packages/agent-core/src/harness/index.ts
+++ b/packages/agent-core/src/harness/index.ts
@@ -1,3 +1,3 @@
 export { runAgentHarness } from "./runner.js";
 export { listWorkspaceManifest, changedWorkspaceFiles } from "./manifest.js";
-export { genericValidationCommandSpecs, summaryValidationCommands, validationCommandSpecs } from "./validation.js";
+export { explicitValidationCommandSpecs, genericValidationCommandSpecs, validationCommandSpecs } from "./validation.js";

--- a/packages/agent-core/src/harness/retry.ts
+++ b/packages/agent-core/src/harness/retry.ts
@@ -38,7 +38,7 @@ export function retryBudgetDecision(options: {
     return {
       retry_number: options.retryNumber,
       action: "skipped",
-      reason: "insufficient_harness_budget_for_retry",
+      reason: "insufficient_run_controller_budget_for_retry",
       trigger: options.trigger,
       remaining_harness_budget_sec: remaining,
       minimum_retry_budget_sec: minimum
@@ -65,7 +65,7 @@ export function instructionWithRetryFeedback(options: {
   const lines = [
     options.originalInstruction,
     "",
-    "The previous attempt failed harness validation. Fix the issue and rerun validation before finishing."
+    "The previous attempt failed post-run checks. Fix the issue and rerun the relevant checks before finishing."
   ];
 
   options.failedResults.forEach((result, index) => {

--- a/packages/agent-core/src/harness/retry.ts
+++ b/packages/agent-core/src/harness/retry.ts
@@ -88,8 +88,7 @@ export function instructionWithRetryFeedback(options: {
         finish_reason: options.previousAttemptResult.finishReason,
         turns: options.previousAttemptResult.turns,
         commands_executed: options.previousAttemptResult.commandsExecuted,
-        last_error: options.previousAttemptResult.lastError,
-        validation_commands: options.previousAttemptSummary.validation_commands ?? []
+        last_error: options.previousAttemptResult.lastError
       },
       null,
       2

--- a/packages/agent-core/src/harness/runner.ts
+++ b/packages/agent-core/src/harness/runner.ts
@@ -11,10 +11,10 @@ import type {
 } from "../types.js";
 import { changedWorkspaceFiles, listWorkspaceManifest } from "./manifest.js";
 import { retryBudgetDecision, retryTrigger, instructionWithRetryFeedback } from "./retry.js";
-import { runPreVerifierCleanup } from "./cleanup.js";
+import { runPostRunCleanup } from "./cleanup.js";
 import { aggregateAttemptResults, relativeArtifactPath, summaryFromAttempt } from "./summary.js";
 import { runHarnessCommand, validationCommandSpecs } from "./validation.js";
-import { cleanupServicesBeforeVerifier } from "../tools/service.js";
+import { finalizeManagedServices } from "../tools/service.js";
 import { redactSecrets } from "../redaction.js";
 
 const DEFAULT_VALIDATION_TIMEOUT_SEC = 60;
@@ -52,8 +52,7 @@ function summaryFeedback(summary: SummaryJson): string {
       finish_reason: summary.finish_reason,
       turns: summary.turns,
       commands_executed: summary.commands_executed,
-      last_error: summary.last_error,
-      validation_commands: summary.validation_commands ?? []
+      last_error: summary.last_error
     },
     null,
     2
@@ -68,7 +67,7 @@ function harnessEnabled(config: AgentHarnessConfig): boolean {
   return (
     config.validationMode === "auto" ||
     Boolean(config.precheckCommand?.trim()) ||
-    (config.preVerifierCleanupGlobs?.length ?? 0) > 0 ||
+    (config.postRunCleanupGlobs?.length ?? 0) > 0 ||
     (config.validationRetryLimit ?? 0) > 0 ||
     Boolean(config.attemptsDir)
   );
@@ -88,7 +87,7 @@ async function runChecks(options: {
   if (options.config.validationMode === "auto") {
     const afterManifest = await listWorkspaceManifest(workspacePath);
     const changedFiles = options.beforeManifest ? changedWorkspaceFiles(options.beforeManifest, afterManifest) : [];
-    for (const spec of validationCommandSpecs(options.attemptSummary, changedFiles)) {
+    for (const spec of validationCommandSpecs(options.config.validationCommands ?? [], changedFiles)) {
       emitHarnessEvent(options.config, "harness_check_start", {
         kind: "validation",
         source: spec.source,
@@ -194,12 +193,6 @@ async function writeHarnessSummary(result: AgentRunResult, summaryJsonPath?: str
   if (!summaryJsonPath) return;
   const summary = summaryFromAttempt(result);
   summary.harness = result.harness;
-  if (result.harness) {
-    const validationCommands = result.harness.validation_results.map((item) => item.command);
-    if (validationCommands.length > 0) {
-      summary.validation_commands = [...new Set([...(summary.validation_commands ?? []), ...validationCommands])];
-    }
-  }
   const resolved = path.resolve(summaryJsonPath);
   await mkdir(path.dirname(resolved), { recursive: true });
   await writeFile(resolved, `${JSON.stringify(redactSecrets(summary), null, 2)}\n`, "utf8");
@@ -223,8 +216,8 @@ export async function runAgentHarness(config: AgentHarnessConfig): Promise<Agent
     validation_results: validationResults,
     precheck_results: precheckResults,
     retry_decisions: [],
-    service_cleanup: null,
-    pre_verifier_cleanup: null
+    managed_service_finalization: null,
+    post_run_cleanup: null
   };
 
   const retryLimit = Math.max(0, Math.floor(config.validationRetryLimit ?? 0));
@@ -306,8 +299,8 @@ export async function runAgentHarness(config: AgentHarnessConfig): Promise<Agent
     });
   }
 
-  harness.service_cleanup = await cleanupServicesBeforeVerifier();
-  harness.pre_verifier_cleanup = await runPreVerifierCleanup(config.preVerifierCleanupGlobs ?? []);
+  harness.managed_service_finalization = await finalizeManagedServices();
+  harness.post_run_cleanup = await runPostRunCleanup(config.postRunCleanupGlobs ?? []);
   const finalAttempt = attempts[attempts.length - 1];
   const finalResult = finalResultForHarness({
     attempts,

--- a/packages/agent-core/src/harness/runner.ts
+++ b/packages/agent-core/src/harness/runner.ts
@@ -269,7 +269,7 @@ export async function runAgentHarness(config: AgentHarnessConfig): Promise<Agent
     if (lastFailed.length === 0) break;
 
     if (attempt > retryLimit) {
-      failureMessage = lastFailed[lastFailed.length - 1]?.message ?? "harness validation failed";
+      failureMessage = lastFailed[lastFailed.length - 1]?.message ?? "post-run checks failed";
       break;
     }
 
@@ -286,7 +286,7 @@ export async function runAgentHarness(config: AgentHarnessConfig): Promise<Agent
     });
     harness.retry_decisions.push(decision);
     if (decision.action === "skipped") {
-      failureMessage = `${lastFailed[lastFailed.length - 1]?.message ?? "harness validation failed"}; retry skipped because harness budget remaining (${decision.remaining_harness_budget_sec}s) is below ${decision.minimum_retry_budget_sec}s`;
+      failureMessage = `${lastFailed[lastFailed.length - 1]?.message ?? "post-run checks failed"}; retry skipped because run-controller budget remaining (${decision.remaining_harness_budget_sec}s) is below ${decision.minimum_retry_budget_sec}s`;
       break;
     }
 

--- a/packages/agent-core/src/harness/validation.ts
+++ b/packages/agent-core/src/harness/validation.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import type { HarnessCommandResult, SummaryJson } from "../types.js";
+import type { HarnessCommandResult } from "../types.js";
 import { runBashCommand } from "../command-runner.js";
 
 export interface ValidationCommandSpec {
@@ -17,27 +17,6 @@ function shellQuote(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`;
 }
 
-function validationCommandsFromValue(value: unknown): string[] {
-  if (!Array.isArray(value)) return [];
-  return value.filter((command): command is string => typeof command === "string" && command.trim().length > 0);
-}
-
-export function summaryValidationCommands(summary: SummaryJson | Record<string, unknown> | undefined): ValidationCommandSpec[] {
-  if (!summary || typeof summary !== "object") return [];
-  const commands = [
-    ...validationCommandsFromValue((summary as { validation_commands?: unknown }).validation_commands),
-    ...validationCommandsFromValue((summary as { validationCommands?: unknown }).validationCommands)
-  ];
-  const harness = (summary as { harness?: unknown }).harness;
-  if (harness && typeof harness === "object") {
-    commands.push(
-      ...validationCommandsFromValue((harness as { validation_commands?: unknown }).validation_commands),
-      ...validationCommandsFromValue((harness as { validationCommands?: unknown }).validationCommands)
-    );
-  }
-  return [...new Set(commands)].map((command) => ({ source: "summary", command, relatedFiles: [] }));
-}
-
 function scriptRunCommand(filePath: string): string | null {
   const base = path.posix.basename(filePath);
   if (!/^(check|verify|validate|test)(?:[_\-.].*|$)/.test(base)) return null;
@@ -48,6 +27,13 @@ function scriptRunCommand(filePath: string): string | null {
     return `if command -v node >/dev/null 2>&1; then node ${quoted}; else echo 'node not found for validation' >&2; exit 127; fi`;
   }
   return null;
+}
+
+export function explicitValidationCommandSpecs(commands: string[] = []): ValidationCommandSpec[] {
+  return commands
+    .map((command) => command.trim())
+    .filter((command, index, list) => command.length > 0 && list.indexOf(command) === index)
+    .map((command) => ({ source: "configured", command, relatedFiles: [] }));
 }
 
 export function genericValidationCommandSpecs(changedFiles: string[]): ValidationCommandSpec[] {
@@ -75,11 +61,11 @@ export function genericValidationCommandSpecs(changedFiles: string[]): Validatio
 }
 
 export function validationCommandSpecs(
-  summary: SummaryJson,
+  configuredCommands: string[] = [],
   changedFiles: string[]
 ): ValidationCommandSpec[] {
   const specs = [
-    ...summaryValidationCommands(summary),
+    ...explicitValidationCommandSpecs(configuredCommands),
     ...genericValidationCommandSpecs(changedFiles)
   ];
   const seen = new Set<string>();

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -33,7 +33,7 @@ export {
   executeListTool,
   executeReadTool,
   executeServiceTool,
-  cleanupServicesBeforeVerifier,
+  finalizeManagedServices,
   executeTodoTool,
   filterToolRegistry,
   matchesSimpleGlob,

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -1,5 +1,5 @@
 export { runAgent, summaryJsonFromRunResult, writeRunSummary } from "./agent.js";
-export { runAgentHarness } from "./harness/index.js";
+export { runAgentHarness, runAgentHarness as runAgentWithController } from "./harness/index.js";
 export { createMcpToolRegistry } from "./mcp.js";
 export type { CreateMcpToolRegistryOptions, CreateMcpToolRegistryResult } from "./mcp.js";
 export {
@@ -47,6 +47,8 @@ export type {
   AgentHarnessConfig,
   AgentHarnessSummary,
   AgentHarnessValidationMode,
+  AgentRunControllerConfig,
+  AgentRunControllerSummary,
   AgentRunConfig,
   AgentRunResult,
   AgentRunStatus,
@@ -62,6 +64,10 @@ export type {
   PermissionMode,
   PermissionRequest,
   RegisteredTool,
+  RunControllerCleanupResult,
+  RunControllerCommandResult,
+  RunControllerRetryDecision,
+  RunControllerServiceCleanupResult,
   SummaryJson,
   TodoItem,
   TodoStatus,

--- a/packages/agent-core/src/prompts.ts
+++ b/packages/agent-core/src/prompts.ts
@@ -5,8 +5,6 @@ Rules:
 - Inspect before editing.
 - Prefer small, verifiable changes.
 - Use bash to run tests or validation commands when available.
-- For long-running servers or daemons, use service.start/status/logs/stop; do not start them with bare &, nohup, or setsid in bash. Services with a port or readinessCommand stay available to the verifier by default; set keepForVerifier=false only for temporary helpers.
-- The evaluator verifies the final container state, not your final text.
+- For long-running servers or daemons, use service.start/status/logs/stop; do not start them with bare &, nohup, or setsid in bash. Services with a port or readinessCommand stay available after the run by default; set keepAliveAfterRun=false only for temporary helpers.
 - Do not stop after only explaining a solution. Implement it.
-- When the task is complete and no more tool calls are needed, give a concise final summary.
-- If you have useful self-check commands, include a JSON code block like {"validation_commands":["command"]}.`;
+- When the task is complete and no more tool calls are needed, give a concise final summary.`;

--- a/packages/agent-core/src/tools/bash.ts
+++ b/packages/agent-core/src/tools/bash.ts
@@ -23,11 +23,33 @@ function formatOutput(exitCode: number | null, stdout: string, stderr: string, t
   return parts.join("\n");
 }
 
+function looksLikeLongRunningServerCommand(command: string): boolean {
+  const normalized = command.replace(/\s+/g, " ").trim().toLowerCase();
+  const patterns = [
+    /(?:^|[;&|()]\s*)(?:npm|pnpm|yarn|bun) (?:run )?dev(?:\s|$)/,
+    /(?:^|[;&|()]\s*)(?:npx )?vite(?:\s|$)/,
+    /(?:^|[;&|()]\s*)(?:npm exec |pnpm exec |yarn )?vite(?:\s|$)/,
+    /(?:^|[;&|()]\s*)(?:npx )?next dev(?:\s|$)/,
+    /(?:^|[;&|()]\s*)(?:npx )?astro dev(?:\s|$)/,
+    /(?:^|[;&|()]\s*)(?:npx )?nuxt dev(?:\s|$)/
+  ];
+  return patterns.some((pattern) => pattern.test(normalized));
+}
+
 export async function executeBashTool(args: unknown, context: ToolExecutionContext): Promise<ToolResult> {
   const parsed = (args && typeof args === "object" ? args : {}) as BashArgs;
   const command = typeof parsed.command === "string" ? parsed.command : "";
   if (!command.trim()) {
     return { ok: false, content: "bash requires a non-empty command string" };
+  }
+
+  if (looksLikeLongRunningServerCommand(command)) {
+    return {
+      ok: false,
+      content:
+        "This looks like a long-running dev server command. Use service.start instead of bash so the run can continue after the server is ready.",
+      metadata: { blockedReason: "long_running_service_command" }
+    };
   }
 
   if (isProbablyMutatingCommand(command)) {

--- a/packages/agent-core/src/tools/index.ts
+++ b/packages/agent-core/src/tools/index.ts
@@ -2,7 +2,7 @@ export { executeBashTool } from "./bash.js";
 export { executeReadTool } from "./read.js";
 export { executeWriteTool } from "./write.js";
 export { executeEditTool } from "./edit.js";
-export { executeServiceTool, cleanupServicesBeforeVerifier } from "./service.js";
+export { executeServiceTool, finalizeManagedServices } from "./service.js";
 export { executeListTool } from "./list.js";
 export { executeGlobTool, matchesSimpleGlob } from "./glob.js";
 export { executeGrepTool } from "./grep.js";

--- a/packages/agent-core/src/tools/registry.ts
+++ b/packages/agent-core/src/tools/registry.ts
@@ -114,7 +114,7 @@ const serviceTool: RegisteredTool = {
     function: {
       name: "service",
       description:
-        "Manage long-running background services. Use service.start for servers instead of bare '&', nohup, or setsid in bash. Services with a port or readinessCommand are kept for the verifier by default; set keepForVerifier=false only for temporary helpers.",
+        "Manage long-running background services. Use service.start for servers instead of bare '&', nohup, or setsid in bash. Services with a port or readinessCommand stay available after the run by default; set keepAliveAfterRun=false only for temporary helpers.",
       parameters: {
         type: "object",
         properties: {
@@ -125,7 +125,7 @@ const serviceTool: RegisteredTool = {
           port: { type: "number" },
           readinessCommand: { type: "string" },
           logPath: { type: "string" },
-          keepForVerifier: { type: "boolean" },
+          keepAliveAfterRun: { type: "boolean" },
           readinessTimeoutSec: { type: "number" },
           maxLogChars: { type: "number" }
         },

--- a/packages/agent-core/src/tools/service.ts
+++ b/packages/agent-core/src/tools/service.ts
@@ -17,7 +17,7 @@ interface ServiceArgs {
   port?: unknown;
   readinessCommand?: unknown;
   logPath?: unknown;
-  keepForVerifier?: unknown;
+  keepAliveAfterRun?: unknown;
   readinessTimeoutSec?: unknown;
   maxLogChars?: unknown;
 }
@@ -30,7 +30,7 @@ export interface ServiceRecord {
   port?: number;
   readinessCommand?: string;
   logPath: string;
-  keepForVerifier: boolean;
+  keepAliveAfterRun: boolean;
   startedAt: string;
 }
 
@@ -86,8 +86,8 @@ function asOptionalBool(value: unknown): boolean | undefined {
   return undefined;
 }
 
-function defaultKeepForVerifier(args: ServiceArgs, port: number | undefined, readinessCommand: string | undefined): boolean {
-  const explicit = asOptionalBool(args.keepForVerifier);
+function defaultKeepAliveAfterRun(args: ServiceArgs, port: number | undefined, readinessCommand: string | undefined): boolean {
+  const explicit = asOptionalBool(args.keepAliveAfterRun);
   if (explicit !== undefined) return explicit;
   return port !== undefined || readinessCommand !== undefined;
 }
@@ -259,7 +259,7 @@ async function startService(args: ServiceArgs, context: ToolExecutionContext): P
     ...(port ? { port } : {}),
     ...(readinessCommand ? { readinessCommand } : {}),
     logPath,
-    keepForVerifier: defaultKeepForVerifier(args, port, readinessCommand),
+    keepAliveAfterRun: defaultKeepAliveAfterRun(args, port, readinessCommand),
     startedAt: new Date().toISOString()
   };
 
@@ -358,11 +358,11 @@ async function stopService(args: ServiceArgs, context: ToolExecutionContext): Pr
   };
 }
 
-export async function cleanupServicesBeforeVerifier(): Promise<ServiceCleanupResult> {
+export async function finalizeManagedServices(): Promise<ServiceCleanupResult> {
   const services = await readRegistry();
   const result: ServiceCleanupResult = { stopped: [], kept: [], missing: [], errors: [] };
   for (const service of services) {
-    if (service.keepForVerifier) {
+    if (service.keepAliveAfterRun) {
       result.kept.push(service.name);
       continue;
     }
@@ -374,7 +374,7 @@ export async function cleanupServicesBeforeVerifier(): Promise<ServiceCleanupRes
     }
   }
   const removed = new Set([...result.stopped, ...result.missing]);
-  await writeRegistry(services.filter((service) => service.keepForVerifier || !removed.has(service.name)));
+  await writeRegistry(services.filter((service) => service.keepAliveAfterRun || !removed.has(service.name)));
   return result;
 }
 

--- a/packages/agent-core/src/tools/service.ts
+++ b/packages/agent-core/src/tools/service.ts
@@ -92,6 +92,10 @@ function defaultKeepAliveAfterRun(args: ServiceArgs, port: number | undefined, r
   return port !== undefined || readinessCommand !== undefined;
 }
 
+function serviceUrl(port: number | undefined): string | undefined {
+  return port ? `http://127.0.0.1:${port}` : undefined;
+}
+
 async function readRegistry(): Promise<ServiceRecord[]> {
   try {
     const value = JSON.parse(await readFile(registryPath(), "utf8"));
@@ -287,10 +291,11 @@ async function startService(args: ServiceArgs, context: ToolExecutionContext): P
     };
   }
 
+  const url = serviceUrl(record.port);
   return {
     ok: true,
-    content: `service ${name} started pid=${pid} log=${logPath}`,
-    metadata: { ...record, ready: true }
+    content: `service ${name} started${url ? ` url=${url}` : ""} pid=${pid} log=${logPath}`,
+    metadata: { ...record, ready: true, ...(url ? { url } : {}) }
   };
 }
 

--- a/packages/agent-core/src/types.ts
+++ b/packages/agent-core/src/types.ts
@@ -125,11 +125,12 @@ export interface AgentRunConfig {
 
 export interface AgentHarnessConfig extends AgentRunConfig {
   validationMode?: AgentHarnessValidationMode;
+  validationCommands?: string[];
   validationRetryLimit?: number;
   validationTimeoutSec?: number;
   precheckCommand?: string;
   precheckTimeoutSec?: number;
-  preVerifierCleanupGlobs?: string[];
+  postRunCleanupGlobs?: string[];
   harnessTimeoutSec?: number;
   retryMinBudgetSec?: number;
   attemptsDir?: string;
@@ -254,8 +255,8 @@ export interface AgentHarnessSummary {
   validation_results: HarnessCommandResult[];
   precheck_results: HarnessCommandResult[];
   retry_decisions: HarnessRetryDecision[];
-  service_cleanup?: HarnessServiceCleanupResult | null;
-  pre_verifier_cleanup: HarnessCleanupResult | null;
+  managed_service_finalization?: HarnessServiceCleanupResult | null;
+  post_run_cleanup: HarnessCleanupResult | null;
 }
 
 export interface SummaryJson {
@@ -273,7 +274,6 @@ export interface SummaryJson {
   duration_ms: number;
   last_error: string | null;
   final_message?: string;
-  validation_commands?: string[];
   harness?: AgentHarnessSummary;
   tools_available?: string[];
   changed_files?: string[];

--- a/packages/agent-core/src/types.ts
+++ b/packages/agent-core/src/types.ts
@@ -259,6 +259,13 @@ export interface AgentHarnessSummary {
   post_run_cleanup: HarnessCleanupResult | null;
 }
 
+export type AgentRunControllerConfig = AgentHarnessConfig;
+export type AgentRunControllerSummary = AgentHarnessSummary;
+export type RunControllerCommandResult = HarnessCommandResult;
+export type RunControllerRetryDecision = HarnessRetryDecision;
+export type RunControllerCleanupResult = HarnessCleanupResult;
+export type RunControllerServiceCleanupResult = HarnessServiceCleanupResult;
+
 export interface SummaryJson {
   status: AgentRunStatus;
   finish_reason: AgentFinishReason;

--- a/packages/agent-tui/package.json
+++ b/packages/agent-tui/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "agent-tui",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "agent-tui": "./dist/index.js"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "clean": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\""
+  },
+  "dependencies": {
+    "agent-ai": "workspace:*",
+    "agent-core": "workspace:*"
+  }
+}

--- a/packages/agent-tui/src/app.tsx
+++ b/packages/agent-tui/src/app.tsx
@@ -1,0 +1,275 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import readline from "node:readline";
+import type { ProviderName } from "agent-ai";
+import type { AgentEvent, AgentRunResult, PermissionDecision, PermissionMode } from "agent-core";
+import { ApprovalPrompt } from "./components/approval-prompt.js";
+import { Composer } from "./components/composer.js";
+import { DiffPanel } from "./components/diff-panel.js";
+import { StatusBar } from "./components/status-bar.js";
+import { Timeline } from "./components/timeline.js";
+import { ToolPanel } from "./components/tool-panel.js";
+import { TuiPermissionController } from "./permission.js";
+import { runSession } from "./run-session.js";
+
+const execFileAsync = promisify(execFile);
+
+export interface TuiAppOptions {
+  workspace: string;
+  provider: ProviderName;
+  model?: string;
+  permissionMode: PermissionMode;
+}
+
+class TuiApp {
+  private inputBuffer = "";
+  private running = false;
+  private exitAfterRun = false;
+  private events: AgentEvent[] = [];
+  private result: AgentRunResult | null = null;
+  private message: string | null = null;
+  private showTools = false;
+  private showDiff = false;
+  private diffText = "";
+  private readonly permissionController = new TuiPermissionController();
+
+  constructor(
+    private readonly options: TuiAppOptions,
+    private readonly stdin: NodeJS.ReadStream,
+    private readonly stdout: NodeJS.WriteStream
+  ) {}
+
+  async start(): Promise<void> {
+    readline.emitKeypressEvents(this.stdin);
+    this.permissionController.onChange(() => this.render());
+    if (this.stdin.isTTY) this.stdin.setRawMode(true);
+    this.stdin.resume();
+    this.stdin.on("keypress", this.handleKeypress);
+    this.stdout.write("\x1b[?25l");
+    this.render();
+    await new Promise<void>((resolve) => {
+      this.resolveExit = resolve;
+    });
+  }
+
+  private resolveExit: (() => void) | null = null;
+
+  private readonly handleKeypress = (text: string, key: readline.Key): void => {
+    if (key.ctrl && key.name === "c") {
+      this.stop();
+      return;
+    }
+
+    const pending = this.permissionController.pending;
+    if (pending) {
+      const decision = this.permissionDecisionForKey(text);
+      if (decision) this.permissionController.respond(decision);
+      return;
+    }
+
+    if (key.name === "return") {
+      void this.submitInput();
+      return;
+    }
+    if (key.name === "backspace") {
+      this.inputBuffer = this.inputBuffer.slice(0, -1);
+      this.render();
+      return;
+    }
+    if (key.name === "escape") {
+      this.inputBuffer = "";
+      this.render();
+      return;
+    }
+    if (text && !key.ctrl && !key.meta && text >= " ") {
+      this.inputBuffer += text;
+      this.render();
+    }
+  };
+
+  private permissionDecisionForKey(text: string): PermissionDecision | null {
+    const normalized = text.trim().toLowerCase();
+    if (normalized === "y") return "allow";
+    if (normalized === "n") return "deny";
+    if (normalized === "a") return "always_allow";
+    return null;
+  }
+
+  private async submitInput(): Promise<void> {
+    const value = this.inputBuffer.trim();
+    this.inputBuffer = "";
+    if (!value) {
+      this.render();
+      return;
+    }
+    if (value.startsWith("/")) {
+      await this.handleCommand(value);
+      return;
+    }
+    if (this.running) {
+      this.message = "A run is already active.";
+      this.render();
+      return;
+    }
+    await this.startRun(value);
+  }
+
+  private async handleCommand(command: string): Promise<void> {
+    const [name, ...rest] = command.split(/\s+/);
+    const value = rest.join(" ").trim();
+    if (name === "/exit") {
+      if (this.running) {
+        this.exitAfterRun = true;
+        this.message = "Will exit after the active run finishes.";
+        this.render();
+      } else {
+        this.stop();
+      }
+      return;
+    }
+    if (name === "/clear") {
+      this.events = [];
+      this.result = null;
+      this.message = "Cleared.";
+      this.render();
+      return;
+    }
+    if (name === "/model") {
+      this.options.model = value || undefined;
+      this.message = `Model set to ${this.options.model ?? "default"}.`;
+      this.render();
+      return;
+    }
+    if (name === "/provider") {
+      if (value !== "deepseek" && value !== "glm") {
+        this.message = "Provider must be deepseek or glm.";
+      } else {
+        this.options.provider = value;
+        this.message = `Provider set to ${value}.`;
+      }
+      this.render();
+      return;
+    }
+    if (name === "/permission") {
+      if (value !== "ask" && value !== "yolo") {
+        this.message = "Permission mode must be ask or yolo.";
+      } else {
+        this.options.permissionMode = value;
+        this.message = `Permission mode set to ${value}.`;
+      }
+      this.render();
+      return;
+    }
+    if (name === "/tools") {
+      this.showTools = !this.showTools;
+      this.render();
+      return;
+    }
+    if (name === "/diff") {
+      this.showDiff = !this.showDiff;
+      if (this.showDiff) await this.refreshDiff();
+      this.render();
+      return;
+    }
+    this.message = `Unknown command: ${name}`;
+    this.render();
+  }
+
+  private async startRun(instruction: string): Promise<void> {
+    this.running = true;
+    this.result = null;
+    this.message = "Run started.";
+    this.render();
+    try {
+      const result = await runSession({
+        instruction,
+        workspacePath: this.options.workspace,
+        provider: this.options.provider,
+        model: this.options.model,
+        permissionMode: this.options.permissionMode,
+        permissionController: this.permissionController,
+        onEvent: (event) => {
+          this.events.push(event);
+          this.render();
+        }
+      });
+      this.result = result;
+      this.message = result.finalMessage ?? null;
+      if (this.showDiff) await this.refreshDiff();
+    } catch (error) {
+      this.message = error instanceof Error ? error.message : String(error);
+    } finally {
+      this.running = false;
+      this.render();
+      if (this.exitAfterRun) this.stop();
+    }
+  }
+
+  private async refreshDiff(): Promise<void> {
+    try {
+      const { stdout } = await execFileAsync("git", ["-C", this.options.workspace, "diff", "--stat"], {
+        timeout: 5000,
+        maxBuffer: 20000
+      });
+      this.diffText = stdout.toString();
+    } catch (error) {
+      this.diffText = error instanceof Error ? error.message : String(error);
+    }
+  }
+
+  private render(): void {
+    const rows = this.stdout.rows ?? 30;
+    const reserved = 8 + (this.showTools ? 8 : 0) + (this.showDiff ? 8 : 0);
+    const timelineRows = Math.max(4, rows - reserved);
+    const sections = [
+      StatusBar({
+        workspacePath: this.options.workspace,
+        provider: this.options.provider,
+        model: this.options.model,
+        permissionMode: this.options.permissionMode,
+        running: this.running,
+        result: this.result,
+        message: this.message
+      }),
+      "",
+      ApprovalPrompt(this.permissionController.pending),
+      Timeline(this.events, timelineRows),
+      this.showTools ? ToolPanel(this.events, this.result) : "",
+      this.showDiff ? DiffPanel(this.result, this.diffText) : "",
+      "",
+      this.result ? this.resultSummary(this.result) : "",
+      Composer({
+        input: this.inputBuffer,
+        running: this.running,
+        approvalPending: Boolean(this.permissionController.pending)
+      })
+    ].filter((section) => section.length > 0);
+    this.stdout.write(`\x1b[2J\x1b[H${sections.join("\n\n")}`);
+  }
+
+  private resultSummary(result: AgentRunResult): string {
+    const lines = [
+      "Summary",
+      `  status: ${result.status}`,
+      `  finish: ${result.finishReason}`,
+      `  changed: ${(result.changedFiles ?? []).join(", ") || "none"}`
+    ];
+    if (result.todoItems && result.todoItems.length > 0) {
+      lines.push(`  todos: ${result.todoItems.map((item) => `${item.id}:${item.status}:${item.text}`).join(" | ")}`);
+    }
+    if (result.finalMessage) lines.push(`  final: ${result.finalMessage}`);
+    return lines.join("\n");
+  }
+
+  private stop(): void {
+    this.stdin.off("keypress", this.handleKeypress);
+    if (this.stdin.isTTY) this.stdin.setRawMode(false);
+    this.stdout.write("\x1b[?25h\x1b[2J\x1b[H");
+    this.resolveExit?.();
+  }
+}
+
+export async function runTuiApp(options: TuiAppOptions): Promise<void> {
+  const app = new TuiApp(options, process.stdin, process.stdout);
+  await app.start();
+}

--- a/packages/agent-tui/src/app.tsx
+++ b/packages/agent-tui/src/app.tsx
@@ -45,7 +45,7 @@ class TuiApp {
     if (this.stdin.isTTY) this.stdin.setRawMode(true);
     this.stdin.resume();
     this.stdin.on("keypress", this.handleKeypress);
-    this.stdout.write("\x1b[?25l");
+    this.stdout.write("\x1b[?25h");
     this.render();
     await new Promise<void>((resolve) => {
       this.resolveExit = resolve;
@@ -64,6 +64,10 @@ class TuiApp {
     if (pending) {
       const decision = this.permissionDecisionForKey(text);
       if (decision) this.permissionController.respond(decision);
+      else {
+        this.message = "Approval waiting: press y to allow, n to deny, or a to always allow.";
+        this.render();
+      }
       return;
     }
 
@@ -194,10 +198,10 @@ class TuiApp {
         }
       });
       this.result = result;
-      this.message = result.finalMessage ?? null;
+      this.message = this.completionMessage(result);
       if (this.showDiff) await this.refreshDiff();
     } catch (error) {
-      this.message = error instanceof Error ? error.message : String(error);
+      this.message = `Run failed: ${error instanceof Error ? error.message : String(error)}`;
     } finally {
       this.running = false;
       this.render();
@@ -241,10 +245,17 @@ class TuiApp {
       Composer({
         input: this.inputBuffer,
         running: this.running,
-        approvalPending: Boolean(this.permissionController.pending)
+        approvalPending: Boolean(this.permissionController.pending),
+        lastStatus: this.result?.status
       })
     ].filter((section) => section.length > 0);
     this.stdout.write(`\x1b[2J\x1b[H${sections.join("\n\n")}`);
+  }
+
+  private completionMessage(result: AgentRunResult): string {
+    if (result.status === "completed") return "Run completed.";
+    if (result.status === "stopped") return `Run stopped: ${result.finishReason}.`;
+    return `Run failed: ${result.lastError ?? result.finishReason}.`;
   }
 
   private resultSummary(result: AgentRunResult): string {

--- a/packages/agent-tui/src/components/approval-prompt.tsx
+++ b/packages/agent-tui/src/components/approval-prompt.tsx
@@ -3,10 +3,12 @@ import { redactSecretText, type PermissionRequest } from "agent-core";
 export function ApprovalPrompt(request: PermissionRequest | null): string {
   if (!request) return "";
   return [
-    "Approval",
+    "Approval required",
+    "  The run is paused. Press one key to continue; Enter is not required.",
+    "  y = allow once    n = deny    a = always allow this kind of request",
+    "",
     `  tool: ${request.toolName}`,
     `  risk: ${request.risk}`,
-    `  reason: ${redactSecretText(request.reason)}`,
-    "  y=allow n=deny a=always allow"
+    `  reason: ${redactSecretText(request.reason)}`
   ].join("\n");
 }

--- a/packages/agent-tui/src/components/approval-prompt.tsx
+++ b/packages/agent-tui/src/components/approval-prompt.tsx
@@ -1,0 +1,12 @@
+import { redactSecretText, type PermissionRequest } from "agent-core";
+
+export function ApprovalPrompt(request: PermissionRequest | null): string {
+  if (!request) return "";
+  return [
+    "Approval",
+    `  tool: ${request.toolName}`,
+    `  risk: ${request.risk}`,
+    `  reason: ${redactSecretText(request.reason)}`,
+    "  y=allow n=deny a=always allow"
+  ].join("\n");
+}

--- a/packages/agent-tui/src/components/composer.tsx
+++ b/packages/agent-tui/src/components/composer.tsx
@@ -1,0 +1,10 @@
+export interface ComposerProps {
+  input: string;
+  running: boolean;
+  approvalPending: boolean;
+}
+
+export function Composer(props: ComposerProps): string {
+  const prompt = props.approvalPending ? "approval> " : props.running ? "sigma (running)> " : "sigma> ";
+  return `${prompt}${props.input}`;
+}

--- a/packages/agent-tui/src/components/composer.tsx
+++ b/packages/agent-tui/src/components/composer.tsx
@@ -1,10 +1,23 @@
+import type { AgentRunStatus } from "agent-core";
+
 export interface ComposerProps {
   input: string;
   running: boolean;
   approvalPending: boolean;
+  lastStatus?: AgentRunStatus;
 }
 
 export function Composer(props: ComposerProps): string {
-  const prompt = props.approvalPending ? "approval> " : props.running ? "sigma (running)> " : "sigma> ";
+  const prompt = props.approvalPending
+    ? "approval [y/n/a]> "
+    : props.running
+      ? "sigma (running)> "
+      : props.lastStatus === "completed"
+        ? "sigma (done)> "
+        : props.lastStatus === "stopped"
+          ? "sigma (stopped)> "
+          : props.lastStatus === "error"
+            ? "sigma (error)> "
+            : "sigma> ";
   return `${prompt}${props.input}`;
 }

--- a/packages/agent-tui/src/components/diff-panel.tsx
+++ b/packages/agent-tui/src/components/diff-panel.tsx
@@ -1,0 +1,11 @@
+import type { AgentRunResult } from "agent-core";
+
+export function DiffPanel(result: AgentRunResult | null, diffText: string): string {
+  const changed = result?.changedFiles ?? [];
+  const lines = ["Diff"];
+  if (changed.length > 0) {
+    lines.push(`  changed: ${changed.join(", ")}`);
+  }
+  lines.push(...(diffText.trim() ? diffText.trim().split(/\r?\n/).map((line) => `  ${line}`) : ["  No diff available."]));
+  return lines.join("\n");
+}

--- a/packages/agent-tui/src/components/status-bar.tsx
+++ b/packages/agent-tui/src/components/status-bar.tsx
@@ -1,0 +1,25 @@
+import type { ProviderName } from "agent-ai";
+import type { AgentRunResult, PermissionMode } from "agent-core";
+
+export interface StatusBarProps {
+  workspacePath: string;
+  provider: ProviderName;
+  model?: string;
+  permissionMode: PermissionMode;
+  running: boolean;
+  result: AgentRunResult | null;
+  message: string | null;
+}
+
+export function StatusBar(props: StatusBarProps): string {
+  const state = props.running ? "running" : props.result ? props.result.status : "idle";
+  const finish = props.result ? ` finish=${props.result.finishReason}` : "";
+  const message = props.message ? ` | ${props.message}` : "";
+  return [
+    `Sigma TUI | ${state}${finish}`,
+    `provider=${props.provider}`,
+    `model=${props.model ?? "default"}`,
+    `permission=${props.permissionMode}`,
+    `workspace=${props.workspacePath}${message}`
+  ].join(" | ");
+}

--- a/packages/agent-tui/src/components/timeline.tsx
+++ b/packages/agent-tui/src/components/timeline.tsx
@@ -4,6 +4,24 @@ function truncate(value: string, max = 120): string {
   return value.length <= max ? value : `${value.slice(0, Math.max(0, max - 3))}...`;
 }
 
+function toolStartDetail(toolCall: { function?: { name?: string; arguments?: unknown } } | undefined): string {
+  const name = toolCall?.function?.name ?? "unknown";
+  const args = toolCall?.function?.arguments;
+  if (args && typeof args === "object") {
+    const values = args as Record<string, unknown>;
+    if (name === "bash" && typeof values.command === "string") {
+      return `${name} ${truncate(redactSecretText(values.command), 100)}`;
+    }
+    if (name === "service") {
+      const action = typeof values.action === "string" ? values.action : "service";
+      const serviceName = typeof values.name === "string" ? ` ${values.name}` : "";
+      const command = typeof values.command === "string" ? ` ${truncate(redactSecretText(values.command), 80)}` : "";
+      return `${name} ${action}${serviceName}${command}`;
+    }
+  }
+  return name;
+}
+
 function eventLine(event: AgentEvent): string {
   const time = event.timestamp.slice(11, 19);
   const meta = event.metadata ?? {};
@@ -17,7 +35,7 @@ function eventLine(event: AgentEvent): string {
   }
   if (event.type === "tool_start") {
     const toolCall = meta.toolCall as { function?: { name?: string } } | undefined;
-    return `${time} tool_start ${toolCall?.function?.name ?? "unknown"}`;
+    return `${time} tool_start ${toolStartDetail(toolCall)}`;
   }
   if (event.type === "tool_end") {
     const result = meta.result as { ok?: boolean; content?: string } | undefined;

--- a/packages/agent-tui/src/components/timeline.tsx
+++ b/packages/agent-tui/src/components/timeline.tsx
@@ -1,0 +1,38 @@
+import { redactSecretText, type AgentEvent } from "agent-core";
+
+function truncate(value: string, max = 120): string {
+  return value.length <= max ? value : `${value.slice(0, Math.max(0, max - 3))}...`;
+}
+
+function eventLine(event: AgentEvent): string {
+  const time = event.timestamp.slice(11, 19);
+  const meta = event.metadata ?? {};
+  if (event.type === "run_start") return `${time} run_start workspace=${meta.workspacePath ?? ""}`;
+  if (event.type === "model_start") return `${time} model_start turn=${meta.turn ?? ""}`;
+  if (event.type === "model_end") return `${time} model_end turn=${meta.turn ?? ""}`;
+  if (event.type === "assistant_message") {
+    const content = typeof meta.content === "string" ? redactSecretText(meta.content) : "";
+    const toolCalls = Array.isArray(meta.toolCalls) ? ` tool_calls=${meta.toolCalls.length}` : "";
+    return `${time} assistant ${truncate(content || "(tool call)")}${toolCalls}`;
+  }
+  if (event.type === "tool_start") {
+    const toolCall = meta.toolCall as { function?: { name?: string } } | undefined;
+    return `${time} tool_start ${toolCall?.function?.name ?? "unknown"}`;
+  }
+  if (event.type === "tool_end") {
+    const result = meta.result as { ok?: boolean; content?: string } | undefined;
+    return `${time} tool_end ${meta.toolName ?? "unknown"} ok=${String(result?.ok ?? false)} ${truncate(redactSecretText(result?.content ?? ""), 90)}`;
+  }
+  if (event.type === "error") return `${time} error ${truncate(redactSecretText(String(meta.message ?? "")))}`;
+  if (event.type === "run_end") {
+    const result = meta.result as { status?: string; finishReason?: string } | undefined;
+    return `${time} run_end status=${result?.status ?? ""} finish=${result?.finishReason ?? ""}`;
+  }
+  return `${time} ${event.type}`;
+}
+
+export function Timeline(events: AgentEvent[], maxLines: number): string {
+  const visible = events.slice(Math.max(0, events.length - maxLines));
+  if (visible.length === 0) return "Timeline\n  No runs yet.";
+  return ["Timeline", ...visible.map((event) => `  ${eventLine(event)}`)].join("\n");
+}

--- a/packages/agent-tui/src/components/tool-panel.tsx
+++ b/packages/agent-tui/src/components/tool-panel.tsx
@@ -1,0 +1,13 @@
+import type { AgentEvent, AgentRunResult } from "agent-core";
+
+export function ToolPanel(events: AgentEvent[], result: AgentRunResult | null): string {
+  const toolEvents = events.filter((event) => event.type === "tool_end").slice(-8);
+  const tools = result?.toolsAvailable?.join(", ") || "available after first run";
+  const lines = ["Tools", `  available: ${tools}`];
+  for (const event of toolEvents) {
+    const meta = event.metadata ?? {};
+    const res = meta.result as { ok?: boolean } | undefined;
+    lines.push(`  ${meta.toolName ?? "unknown"} ok=${String(res?.ok ?? false)}`);
+  }
+  return lines.join("\n");
+}

--- a/packages/agent-tui/src/index.tsx
+++ b/packages/agent-tui/src/index.tsx
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+import path from "node:path";
+import type { ProviderName } from "agent-ai";
+import type { PermissionMode } from "agent-core";
+import { runTuiApp } from "./app.js";
+
+interface CliOptions {
+  workspace: string;
+  provider: ProviderName;
+  model?: string;
+  permissionMode: PermissionMode;
+}
+
+function printHelp(): void {
+  process.stdout.write(`agent-tui [flags]
+
+Flags:
+  --workspace <path>             Workspace directory (default: current directory)
+  --provider <deepseek|glm>      Model provider (default: deepseek)
+  --model <name>                 Model name
+  --permission-mode <ask|yolo>   Permission handling (default: ask)
+  --help                         Show this help
+
+Inside the TUI:
+  /exit
+  /clear
+  /model <name>
+  /provider <deepseek|glm>
+  /permission <ask|yolo>
+  /tools
+  /diff
+`);
+}
+
+function parseArgs(argv: string[]): CliOptions | "help" {
+  const flags = new Map<string, string | true>();
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--help" || arg === "-h") return "help";
+    if (!arg.startsWith("--")) continue;
+    const name = arg.slice(2);
+    const next = argv[index + 1];
+    if (next && !next.startsWith("--")) {
+      flags.set(name, next);
+      index += 1;
+    } else {
+      flags.set(name, true);
+    }
+  }
+
+  const provider = flags.get("provider") ?? "deepseek";
+  if (provider !== "deepseek" && provider !== "glm") {
+    throw new Error("Unsupported provider. Use deepseek or glm.");
+  }
+  const permissionMode = flags.get("permission-mode") ?? "ask";
+  if (permissionMode !== "ask" && permissionMode !== "yolo") {
+    throw new Error("Unsupported permission mode. Use ask or yolo.");
+  }
+
+  const workspace = flags.get("workspace");
+  const model = flags.get("model");
+  return {
+    workspace: path.resolve(typeof workspace === "string" ? workspace : process.cwd()),
+    provider,
+    model: typeof model === "string" ? model : undefined,
+    permissionMode
+  };
+}
+
+async function main(): Promise<number> {
+  const parsed = parseArgs(process.argv.slice(2));
+  if (parsed === "help") {
+    printHelp();
+    return 0;
+  }
+  await runTuiApp(parsed);
+  return 0;
+}
+
+main()
+  .then((code) => {
+    process.exitCode = code;
+  })
+  .catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });

--- a/packages/agent-tui/src/permission.ts
+++ b/packages/agent-tui/src/permission.ts
@@ -1,0 +1,40 @@
+import type { PermissionDecider, PermissionDecision, PermissionRequest } from "agent-core";
+
+export type PermissionListener = () => void;
+
+export class TuiPermissionController implements PermissionDecider {
+  private readonly listeners = new Set<PermissionListener>();
+  private pendingRequest: PermissionRequest | null = null;
+  private resolveDecision: ((decision: PermissionDecision) => void) | null = null;
+
+  onChange(listener: PermissionListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  get pending(): PermissionRequest | null {
+    return this.pendingRequest;
+  }
+
+  async decide(request: PermissionRequest): Promise<PermissionDecision> {
+    if (this.pendingRequest) return "deny";
+    this.pendingRequest = request;
+    this.notify();
+    return await new Promise<PermissionDecision>((resolve) => {
+      this.resolveDecision = resolve;
+    });
+  }
+
+  respond(decision: PermissionDecision): void {
+    if (!this.resolveDecision) return;
+    const resolve = this.resolveDecision;
+    this.pendingRequest = null;
+    this.resolveDecision = null;
+    resolve(decision);
+    this.notify();
+  }
+
+  private notify(): void {
+    for (const listener of this.listeners) listener();
+  }
+}

--- a/packages/agent-tui/src/run-session.ts
+++ b/packages/agent-tui/src/run-session.ts
@@ -1,0 +1,40 @@
+import { createModelClient, type ProviderName } from "agent-ai";
+import {
+  AgentEventBus,
+  runAgent,
+  type AgentEvent,
+  type AgentRunResult,
+  type PermissionMode
+} from "agent-core";
+import type { TuiPermissionController } from "./permission.js";
+
+export interface RunSessionOptions {
+  instruction: string;
+  workspacePath: string;
+  provider: ProviderName;
+  model?: string;
+  permissionMode: PermissionMode;
+  permissionController: TuiPermissionController;
+  onEvent(event: AgentEvent): void;
+}
+
+export async function runSession(options: RunSessionOptions): Promise<AgentRunResult> {
+  const eventBus = new AgentEventBus();
+  const unsubscribe = eventBus.on(options.onEvent);
+  const modelClient = createModelClient(options.provider, { model: options.model });
+
+  try {
+    return await runAgent({
+      instruction: options.instruction,
+      workspacePath: options.workspacePath,
+      modelClient,
+      permissionMode: options.permissionMode,
+      permissionDecider: options.permissionMode === "ask" ? options.permissionController : undefined,
+      contextMode: "repo-map",
+      eventBus
+      // TODO: when agent-core emits assistant delta events from modelClient.stream, render token-level updates here.
+    });
+  } finally {
+    unsubscribe();
+  }
+}

--- a/packages/agent-tui/tsconfig.json
+++ b/packages/agent-tui/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "composite": true,
+    "tsBuildInfoFile": "dist/.tsbuildinfo",
+    "jsx": "react-jsx"
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "references": [
+    { "path": "../agent-ai" },
+    { "path": "../agent-core" }
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,15 @@ importers:
         specifier: workspace:*
         version: link:../agent-ai
 
+  packages/agent-tui:
+    dependencies:
+      agent-ai:
+        specifier: workspace:*
+        version: link:../agent-ai
+      agent-core:
+        specifier: workspace:*
+        version: link:../agent-core
+
 packages:
 
   '@esbuild/aix-ppc64@0.28.1':

--- a/portable/harbor/sigma_harbor_agent.py
+++ b/portable/harbor/sigma_harbor_agent.py
@@ -115,18 +115,6 @@ def _normalize_globs(value: str | list[str] | tuple[str, ...] | None) -> list[st
     return []
 
 
-def _as_bool(value: Any, fallback: bool) -> bool:
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, str):
-        text = value.strip().lower()
-        if text in {"1", "true", "yes", "on"}:
-            return True
-        if text in {"0", "false", "no", "off"}:
-            return False
-    return fallback
-
-
 class SigmaCliHarborAgent(BaseAgent):
     """Run Sigma's packaged Node CLI as a Harbor external agent."""
 
@@ -142,21 +130,18 @@ class SigmaCliHarborAgent(BaseAgent):
         max_turns: int = 200,
         command_timeout_sec: int = 180,
         max_wall_time_sec: int = 7200,
-        pre_verifier_cleanup_globs: str | list[str] | None = None,
+        post_run_cleanup_globs: str | list[str] | None = None,
         precheck_command: str | None = None,
         precheck_timeout_sec: int | None = None,
         validation_mode: str | None = None,
-        validation_retry_limit: int | None = None,
+        validation_retry_limit: int = 0,
         validation_timeout_sec: int | None = None,
         harness_timeout_sec: int | None = None,
-        precheck_retry_limit: int = 0,
-        harbor_agent_timeout_sec: int | None = None,
         agent_timeout_grace_sec: int = 120,
         retry_min_budget_sec: int | None = None,
         max_message_history_chars: int | None = 250000,
         message_history_retain: int = 24,
         compaction_summary_chars: int = 30000,
-        generic_validation_enabled: bool | str = False,
         **kwargs: Any,
     ) -> None:
         resolved_logs_dir = pathlib.Path(logs_dir) if logs_dir is not None else pathlib.Path.cwd() / ".agent" / "harbor"
@@ -169,15 +154,13 @@ class SigmaCliHarborAgent(BaseAgent):
         self.max_turns = max_turns
         self.command_timeout_sec = command_timeout_sec
         self.max_wall_time_sec = max_wall_time_sec
-        self.cleanup_globs = _normalize_globs(pre_verifier_cleanup_globs)
+        self.cleanup_globs = _normalize_globs(post_run_cleanup_globs)
         self.precheck_command = precheck_command.strip() if isinstance(precheck_command, str) and precheck_command.strip() else None
         self.precheck_timeout_sec = max(1, _as_int(precheck_timeout_sec, command_timeout_sec))
-        retry_limit = validation_retry_limit if validation_retry_limit is not None else precheck_retry_limit
-        self.validation_retry_limit = max(0, _as_int(retry_limit, 0))
-        self.validation_mode = self._resolve_validation_mode(validation_mode, generic_validation_enabled)
-        harbor_timeout_value = harness_timeout_sec if harness_timeout_sec is not None else harbor_agent_timeout_sec
-        harbor_timeout = _as_int(harbor_timeout_value, 0)
-        self.harbor_agent_timeout_sec = harbor_timeout if harbor_timeout > 0 else None
+        self.validation_retry_limit = max(0, _as_int(validation_retry_limit, 0))
+        self.validation_mode = self._resolve_validation_mode(validation_mode)
+        harness_timeout = _as_int(harness_timeout_sec, 0)
+        self.harness_timeout_sec = harness_timeout if harness_timeout > 0 else None
         self.agent_timeout_grace_sec = max(0, _as_int(agent_timeout_grace_sec, 120))
         retry_min_budget = _as_int(retry_min_budget_sec, 0)
         self.retry_min_budget_sec = retry_min_budget if retry_min_budget > 0 else None
@@ -186,7 +169,6 @@ class SigmaCliHarborAgent(BaseAgent):
         )
         self.message_history_retain = max(0, _as_int(message_history_retain, 24))
         self.compaction_summary_chars = max(1, _as_int(compaction_summary_chars, 30000))
-        self.generic_validation_enabled = self.validation_mode != "off"
         self.validation_timeout_sec = max(1, _as_int(validation_timeout_sec, self.precheck_timeout_sec))
 
     @staticmethod
@@ -196,10 +178,10 @@ class SigmaCliHarborAgent(BaseAgent):
     def version(self) -> str | None:
         return "0.1.0"
 
-    def _resolve_validation_mode(self, validation_mode: str | None, generic_validation_enabled: bool | str) -> str:
+    def _resolve_validation_mode(self, validation_mode: str | None) -> str:
         if isinstance(validation_mode, str) and validation_mode.strip():
             return validation_mode.strip()
-        return "auto" if _as_bool(generic_validation_enabled, False) else "off"
+        return "off"
 
     async def setup(self, environment: BaseEnvironment) -> None:
         await environment.exec("mkdir -p /tmp/agent", timeout_sec=30)
@@ -302,9 +284,9 @@ class SigmaCliHarborAgent(BaseAgent):
                 ]
             )
         if self.cleanup_globs:
-            command.extend(["--pre-verifier-cleanup-globs", ",".join(self.cleanup_globs)])
-        if self.harbor_agent_timeout_sec is not None:
-            command.extend(["--harness-timeout-sec", str(self.harbor_agent_timeout_sec)])
+            command.extend(["--post-run-cleanup-globs", ",".join(self.cleanup_globs)])
+        if self.harness_timeout_sec is not None:
+            command.extend(["--harness-timeout-sec", str(self.harness_timeout_sec)])
         if self.retry_min_budget_sec is not None:
             command.extend(["--retry-min-budget-sec", str(self.retry_min_budget_sec)])
         if self.max_message_history_chars and self.max_message_history_chars > 0:
@@ -322,7 +304,7 @@ class SigmaCliHarborAgent(BaseAgent):
 
     async def _run_agent_once(self, environment: BaseEnvironment, env_vars: dict[str, str], context: AgentContext) -> Any:
         command = self._agent_command(context)
-        base_timeout = self.harbor_agent_timeout_sec or self.max_wall_time_sec
+        base_timeout = self.harness_timeout_sec or self.max_wall_time_sec
         return await environment.exec(
             " ".join(shlex.quote(part) for part in command),
             env=env_vars or None,
@@ -500,7 +482,7 @@ ln -sf /opt/agent-cli/bin/agent /usr/local/bin/agent
         validation_results = harness.get("validation_results") if isinstance(harness, dict) else []
         precheck_results = harness.get("precheck_results") if isinstance(harness, dict) else []
         retry_decisions = harness.get("retry_decisions") if isinstance(harness, dict) else []
-        cleanup = harness.get("pre_verifier_cleanup") if isinstance(harness, dict) else None
+        cleanup = harness.get("post_run_cleanup") if isinstance(harness, dict) else None
 
         metadata = {
             "task_id": task_id,
@@ -515,13 +497,13 @@ ln -sf /opt/agent-cli/bin/agent /usr/local/bin/agent
             "cost_usd": getattr(context, "cost_usd", None),
             "precheck_results": precheck_results if isinstance(precheck_results, list) else [],
             "validation_results": validation_results if isinstance(validation_results, list) else [],
-            "generic_validation_enabled": self.generic_validation_enabled,
+            "validation_mode": self.validation_mode,
             "validation_timeout_sec": self.validation_timeout_sec,
             "precheck_timeout_sec": self.precheck_timeout_sec,
             "retry_decisions": retry_decisions if isinstance(retry_decisions, list) else [],
             "changed_app_files": self._changed_files_from_harness(summary),
             "workspace_snapshots": [],
-            "pre_verifier_cleanup": cleanup,
+            "post_run_cleanup": cleanup,
             "failure_signals": self._failure_signals_for_metadata(result, summary),
         }
         (task_dir / "metadata.json").write_text(f"{json.dumps(metadata, indent=2)}\n", encoding="utf-8")
@@ -572,9 +554,9 @@ ln -sf /opt/agent-cli/bin/agent /usr/local/bin/agent
                 if decision.get("action") == "started" and "validation" in str(decision.get("trigger") or ""):
                     add("validation_retry_used")
 
-        cleanup = harness.get("pre_verifier_cleanup") if isinstance(harness, dict) else None
+        cleanup = harness.get("post_run_cleanup") if isinstance(harness, dict) else None
         if isinstance(cleanup, dict) and cleanup.get("warning"):
-            add("pre_verifier_cleanup_warning")
+            add("post_run_cleanup_warning")
 
         result_text = _output_text(result) if result is not None else ""
         if re.search(r"finish[_ ]?reason\"?\s*[:=]\s*\"?max_wall_time", result_text, flags=re.IGNORECASE) or re.search(

--- a/scripts/bench-common.mjs
+++ b/scripts/bench-common.mjs
@@ -215,12 +215,10 @@ function asOptionalNonNegativeInt(value, name) {
   return parsed;
 }
 
-function asBoolean(value, fallback, name) {
-  if (value === undefined || value === null || value === "") return fallback;
-  const text = String(value).trim().toLowerCase();
-  if (["1", "true", "yes", "on"].includes(text)) return true;
-  if (["0", "false", "no", "off"].includes(text)) return false;
-  throw new Error(`${name} must be a boolean-like value.`);
+function asValidationMode(value, fallback = "auto") {
+  const text = String(value ?? fallback).trim().toLowerCase();
+  if (text === "auto" || text === "off") return text;
+  throw new Error("AGENT_VALIDATION_MODE must be auto or off.");
 }
 
 export function resolveRunOptions(argv, env = process.env) {
@@ -260,15 +258,11 @@ export function resolveRunOptions(argv, env = process.env) {
       defaultPrecheckTimeoutSec,
       "AGENT_PRECHECK_TIMEOUT_SEC"
     ),
-    precheckRetryLimit: asOptionalNonNegativeInt(
-      env.AGENT_PRECHECK_RETRY_LIMIT,
-      "AGENT_PRECHECK_RETRY_LIMIT"
+    validationRetryLimit: asOptionalNonNegativeInt(
+      env.AGENT_VALIDATION_RETRY_LIMIT,
+      "AGENT_VALIDATION_RETRY_LIMIT"
     ),
-    genericValidationEnabled: asBoolean(
-      env.AGENT_GENERIC_VALIDATION,
-      true,
-      "AGENT_GENERIC_VALIDATION"
-    )
+    validationMode: asValidationMode(env.AGENT_VALIDATION_MODE, "auto")
   };
 }
 
@@ -384,32 +378,32 @@ export function computeHarborTimeoutPlan(options = {}, timeoutProbe = null) {
     0,
     Math.ceil(asFinitePositiveNumber(options.agentTimeoutGraceSec) ?? defaultAgentTimeoutGraceSec)
   );
-  const precheckRetryLimitWasProvided =
-    options.precheckRetryLimit !== undefined && options.precheckRetryLimit !== null && options.precheckRetryLimit !== "";
-  const requestedPrecheckRetryLimit = precheckRetryLimitWasProvided && Number.isFinite(Number(options.precheckRetryLimit))
-    ? Math.max(0, Math.ceil(Number(options.precheckRetryLimit)))
+  const validationRetryLimitWasProvided =
+    options.validationRetryLimit !== undefined && options.validationRetryLimit !== null && options.validationRetryLimit !== "";
+  const requestedValidationRetryLimit = validationRetryLimitWasProvided && Number.isFinite(Number(options.validationRetryLimit))
+    ? Math.max(0, Math.ceil(Number(options.validationRetryLimit)))
     : null;
-  const genericValidationEnabled = options.mode === "smoke" ? false : options.genericValidationEnabled !== false;
+  const validationMode = options.mode === "smoke" ? "off" : asValidationMode(options.validationMode, "auto");
+  const validationEnabled = validationMode === "auto";
   const defaultRetryLimit =
     options.mode === "smoke"
       ? 0
-      : genericValidationEnabled
+      : validationEnabled
         ? defaultPrecheckRetryLimit
         : 0;
-  const precheckRetryLimit = requestedPrecheckRetryLimit ?? defaultRetryLimit;
-  const validationOrPrecheckEnabled = genericValidationEnabled;
-  const precheckTimeoutSec = precheckRetryLimit > 0 || validationOrPrecheckEnabled
+  const validationRetryLimit = requestedValidationRetryLimit ?? defaultRetryLimit;
+  const precheckTimeoutSec = validationRetryLimit > 0 || validationEnabled
     ? Math.max(1, Math.ceil(asFinitePositiveNumber(options.precheckTimeoutSec) ?? defaultPrecheckTimeoutSec))
     : 0;
-  const retryBudgetSec = precheckRetryLimit * agentWallTimeSec;
+  const retryBudgetSec = validationRetryLimit * agentWallTimeSec;
   const precheckBudgetSec = precheckTimeoutSec > 0
-    ? (precheckRetryLimit + (validationOrPrecheckEnabled ? 1 : 0)) * precheckTimeoutSec
+    ? (validationRetryLimit + (validationEnabled ? 1 : 0)) * precheckTimeoutSec
     : 0;
   const cleanupGraceSec = graceSec;
-  const harborAgentTimeoutSec = agentWallTimeSec + retryBudgetSec + precheckBudgetSec + cleanupGraceSec;
+  const harnessTimeoutSec = agentWallTimeSec + retryBudgetSec + precheckBudgetSec + cleanupGraceSec;
   const agentTimeoutMultiplier =
-    harborAgentTimeoutSec > recommendedAgentTimeoutSec
-      ? formatMultiplier(harborAgentTimeoutSec / recommendedAgentTimeoutSec)
+    harnessTimeoutSec > recommendedAgentTimeoutSec
+      ? formatMultiplier(harnessTimeoutSec / recommendedAgentTimeoutSec)
       : null;
 
   return {
@@ -418,12 +412,12 @@ export function computeHarborTimeoutPlan(options = {}, timeoutProbe = null) {
     cleanup_grace_sec: cleanupGraceSec,
     retry_budget_sec: retryBudgetSec,
     precheck_timeout_sec: precheckTimeoutSec,
-    precheck_retry_limit: precheckRetryLimit,
+    validation_retry_limit: validationRetryLimit,
     precheck_budget_sec: precheckBudgetSec,
-    generic_validation_enabled: genericValidationEnabled,
+    validation_mode: validationMode,
     validation_timeout_sec: precheckTimeoutSec,
-    harbor_agent_timeout_sec: harborAgentTimeoutSec,
-    effective_harbor_agent_timeout_sec: harborAgentTimeoutSec,
+    harness_timeout_sec: harnessTimeoutSec,
+    effective_harness_timeout_sec: harnessTimeoutSec,
     leniency_multiplier: leniencyMultiplier,
     leniency_min_extra_sec: leniencyMinExtraSec,
     recommended_agent_timeout_sec: recommendedAgentTimeoutSec,
@@ -483,16 +477,16 @@ function benchmarkAgentKwargs(options, timeoutPlan = null, timeoutProbe = null) 
   if (timeoutPlan?.agent_wall_time_sec) {
     agentKwargs.max_wall_time_sec = timeoutPlan.agent_wall_time_sec;
   }
-  if (timeoutPlan?.effective_harbor_agent_timeout_sec) {
-    agentKwargs.harbor_agent_timeout_sec = timeoutPlan.effective_harbor_agent_timeout_sec;
+  if (timeoutPlan?.effective_harness_timeout_sec) {
+    agentKwargs.harness_timeout_sec = timeoutPlan.effective_harness_timeout_sec;
   }
   if (timeoutPlan?.cleanup_grace_sec !== undefined) {
     agentKwargs.agent_timeout_grace_sec = timeoutPlan.cleanup_grace_sec;
   }
 
-  agentKwargs.generic_validation_enabled = timeoutPlan?.generic_validation_enabled ?? options.genericValidationEnabled !== false;
+  agentKwargs.validation_mode = timeoutPlan?.validation_mode ?? asValidationMode(options.validationMode, "auto");
   agentKwargs.validation_timeout_sec = timeoutPlan?.validation_timeout_sec ?? defaultPrecheckTimeoutSec;
-  agentKwargs.precheck_retry_limit = timeoutPlan?.precheck_retry_limit ?? defaultPrecheckRetryLimit;
+  agentKwargs.validation_retry_limit = timeoutPlan?.validation_retry_limit ?? defaultPrecheckRetryLimit;
   agentKwargs.precheck_timeout_sec = timeoutPlan?.precheck_timeout_sec ?? defaultPrecheckTimeoutSec;
   return agentKwargs;
 }
@@ -634,6 +628,11 @@ export function buildHarborArgs(options) {
   args.push("--ak", formatAgentKwarg("max_turns", "int", options.maxTurns, capabilities));
   args.push("--ak", formatAgentKwarg("command_timeout_sec", "int", options.commandTimeoutSec, capabilities));
   args.push("--ak", formatAgentKwarg("max_wall_time_sec", "int", timeoutPlan.agent_wall_time_sec, capabilities));
+  args.push("--ak", formatAgentKwarg("harness_timeout_sec", "int", timeoutPlan.effective_harness_timeout_sec, capabilities));
+  args.push("--ak", formatAgentKwarg("validation_mode", "str", timeoutPlan.validation_mode, capabilities));
+  args.push("--ak", formatAgentKwarg("validation_retry_limit", "int", timeoutPlan.validation_retry_limit, capabilities));
+  args.push("--ak", formatAgentKwarg("validation_timeout_sec", "int", timeoutPlan.validation_timeout_sec, capabilities));
+  args.push("--ak", formatAgentKwarg("precheck_timeout_sec", "int", timeoutPlan.precheck_timeout_sec, capabilities));
   return args;
 }
 
@@ -937,8 +936,8 @@ function collectFailureSignals(input = {}) {
     }
   }
 
-  if (harness.pre_verifier_cleanup?.warning) {
-    addSignal(signals, "pre_verifier_cleanup_warning");
+  if (harness.post_run_cleanup?.warning) {
+    addSignal(signals, "post_run_cleanup_warning");
   }
   const stoppedServices = [
     ...serviceCleanupStoppedFromSummary(summary),
@@ -1466,8 +1465,8 @@ export function formatMarkdownReport(report) {
     `- Agent wall time sec: ${report.timeout_plan?.agent_wall_time_sec ?? "unknown"}`,
     `- Retry budget sec: ${report.timeout_plan?.retry_budget_sec ?? "unknown"}`,
     `- Precheck timeout sec: ${report.timeout_plan?.precheck_timeout_sec ?? "unknown"}`,
-    `- Harbor agent timeout sec: ${report.timeout_plan?.harbor_agent_timeout_sec ?? "unknown"}`,
-    `- Effective Harbor agent timeout sec: ${report.timeout_plan?.effective_harbor_agent_timeout_sec ?? report.timeout_plan?.harbor_agent_timeout_sec ?? "unknown"}`,
+    `- Harness timeout sec: ${report.timeout_plan?.harness_timeout_sec ?? "unknown"}`,
+    `- Effective harness timeout sec: ${report.timeout_plan?.effective_harness_timeout_sec ?? report.timeout_plan?.harness_timeout_sec ?? "unknown"}`,
     `- Agent timeout multiplier: ${report.timeout_plan?.agent_timeout_multiplier ?? "none"}`,
     "",
     "## Counts",

--- a/scripts/package-harbor-runtime.mjs
+++ b/scripts/package-harbor-runtime.mjs
@@ -39,7 +39,7 @@ function baseBenchmarkOptions(agentCliTarball) {
     model: "deepseek-v4-pro",
     maxTurns: 200,
     commandTimeoutSec: 180,
-    genericValidationEnabled: true,
+    validationMode: "auto",
     agentCliTarball,
     agentImportPath: portableAgentImportPath,
     env: {}

--- a/tests/agent-cli.solve.test.ts
+++ b/tests/agent-cli.solve.test.ts
@@ -66,11 +66,12 @@ describe("agent-cli solve", () => {
       workspace: "work",
       provider: "deepseek",
       "validation-mode": "auto",
+      "validation-command": "npm test",
       "validation-retry-limit": "2",
       "validation-timeout-sec": "45",
       "precheck-command": "pytest",
       "precheck-timeout-sec": "30",
-      "pre-verifier-cleanup-globs": "/tmp/cache*.tmp,/tmp/other*.tmp",
+      "post-run-cleanup-globs": "/tmp/cache*.tmp,/tmp/other*.tmp",
       "harness-timeout-sec": "600",
       "retry-min-budget-sec": "90",
       "attempts-dir": "/tmp/agent/attempts"
@@ -78,11 +79,12 @@ describe("agent-cli solve", () => {
 
     expect(config).toMatchObject({
       validationMode: "auto",
+      validationCommands: ["npm test"],
       validationRetryLimit: 2,
       validationTimeoutSec: 45,
       precheckCommand: "pytest",
       precheckTimeoutSec: 30,
-      preVerifierCleanupGlobs: ["/tmp/cache*.tmp", "/tmp/other*.tmp"],
+      postRunCleanupGlobs: ["/tmp/cache*.tmp", "/tmp/other*.tmp"],
       harnessTimeoutSec: 600,
       retryMinBudgetSec: 90,
       attemptsDir: "/tmp/agent/attempts"

--- a/tests/agent-core.harness.test.ts
+++ b/tests/agent-core.harness.test.ts
@@ -8,11 +8,20 @@ import {
   runHarnessCommand,
   validationCommandSpecs
 } from "../packages/agent-core/src/harness/validation.js";
-import { runAgentHarness } from "../packages/agent-core/src/index.js";
+import {
+  runAgentHarness,
+  runAgentWithController,
+  type AgentRunControllerConfig,
+  type AgentRunControllerSummary,
+  type RunControllerCleanupResult,
+  type RunControllerCommandResult,
+  type RunControllerRetryDecision,
+  type RunControllerServiceCleanupResult
+} from "../packages/agent-core/src/index.js";
 
 class SequenceModel implements ModelClient {
   readonly provider = "deepseek" as const;
-  readonly model = "fake-harness-model";
+  readonly model = "fake-run-controller-model";
   readonly requests: ModelRequest[] = [];
   private index = 0;
 
@@ -46,10 +55,31 @@ function writeResponse(filePath: string, content: string): ModelResponse {
 }
 
 async function tempWorkspace(): Promise<string> {
-  return await mkdtemp(path.join(os.tmpdir(), "agent-harness-"));
+  return await mkdtemp(path.join(os.tmpdir(), "agent-run-controller-"));
 }
 
+function acceptRunControllerAliases(
+  _config: AgentRunControllerConfig,
+  _summary: AgentRunControllerSummary,
+  _command: RunControllerCommandResult,
+  _decision: RunControllerRetryDecision,
+  _cleanup: RunControllerCleanupResult,
+  _serviceCleanup: RunControllerServiceCleanupResult
+): void {}
+
 describe("agent-core harness", () => {
+  it("exports run-controller aliases for the existing controller API", () => {
+    expect(runAgentWithController).toBe(runAgentHarness);
+    acceptRunControllerAliases(
+      {} as AgentRunControllerConfig,
+      {} as AgentRunControllerSummary,
+      {} as RunControllerCommandResult,
+      {} as RunControllerRetryDecision,
+      {} as RunControllerCleanupResult,
+      {} as RunControllerServiceCleanupResult
+    );
+  });
+
   it("kills timed-out validation commands that ignore SIGTERM", async () => {
     const dir = await tempWorkspace();
     const startedAt = Date.now();
@@ -198,6 +228,9 @@ describe("agent-core harness", () => {
       request.messages.some((message) => message.role === "user" && String(message.content).includes("Validation failure 1"))
     );
     expect(retryRequest).toBeTruthy();
+    const retryInstruction = retryRequest?.messages.find((message) => message.role === "user")?.content;
+    expect(String(retryInstruction)).toContain("The previous attempt failed post-run checks.");
+    expect(String(retryInstruction).toLowerCase()).not.toContain("harness");
     const summary = JSON.parse(await readFile(summaryPath, "utf8"));
     expect(summary.harness.retry_decisions).toEqual([expect.objectContaining({ action: "started", trigger: "validation" })]);
     await expect(stat(path.join(attemptsDir, "attempt-1", "summary.json"))).resolves.toBeTruthy();

--- a/tests/agent-core.harness.test.ts
+++ b/tests/agent-core.harness.test.ts
@@ -119,13 +119,13 @@ describe("agent-core harness", () => {
     expect(commands.some((command) => /(?:^|[ ;])node parser\.js(?:[ ;]|$)/.test(command))).toBe(false);
   });
 
-  it("does not generate task-specific validation", () => {
+  it("combines explicitly configured validation with generic changed-file checks", () => {
     const specs = validationCommandSpecs(
-      { validation_commands: ["npm test"] } as never,
+      ["npm test"],
       ["main.py"]
     );
 
-    expect(specs.map((spec) => spec.source)).toEqual(["summary", "changed-file"]);
+    expect(specs.map((spec) => spec.source)).toEqual(["configured", "changed-file"]);
     expect(specs.map((spec) => spec.command)).toEqual(["npm test", "python -m py_compile main.py"]);
   });
 
@@ -244,7 +244,7 @@ describe("agent-core harness", () => {
     expect(retryRequest).toBeTruthy();
   });
 
-  it("runs pre-verifier cleanup and records warnings separately from success", async () => {
+  it("runs post-run cleanup and records warnings separately from success", async () => {
     const dir = await tempWorkspace();
     const target = path.join(dir, "cleanup.tmp");
     await writeFile(target, "cleanup", "utf8");
@@ -256,14 +256,14 @@ describe("agent-core harness", () => {
       workspacePath: dir,
       modelClient: model,
       validationMode: "off",
-      preVerifierCleanupGlobs: [target],
+      postRunCleanupGlobs: [target],
       permissionMode: "yolo",
       summaryJsonPath: summaryPath
     });
 
     expect(result.status).toBe("completed");
     const summary = JSON.parse(await readFile(summaryPath, "utf8"));
-    expect(summary.harness.pre_verifier_cleanup).toMatchObject({ patterns: [target], exit_code: 0 });
+    expect(summary.harness.post_run_cleanup).toMatchObject({ patterns: [target], exit_code: 0 });
     await expect(stat(target)).rejects.toThrow();
   });
 });

--- a/tests/agent-core.loop.test.ts
+++ b/tests/agent-core.loop.test.ts
@@ -173,7 +173,7 @@ describe("agent loop", () => {
     expect(thirdRequestMessages[1]).toMatchObject({ role: "user", content: "make lots of output" });
     expect(thirdRequestMessages[2].role).toBe("user");
     expect((thirdRequestMessages[2] as { content?: string }).content).toContain(
-      "Previous agent conversation compacted by harness."
+      "Previous agent conversation compacted by the run controller."
     );
     expect(thirdRequestMessages[3].role).toBe("assistant");
   });

--- a/tests/agent-core.tools.test.ts
+++ b/tests/agent-core.tools.test.ts
@@ -66,6 +66,15 @@ describe("agent-core tools", () => {
     expect(result.metadata?.timedOut).toBe(true);
   });
 
+  it("guides dev servers to the service tool instead of blocking bash", async () => {
+    const { context } = await workspace();
+    const result = await executeBashTool({ command: "npm run dev -- --host 127.0.0.1" }, context);
+
+    expect(result.ok).toBe(false);
+    expect(result.content).toContain("service.start");
+    expect(result.metadata?.blockedReason).toBe("long_running_service_command");
+  });
+
   it("returns after shell exit even when a background child keeps stdout open", async () => {
     const { context } = await workspace();
     const startedAt = Date.now();
@@ -147,6 +156,8 @@ describe("agent-core tools", () => {
       context
     );
     expect(start.ok).toBe(true);
+    expect(start.content).toContain(`url=http://127.0.0.1:${port}`);
+    expect(start.metadata?.url).toBe(`http://127.0.0.1:${port}`);
 
     const status = await executeServiceTool({ action: "status", name: "web" }, context);
     expect(status.ok).toBe(true);

--- a/tests/agent-core.tools.test.ts
+++ b/tests/agent-core.tools.test.ts
@@ -4,10 +4,10 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
-  cleanupServicesBeforeVerifier,
   executeBashTool,
   executeEditTool,
   executeReadTool,
+  finalizeManagedServices,
   executeServiceTool,
   executeWriteTool,
   type ToolExecutionContext
@@ -160,7 +160,7 @@ describe("agent-core tools", () => {
     expect(stop.ok).toBe(true);
   });
 
-  it("preserves keepForVerifier services during pre-verifier cleanup", async () => {
+  it("preserves keepAliveAfterRun services during managed service finalization", async () => {
     const { dir, context } = await workspace();
     process.env.AGENT_SERVICE_REGISTRY = path.join(dir, "services.json");
     process.env.AGENT_SERVICE_LOG_DIR = path.join(dir, "logs");
@@ -175,7 +175,7 @@ describe("agent-core tools", () => {
     ).resolves.toMatchObject({ ok: true });
     await expect(
       executeServiceTool(
-        { action: "start", name: "kept", command: "node -e \"setInterval(()=>{}, 1000)\"", keepForVerifier: true },
+        { action: "start", name: "kept", command: "node -e \"setInterval(()=>{}, 1000)\"", keepAliveAfterRun: true },
         context
       )
     ).resolves.toMatchObject({ ok: true });
@@ -209,14 +209,14 @@ describe("agent-core tools", () => {
           name: "explicit-stop",
           command: `node -e "require('http').createServer((req,res)=>res.end('ok')).listen(${explicitStopPort}, '127.0.0.1')"`,
           port: explicitStopPort,
-          keepForVerifier: false,
+          keepAliveAfterRun: false,
           readinessTimeoutSec: 5
         },
         context
       )
     ).resolves.toMatchObject({ ok: true });
 
-    const cleanup = await cleanupServicesBeforeVerifier();
+    const cleanup = await finalizeManagedServices();
     expect(cleanup.stopped).toContain("temp");
     expect(cleanup.stopped).toContain("explicit-stop");
     expect(cleanup.kept).toContain("kept");

--- a/tests/bench-common.test.ts
+++ b/tests/bench-common.test.ts
@@ -68,7 +68,17 @@ describe("Terminal-Bench command construction", () => {
       "--ak",
       "command_timeout_sec:int=180",
       "--ak",
-      "max_wall_time_sec:int=7200"
+      "max_wall_time_sec:int=7200",
+      "--ak",
+      "harness_timeout_sec:int=14610",
+      "--ak",
+      "validation_mode:str=auto",
+      "--ak",
+      "validation_retry_limit:int=1",
+      "--ak",
+      "validation_timeout_sec:int=45",
+      "--ak",
+      "precheck_timeout_sec:int=45"
     ]);
   });
 
@@ -111,7 +121,17 @@ describe("Terminal-Bench command construction", () => {
       "--ak",
       "command_timeout_sec=180",
       "--ak",
-      "max_wall_time_sec=7200"
+      "max_wall_time_sec=7200",
+      "--ak",
+      "harness_timeout_sec=14610",
+      "--ak",
+      "validation_mode=auto",
+      "--ak",
+      "validation_retry_limit=1",
+      "--ak",
+      "validation_timeout_sec=45",
+      "--ak",
+      "precheck_timeout_sec=45"
     ]);
   });
 
@@ -146,9 +166,9 @@ describe("Terminal-Bench command construction", () => {
       agent_wall_time_sec: 2700,
       retry_budget_sec: 2700,
       precheck_timeout_sec: 45,
-      precheck_retry_limit: 1,
-      harbor_agent_timeout_sec: 5610,
-      effective_harbor_agent_timeout_sec: 5610,
+      validation_retry_limit: 1,
+      harness_timeout_sec: 5610,
+      effective_harness_timeout_sec: 5610,
       agent_timeout_multiplier: "3.12",
       source: "harbor_task_metadata"
     });
@@ -182,8 +202,8 @@ describe("Terminal-Bench command construction", () => {
       agent_wall_time_sec: 9000,
       retry_budget_sec: 9000,
       precheck_timeout_sec: 45,
-      precheck_retry_limit: 1,
-      harbor_agent_timeout_sec: 18210,
+      validation_retry_limit: 1,
+      harness_timeout_sec: 18210,
       agent_timeout_multiplier: "3.04",
       leniency_multiplier: 1.5,
       leniency_min_extra_sec: 600
@@ -205,7 +225,7 @@ describe("Terminal-Bench command construction", () => {
     expect(timeoutPlan).toMatchObject({
       agent_wall_time_sec: 6000,
       retry_budget_sec: 6000,
-      harbor_agent_timeout_sec: 12210,
+      harness_timeout_sec: 12210,
       agent_timeout_multiplier: "6.79",
       source: "explicit_max_wall_time"
     });
@@ -325,14 +345,14 @@ describe("Terminal-Bench command construction", () => {
       agent_cli_tarball: defaultAgentCliTarballForEnv(),
       max_turns: 540,
       max_wall_time_sec: 2700,
-      harbor_agent_timeout_sec: 5610,
-      precheck_retry_limit: 1,
+      harness_timeout_sec: 5610,
+      validation_retry_limit: 1,
       precheck_timeout_sec: 45,
-      generic_validation_enabled: true,
+      validation_mode: "auto",
       validation_timeout_sec: 45
     });
     expect(config.agents[0].kwargs.precheck_command).toBeUndefined();
-    expect(config.agents[0].kwargs.pre_verifier_cleanup_globs).toBeUndefined();
+    expect(config.agents[0].kwargs.post_run_cleanup_globs).toBeUndefined();
   });
 
   it("enables generic validation retry budget for ordinary Terminal-Bench tasks", () => {
@@ -359,30 +379,30 @@ describe("Terminal-Bench command construction", () => {
     expect(timeoutPlan).toMatchObject({
       agent_wall_time_sec: 2700,
       retry_budget_sec: 2700,
-      precheck_retry_limit: 1,
+      validation_retry_limit: 1,
       precheck_timeout_sec: 45,
-      generic_validation_enabled: true
+      validation_mode: "auto"
     });
     expect(config.agents[0].kwargs).toMatchObject({
       agent_cli_tarball: defaultAgentCliTarballForEnv(),
-      generic_validation_enabled: true,
+      validation_mode: "auto",
       validation_timeout_sec: 45,
-      precheck_retry_limit: 1,
+      validation_retry_limit: 1,
       precheck_timeout_sec: 45
     });
     expect(config.agents[0].kwargs.precheck_command).toBeUndefined();
   });
 
-  it("keeps the default validation retry when precheckRetryLimit is unset or null", () => {
+  it("keeps the default validation retry when validationRetryLimit is unset or null", () => {
     const timeoutProbe = {
       resolved_tasks: [{ name: "terminal-bench/ordinary-task" }],
       tasks: [{ task_name: "terminal-bench/ordinary-task", agent_timeout_sec: 1800 }],
       max_agent_timeout_sec: 1800
     };
 
-    expect(computeHarborTimeoutPlan({ agentTimeoutGraceSec: 120 }, timeoutProbe).precheck_retry_limit).toBe(1);
-    expect(computeHarborTimeoutPlan({ agentTimeoutGraceSec: 120, precheckRetryLimit: null }, timeoutProbe).precheck_retry_limit).toBe(1);
-    expect(computeHarborTimeoutPlan({ agentTimeoutGraceSec: 120, precheckRetryLimit: 0 }, timeoutProbe).precheck_retry_limit).toBe(0);
+    expect(computeHarborTimeoutPlan({ agentTimeoutGraceSec: 120 }, timeoutProbe).validation_retry_limit).toBe(1);
+    expect(computeHarborTimeoutPlan({ agentTimeoutGraceSec: 120, validationRetryLimit: null }, timeoutProbe).validation_retry_limit).toBe(1);
+    expect(computeHarborTimeoutPlan({ agentTimeoutGraceSec: 120, validationRetryLimit: 0 }, timeoutProbe).validation_retry_limit).toBe(0);
   });
 
   it("preserves explicit max turns in resolved JobConfig", () => {
@@ -918,7 +938,7 @@ describe("benchmark report generation", () => {
         timeout_plan: {
           retry_budget_sec: 2700,
           precheck_timeout_sec: 45,
-          effective_harbor_agent_timeout_sec: 5610
+          effective_harness_timeout_sec: 5610
         }
       })}\n`,
       "utf8"
@@ -985,7 +1005,7 @@ describe("benchmark report generation", () => {
     );
     expect(report.tasks[0].failure_signals.some((signal) => signal.startsWith("missing_artifact:"))).toBe(false);
     expect(markdown).not.toContain("missing_artifact:");
-    expect(markdown).toContain("Effective Harbor agent timeout sec: 5610");
+    expect(markdown).toContain("Effective harness timeout sec: 5610");
   });
 
   it("reads harness validation, retry, and cleanup signals from summary JSON", async () => {
@@ -1029,7 +1049,7 @@ describe("benchmark report generation", () => {
             { action: "started", trigger: "validation" },
             { action: "skipped", trigger: "validation" }
           ],
-          pre_verifier_cleanup: { patterns: ["/tmp/cache*.tmp"], exit_code: 1, warning: "cleanup failed" }
+          post_run_cleanup: { patterns: ["/tmp/cache*.tmp"], exit_code: 1, warning: "cleanup failed" }
         }
       })}\n`,
       "utf8"
@@ -1042,7 +1062,7 @@ describe("benchmark report generation", () => {
         "validation_failed",
         "validation_retry_used",
         "retry_cut_short_by_budget",
-        "pre_verifier_cleanup_warning"
+        "post_run_cleanup_warning"
       ])
     );
   });

--- a/tests/test_harbor_agent.py
+++ b/tests/test_harbor_agent.py
@@ -180,13 +180,13 @@ class HarborAgentTest(unittest.IsolatedAsyncioTestCase):
             context = SimpleNamespace(task_id="task-a")
             agent = module.SigmaCliHarborAgent(
                 logs_dir=Path(tmp) / "logs",
-                generic_validation_enabled=True,
+                validation_mode="auto",
                 validation_timeout_sec=45,
                 precheck_command="pytest",
                 precheck_timeout_sec=30,
-                precheck_retry_limit=2,
-                pre_verifier_cleanup_globs="/tmp/cache*.tmp",
-                harbor_agent_timeout_sec=600,
+                validation_retry_limit=2,
+                post_run_cleanup_globs="/tmp/cache*.tmp",
+                harness_timeout_sec=600,
                 agent_timeout_grace_sec=15,
                 retry_min_budget_sec=90,
             )
@@ -201,7 +201,7 @@ class HarborAgentTest(unittest.IsolatedAsyncioTestCase):
             self.assertIn("--validation-timeout-sec 45", command)
             self.assertIn("--precheck-command pytest", command)
             self.assertIn("--precheck-timeout-sec 30", command)
-            self.assertIn("--pre-verifier-cleanup-globs '/tmp/cache*.tmp'", command)
+            self.assertIn("--post-run-cleanup-globs '/tmp/cache*.tmp'", command)
             self.assertIn("--harness-timeout-sec 600", command)
             self.assertIn("--retry-min-budget-sec 90", command)
             self.assertIn("--attempts-dir /tmp/agent/attempts", command)
@@ -245,7 +245,7 @@ class HarborAgentTest(unittest.IsolatedAsyncioTestCase):
             self.assertIn("--harness-timeout-sec 700", command)
             self.assertEqual(kwargs["timeout_sec"], 720)
 
-    async def test_run_uses_validation_off_when_generic_validation_disabled(self):
+    async def test_run_uses_validation_off_by_default(self):
         module = import_portable_agent_module()
         with TemporaryDirectory() as tmp:
             exec_commands = []
@@ -306,7 +306,7 @@ class HarborAgentTest(unittest.IsolatedAsyncioTestCase):
                     ],
                     "precheck_results": [],
                     "retry_decisions": [{"action": "skipped", "trigger": "validation"}],
-                    "pre_verifier_cleanup": {"patterns": ["/tmp/cache*.tmp"], "exit_code": 1, "warning": "cleanup failed"},
+                    "post_run_cleanup": {"patterns": ["/tmp/cache*.tmp"], "exit_code": 1, "warning": "cleanup failed"},
                 },
             }
 
@@ -352,10 +352,10 @@ class HarborAgentTest(unittest.IsolatedAsyncioTestCase):
                     (Path(tmp) / "tasks" / "service-task" / "metadata.json").read_text(encoding="utf-8")
                 )
                 self.assertEqual(metadata["validation_results"][0]["command"], "python check.py")
-                self.assertEqual(metadata["pre_verifier_cleanup"]["warning"], "cleanup failed")
+                self.assertEqual(metadata["post_run_cleanup"]["warning"], "cleanup failed")
                 self.assertIn("validation_failed", metadata["failure_signals"])
                 self.assertIn("retry_cut_short_by_budget", metadata["failure_signals"])
-                self.assertIn("pre_verifier_cleanup_warning", metadata["failure_signals"])
+                self.assertIn("post_run_cleanup_warning", metadata["failure_signals"])
             finally:
                 if old_run_dir is None:
                     os.environ.pop("SIGMA_BENCH_RUN_DIR", None)

--- a/tests/test_harbor_agent.py
+++ b/tests/test_harbor_agent.py
@@ -158,7 +158,7 @@ class HarborAgentTest(unittest.IsolatedAsyncioTestCase):
             self.assertIn("usage blew up", str(raised.exception))
             self.assertIn("missing runtime", str(raised.exception))
 
-    async def test_run_forwards_harness_kwargs_as_cli_flags(self):
+    async def test_run_forwards_run_controller_kwargs_as_cli_flags(self):
         module = import_portable_agent_module()
         with TemporaryDirectory() as tmp:
             exec_commands = []
@@ -209,7 +209,7 @@ class HarborAgentTest(unittest.IsolatedAsyncioTestCase):
             self.assertFalse(any("sigma-precheck" in command for command, _kwargs in exec_commands))
             self.assertFalse(any("sigma-validation" in command for command, _kwargs in exec_commands))
 
-    async def test_run_accepts_portable_harness_kwarg_names(self):
+    async def test_run_forwards_canonical_run_controller_kwargs(self):
         module = import_portable_agent_module()
         with TemporaryDirectory() as tmp:
             exec_commands = []

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "references": [
     { "path": "./packages/agent-ai" },
     { "path": "./packages/agent-core" },
-    { "path": "./packages/agent-cli" }
+    { "path": "./packages/agent-cli" },
+    { "path": "./packages/agent-tui" }
   ]
 }


### PR DESCRIPTION
## Summary

- Productize `agent-core` and CLI run-controller naming by removing benchmark/verifier/evaluator semantics from the product path.
- Remove assistant-final-text validation command injection; validation now comes from explicit config/CLI commands or changed-file checks.
- Clean Harbor adapter compatibility aliases and keep Harbor/Terminal-Bench support as an external adapter.
- Add `packages/agent-tui` as a direct `agent-core` product entry with timeline, composer, permissions, tools, and diff panels.
- Split tests so root `pnpm test` no longer runs Harbor adapter tests; add `pnpm test:harbor` and `pnpm test:all`.

## Validation

- `pnpm install`
- `pnpm build`
- `pnpm lint`
- `pnpm test`
- `pnpm test:harbor`
- `pnpm test:all`
- `pnpm --filter agent-tui build`
- `pnpm --filter agent-tui start -- --help`
- `rg -n "evaluator|verifier|benchmark|terminal-bench|harbor" packages\\agent-core packages\\agent-tui` (no matches)
- `pnpm package:harbor-runtime`
- verified `bench:tb:deepseek:k5` script still exists

## Notes

Harbor and Terminal-Bench scripts are intentionally preserved as external benchmark adapters. `agent-tui` is not included in the task-container CLI bundle.