### PR TITLE
Add durable sessions and checkpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 A small coding-agent monorepo inspired by Pi with four layers:
 
 - `packages/agent-ai`: provider-agnostic model interface for DeepSeek and GLM/Zhipu
-- `packages/agent-core`: agent run controller, validation and retry controller, extensible tool registry, repo-aware context, JSONL tracing, session records, MCP bridge, and workspace tools
-- `packages/agent-cli`: plain terminal CLI with `run`, `solve` compatibility alias, `chat`, `doctor`, and `replay`
+- `packages/agent-core`: agent run controller, validation and retry controller, extensible tool registry, repo-aware context, durable sessions, checkpoints, JSONL tracing, MCP bridge, and workspace tools
+- `packages/agent-cli`: plain terminal CLI with `run`, `solve` compatibility alias, `sessions`, `session`, checkpoint commands, `chat`, `doctor`, and `replay`
 - `packages/agent-tui`: interactive terminal product entry that drives the shared `agent-core` run path
 
 Sigma keeps the product runtime portable while adding repo instructions, deterministic repo maps, live progress, approval-gated mutating tools, and stdio MCP tools. There is intentionally no large web UI, sub-agent system, plugin marketplace, long-term memory, or Docker sandbox in this repo.
@@ -111,7 +111,7 @@ During a run, user, assistant, tool, validation, approval, diff, and summary ent
 
 Composer editing is handled in raw mode: Left/Right move the cursor, `Ctrl+A/E` jump to start/end, `Ctrl+U/K` kill to start/end, `Ctrl+W` deletes the previous word, `Ctrl+Y` yanks killed text, `Ctrl+J` inserts a newline, and Up/Down cycle in-memory prompt history. `Tab` accepts an active command/file suggestion or opens the workbench; `Shift+Tab` toggles plan/build mode. `/mode plan` and `/mode build` are also available, and the composer footer shows the active mode while a run is active. Plan mode disables mutating/run tools for new agent runs: `write`, `edit`, `apply_patch`, `bash`, `shell_session`, and `service`. Typing `@prefix` suggests workspace files, ignoring `.git`, `node_modules`, `dist`, `build`, and `.agent/attempts`. Typing `!command` runs a local shell command through the same approval flow as `/shell <command>`. Typing `cd <path>` switches workspace locally when the directory exists; use `/workspace <path>` or `/w <path>` for the explicit command form.
 
-Current UX boundary: the interactive UI is still launched through the `agent-tui` binary. Root `agent` does not auto-enter the TUI and `agent tui` is not implemented. The TUI does not yet provide persisted session index/resume/fork, transcript search, multiple selection in the file palette, or shell completion. `agent run` remains the primary non-interactive path and `agent solve` remains a compatibility alias with the same flags. The TUI uses the shared `agent-core` run path; it does not shell out to `agent chat` and does not import Harbor or Terminal-Bench scripts.
+Current UX boundary: the interactive UI is still launched through the `agent-tui` binary. Root `agent` does not auto-enter the TUI and `agent tui` is not implemented. The TUI uses the shared `agent-core` run path and records durable sessions, but it does not yet provide an in-app session browser/resume/fork UI, transcript search, multiple selection in the file palette, or shell completion. `agent run` remains the primary non-interactive path and `agent solve` remains a compatibility alias with the same flags. The TUI does not shell out to `agent chat` and does not import Harbor or Terminal-Bench scripts.
 
 Programmatic product integrations should prefer the run-controller API names:
 
@@ -154,6 +154,39 @@ pnpm --filter agent-cli start -- doctor --workspace . --provider glm --check-api
 pnpm --filter agent-cli start -- replay --trace-jsonl ./trace.jsonl
 pnpm --filter agent-cli start -- replay --trace-jsonl ./trace.jsonl --timeline
 ```
+
+Durable sessions are recorded by default under `.agent/sessions/` while the compatibility files `.agent/trace.jsonl`, `.agent/session.jsonl`, and `.agent/summary.json` continue to be written:
+
+```text
+.agent/sessions/index.jsonl
+.agent/sessions/<session-id>/meta.json
+.agent/sessions/<session-id>/events.jsonl
+.agent/sessions/<session-id>/summary.json
+.agent/sessions/<session-id>/checkpoints/
+```
+
+Session commands:
+
+```bash
+pnpm --filter agent-cli start -- sessions --workspace .
+pnpm --filter agent-cli start -- history --workspace .
+pnpm --filter agent-cli start -- session show <session-id> --workspace .
+pnpm --filter agent-cli start -- session search "parser error" --workspace .
+pnpm --filter agent-cli start -- session resume <session-id> "continue the fix" --workspace .
+pnpm --filter agent-cli start -- session fork <session-id> "try a smaller approach" --workspace .
+```
+
+`resume` and `fork` start a fresh run with a concise prior-session context block, not a provider-specific replay of every tool message. The new session records `parentSessionId`; forked sessions also record `forkedFromSessionId`.
+
+In git workspaces, mutating tools create lightweight patch checkpoints when they actually change files:
+
+```bash
+pnpm --filter agent-cli start -- checkpoints <session-id> --workspace .
+pnpm --filter agent-cli start -- checkpoint show <session-id> <checkpoint-id> --workspace .
+pnpm --filter agent-cli start -- checkpoint restore <session-id> <checkpoint-id> --workspace .
+```
+
+Checkpoint restore is conservative: it first runs `git apply -R --check` and only applies the reverse patch if the current workspace can accept it cleanly. Non-git checkpointing is not implemented yet; non-git runs continue normally without checkpoint files.
 
 ## Smoke Tests
 
@@ -360,10 +393,12 @@ The core loop exposes these default tools:
 - `list`: lists workspace files/directories with `path`, `depth`, `includeHidden`, and `maxEntries`.
 - `glob`: finds files with simple `*`, `**`, and `?` patterns.
 - `grep`: searches text files, preferring `rg` when available and falling back to Node.
-- `repo_query`: searches workspace files by query and returns compact scored snippets for text, symbols, tests, configs, or paths.
+- `repo_query`: searches workspace files by query and returns compact scored snippets for text, symbols, tests, configs, or paths. Matches include path, line range, score, reasons, and snippet.
+- `symbol_search`: searches declared functions, classes, interfaces, types, constants, and test declarations using the lightweight local code index.
 - `git_status`: read-only `git status`, bounded by the command timeout.
 - `git_diff`: read-only `git diff` or `git diff --staged`, bounded by the command timeout.
 - `apply_patch`: validates and applies safe unified diffs to workspace-relative files, including quoted paths with spaces. Its `git apply` subprocesses are bounded by the command timeout and return `metadata.timedOut` on timeout.
+- `validate`: runs an explicit validation command or infers one for changed files, a file, or the project. It returns structured `ok`, `command`, `kind`, `exitCode`, output tails, related files, and best-effort diagnostics.
 - `todo`: maintains run-scoped todo state for the agent.
 - `shell_session`: starts, sends to, reads from, lists, and stops a persistent non-PTY bash session for multi-step terminal workflows.
 
@@ -392,6 +427,8 @@ SIGMA.md
 The current implementation loads from the workspace root and is structured for nested working directories later. Use `--no-project-instructions` to disable loading and `--project-doc-max-bytes <number>` to change the default 32768-byte limit.
 
 Local `agent run` and `agent solve` default to `--context-mode repo-map`. The repo map is deterministic and budgeted; it includes a bounded file tree, package scripts, pnpm workspace patterns, TypeScript references, exported TS/JS symbols, Python and shell symbols, test file paths, `.agent/config.toml` presence, and a small git state summary. Use `--context-mode off` to disable it or `--repo-map-max-chars <number>` to change the default 20000-character budget.
+
+`repo_query` and `symbol_search` use a separate lightweight code index during tool calls. It scans workspace files with the existing ignore behavior and records file size/mtime, language/ext, declared symbols, imports/requires, and test/config markers. It is deterministic, local, and does not use embeddings or external services.
 
 Generic coding skills are loaded in `--skills-mode auto` by default. Built-in skills cover common stacks such as Python/pytest, Node/TypeScript, Go/Rust/Java tests, services and ports, certificates, archives, data processing, and small-sample ML training checks. Workspace skills can be added as Markdown files under `.agent/skills/*.md`; malformed files are ignored or parsed best-effort. Selected skills are injected after project instructions and repo map context, bounded by `--skills-max-chars`.
 
@@ -589,4 +626,6 @@ The adapter forwards `DEEPSEEK_API_KEY`, `GLM_API_KEY`, `ZAI_API_KEY`, `BIGMODEL
 - Config TOML parsing supports simple top-level scalar keys only.
 - MCP v0 supports local stdio servers only.
 - Repo maps are deterministic static context, not embeddings or a vector database.
+- Checkpoints currently restore through git reverse patches only. Non-git workspaces still get durable sessions but do not get restoreable checkpoints yet.
+- Provider streaming has compatibility event types in core, but model token streaming is not wired into providers or TUI rendering yet.
 - The bundled Harbor artifact contains a Linux Node runtime when `NODE_RUNTIME_TARBALL` or the documented cache file is available at package time.

--- a/README.md
+++ b/README.md
@@ -627,5 +627,5 @@ The adapter forwards `DEEPSEEK_API_KEY`, `GLM_API_KEY`, `ZAI_API_KEY`, `BIGMODEL
 - MCP v0 supports local stdio servers only.
 - Repo maps are deterministic static context, not embeddings or a vector database.
 - Checkpoints currently restore through git reverse patches only. Non-git workspaces still get durable sessions but do not get restoreable checkpoints yet.
-- Provider streaming has compatibility event types in core, but model token streaming is not wired into providers or TUI rendering yet.
+- Streaming/abort support is foundation-level today: core defines compatibility event types and checks abort signals before model requests, but provider token streaming, TUI token-level rendering, mid-model cancellation, and mid-tool cancellation are future work.
 - The bundled Harbor artifact contains a Linux Node runtime when `NODE_RUNTIME_TARBALL` or the documented cache file is available at package time.

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -28,4 +28,4 @@ Date: 2026-07-07
 
 ## Known Limitations
 
-- TUI updates are event-based at turn/tool granularity, not token delta streaming. Token delta rendering is future work once `agent-core` emits assistant delta events from provider streaming.
+- TUI updates are event-based at turn/tool granularity, not token delta streaming. Core has compatibility event types and a pre-model abort check, but provider token streaming, TUI token rendering, mid-model cancellation, and mid-tool cancellation are future work.

--- a/packages/agent-cli/src/commands/session.ts
+++ b/packages/agent-cli/src/commands/session.ts
@@ -1,0 +1,268 @@
+import path from "node:path";
+import {
+  buildResumeInstruction,
+  listCheckpoints,
+  listSessions,
+  loadCheckpoint,
+  loadSessionMeta,
+  loadSessionResumeContext,
+  readSessionEventsText,
+  readSessionSummaryText,
+  restoreCheckpoint,
+  searchSessions,
+  truncateMiddle
+} from "agent-core";
+import { loadCliConfig, parseArgs } from "../config.js";
+import { runRunCommandWithOverrides, type SolveCommandDeps } from "./solve.js";
+
+function stdout(deps: SolveCommandDeps): NodeJS.WritableStream {
+  return deps.stdout ?? process.stdout;
+}
+
+function stderr(deps: SolveCommandDeps): NodeJS.WritableStream {
+  return deps.stderr ?? process.stderr;
+}
+
+function writeJson(value: unknown, deps: SolveCommandDeps): void {
+  stdout(deps).write(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+function parseJsonOrNull(text: string): unknown {
+  if (!text.trim()) return null;
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function compactDate(value: string | undefined): string {
+  if (!value) return "-";
+  return value.replace("T", " ").replace(/\.\d{3}Z$/, "Z");
+}
+
+function flagArgv(flags: Record<string, string | boolean>): string[] {
+  const args: string[] = [];
+  for (const [key, value] of Object.entries(flags)) {
+    if (value === false) continue;
+    args.push(`--${key}`);
+    if (value !== true) args.push(value);
+  }
+  return args;
+}
+
+function printSessions(records: Awaited<ReturnType<typeof listSessions>>, deps: SolveCommandDeps): void {
+  if (records.length === 0) {
+    stdout(deps).write("No sessions found.\n");
+    return;
+  }
+  for (const record of records) {
+    const changed = record.changedFiles.length > 0 ? ` changed=${record.changedFiles.length}` : "";
+    const finish = record.finishReason ? ` finish=${record.finishReason}` : "";
+    stdout(deps).write(
+      `${record.sessionId}  ${record.status}${finish}${changed}  ${compactDate(record.updatedAt)}  ${truncateMiddle(record.title, 80).text}\n`
+    );
+  }
+}
+
+export async function runSessionsCommand(argv: string[], deps: SolveCommandDeps = {}): Promise<number> {
+  const { flags } = parseArgs(argv);
+  const config = loadCliConfig(flags);
+  const records = await listSessions({ workspacePath: config.workspace, limit: 100 });
+  if (flags.json) writeJson(records, deps);
+  else printSessions(records, deps);
+  return 0;
+}
+
+export async function runSessionCommand(argv: string[], deps: SolveCommandDeps = {}): Promise<number> {
+  const [subcommand, ...rest] = argv;
+  if (!subcommand || subcommand === "--help" || subcommand === "-h") {
+    stdout(deps).write(`agent session <command> [args] [flags]
+
+Commands:
+  show <session-id>
+  search <query>
+  resume <session-id> <instruction>
+  fork <session-id> <instruction>
+`);
+    return 0;
+  }
+  if (subcommand === "show") return await runSessionShow(rest, deps);
+  if (subcommand === "search") return await runSessionSearch(rest, deps);
+  if (subcommand === "resume") return await runSessionResumeLike(rest, deps, "resume");
+  if (subcommand === "fork") return await runSessionResumeLike(rest, deps, "fork");
+  stderr(deps).write(`Unknown session command: ${subcommand}\n`);
+  return 1;
+}
+
+async function runSessionShow(argv: string[], deps: SolveCommandDeps): Promise<number> {
+  const { flags, positionals } = parseArgs(argv);
+  const sessionId = positionals[0];
+  if (!sessionId) {
+    stderr(deps).write("session show requires a session id\n");
+    return 1;
+  }
+  const config = loadCliConfig(flags);
+  const meta = await loadSessionMeta({ sessionId, workspacePath: config.workspace });
+  if (!meta) {
+    stderr(deps).write(`Session not found: ${sessionId}\n`);
+    return 1;
+  }
+  const events = (await readSessionEventsText(meta.eventsPath)).trim().split(/\r?\n/).filter(Boolean);
+  const summaryText = await readSessionSummaryText(meta.summaryPath);
+  const payload = {
+    meta,
+    eventCount: events.length,
+    recentEvents: events.slice(-12).map((line) => {
+      try {
+        const parsed = JSON.parse(line) as { type?: string; timestamp?: string; metadata?: unknown };
+        return { type: parsed.type, timestamp: parsed.timestamp, metadata: parsed.metadata };
+      } catch {
+        return { raw: line };
+      }
+    }),
+    summary: parseJsonOrNull(summaryText)
+  };
+  if (flags.json) {
+    writeJson(payload, deps);
+  } else {
+    stdout(deps).write(`${meta.sessionId}\n`);
+    stdout(deps).write(`  title: ${meta.title}\n`);
+    stdout(deps).write(`  status: ${meta.status}${meta.finishReason ? ` (${meta.finishReason})` : ""}\n`);
+    stdout(deps).write(`  workspace: ${meta.workspacePath}\n`);
+    stdout(deps).write(`  model: ${meta.provider}/${meta.model}\n`);
+    stdout(deps).write(`  updated: ${compactDate(meta.updatedAt)}\n`);
+    if (meta.parentSessionId) stdout(deps).write(`  parent: ${meta.parentSessionId}\n`);
+    if (meta.forkedFromSessionId) stdout(deps).write(`  forkedFrom: ${meta.forkedFromSessionId}\n`);
+    if (meta.changedFiles.length > 0) stdout(deps).write(`  changed: ${meta.changedFiles.join(", ")}\n`);
+    if (meta.finalMessage) stdout(deps).write(`  final: ${truncateMiddle(meta.finalMessage, 300).text}\n`);
+    stdout(deps).write(`  events: ${events.length}\n`);
+  }
+  return 0;
+}
+
+async function runSessionSearch(argv: string[], deps: SolveCommandDeps): Promise<number> {
+  const { flags, positionals } = parseArgs(argv);
+  const query = positionals.join(" ").trim();
+  if (!query) {
+    stderr(deps).write("session search requires a query\n");
+    return 1;
+  }
+  const config = loadCliConfig(flags);
+  const results = await searchSessions({ query, workspacePath: config.workspace });
+  if (flags.json) {
+    writeJson(results, deps);
+  } else if (results.length === 0) {
+    stdout(deps).write("No matching sessions found.\n");
+  } else {
+    for (const result of results) {
+      stdout(deps).write(`${result.session.sessionId}  score=${result.score}  ${truncateMiddle(result.session.title, 80).text}\n`);
+      for (const match of result.matches.slice(0, 2)) {
+        stdout(deps).write(`  ${truncateMiddle(match, 140).text}\n`);
+      }
+    }
+  }
+  return 0;
+}
+
+async function runSessionResumeLike(
+  argv: string[],
+  deps: SolveCommandDeps,
+  mode: "resume" | "fork"
+): Promise<number> {
+  const { flags, positionals } = parseArgs(argv);
+  const [sessionId, ...instructionParts] = positionals;
+  const instruction = instructionParts.join(" ").trim();
+  if (!sessionId || !instruction) {
+    stderr(deps).write(`session ${mode} requires a session id and instruction\n`);
+    return 1;
+  }
+  const config = loadCliConfig(flags);
+  const context = await loadSessionResumeContext({ sessionId, workspacePath: config.workspace });
+  if (!context) {
+    stderr(deps).write(`Session not found: ${sessionId}\n`);
+    return 1;
+  }
+  const workspacePath = typeof flags.workspace === "string" ? config.workspace : context.session.workspacePath;
+  const runFlags = flagArgv({ ...flags, workspace: workspacePath });
+  return await runRunCommandWithOverrides(runFlags, deps, {
+    workspacePath,
+    instruction: buildResumeInstruction({ context, instruction, mode }),
+    parentSessionId: context.session.sessionId,
+    forkedFromSessionId: mode === "fork" ? context.session.sessionId : undefined
+  });
+}
+
+export async function runCheckpointsCommand(argv: string[], deps: SolveCommandDeps = {}): Promise<number> {
+  const { flags, positionals } = parseArgs(argv);
+  const sessionId = positionals[0];
+  if (!sessionId) {
+    stderr(deps).write("checkpoints requires a session id\n");
+    return 1;
+  }
+  const config = loadCliConfig(flags);
+  const records = await listCheckpoints({ sessionId, workspacePath: config.workspace });
+  if (flags.json) writeJson(records, deps);
+  else if (records.length === 0) stdout(deps).write("No checkpoints found.\n");
+  else {
+    for (const record of records) {
+      stdout(deps).write(
+        `${record.id}  ${record.toolName}  files=${record.changedFiles.length}  ${compactDate(record.createdAt)}  ${truncateMiddle(record.resultSummary, 80).text}\n`
+      );
+    }
+  }
+  return 0;
+}
+
+export async function runCheckpointCommand(argv: string[], deps: SolveCommandDeps = {}): Promise<number> {
+  const [subcommand, ...rest] = argv;
+  if (subcommand === "show") return await runCheckpointShow(rest, deps);
+  if (subcommand === "restore") return await runCheckpointRestore(rest, deps);
+  stdout(deps).write(`agent checkpoint <command> [args]
+
+Commands:
+  show <session-id> <checkpoint-id>
+  restore <session-id> <checkpoint-id>
+`);
+  return subcommand ? 1 : 0;
+}
+
+async function runCheckpointShow(argv: string[], deps: SolveCommandDeps): Promise<number> {
+  const { flags, positionals } = parseArgs(argv);
+  const [sessionId, checkpointId] = positionals;
+  if (!sessionId || !checkpointId) {
+    stderr(deps).write("checkpoint show requires a session id and checkpoint id\n");
+    return 1;
+  }
+  const config = loadCliConfig(flags);
+  const record = await loadCheckpoint({ sessionId, checkpointId, workspacePath: config.workspace });
+  if (!record) {
+    stderr(deps).write(`Checkpoint not found: ${path.join(sessionId, checkpointId)}\n`);
+    return 1;
+  }
+  if (flags.json) writeJson(record, deps);
+  else {
+    stdout(deps).write(`${record.id}  ${record.toolName}  ${compactDate(record.createdAt)}\n`);
+    stdout(deps).write(`  changed: ${record.changedFiles.join(", ") || "(none)"}\n`);
+    stdout(deps).write(`  patch: ${record.patchPath}\n`);
+    stdout(deps).write(`  result: ${record.resultSummary}\n`);
+  }
+  return 0;
+}
+
+async function runCheckpointRestore(argv: string[], deps: SolveCommandDeps): Promise<number> {
+  const { flags, positionals } = parseArgs(argv);
+  const [sessionId, checkpointId] = positionals;
+  if (!sessionId || !checkpointId) {
+    stderr(deps).write("checkpoint restore requires a session id and checkpoint id\n");
+    return 1;
+  }
+  const config = loadCliConfig(flags);
+  const result = await restoreCheckpoint({ sessionId, checkpointId, workspacePath: config.workspace });
+  if (flags.json) writeJson(result, deps);
+  else {
+    stdout(deps).write(`${result.ok ? "restored" : "restore failed"} checkpoint=${result.checkpointId} exitCode=${result.exitCode}\n`);
+    if (result.stderr.trim()) stdout(deps).write(`${result.stderr.trim()}\n`);
+  }
+  return result.ok ? 0 : 1;
+}

--- a/packages/agent-cli/src/commands/solve.ts
+++ b/packages/agent-cli/src/commands/solve.ts
@@ -21,6 +21,13 @@ export interface SolveCommandDeps {
   stdin?: NodeJS.ReadableStream & { isTTY?: boolean };
 }
 
+export interface RunCommandOverrides {
+  instruction?: string;
+  workspacePath?: string;
+  parentSessionId?: string;
+  forkedFromSessionId?: string;
+}
+
 async function readStdin(stream: NodeJS.ReadableStream): Promise<string> {
   const chunks: Buffer[] = [];
   for await (const chunk of stream) {
@@ -122,7 +129,8 @@ Output flags:
 async function runNonInteractiveCommand(
   argv: string[],
   deps: SolveCommandDeps,
-  commandName: "run" | "solve"
+  commandName: "run" | "solve",
+  overrides: RunCommandOverrides = {}
 ): Promise<number> {
   const stdout = deps.stdout ?? process.stdout;
   const stderr = deps.stderr ?? process.stderr;
@@ -139,7 +147,8 @@ async function runNonInteractiveCommand(
 
     const { flags, positionals } = parseArgs(argv);
     const cliConfig = loadCliConfig(flags);
-    const instruction = await resolveInstruction(flags, positionals, deps);
+    const instruction = overrides.instruction ?? await resolveInstruction(flags, positionals, deps);
+    const workspacePath = overrides.workspacePath ?? cliConfig.workspace;
     const eventBus = new AgentEventBus();
     detachJsonStream = cliConfig.outputFormat === "stream-json"
       ? eventBus.on((event) => writeStreamJsonEvent(event, stdout))
@@ -155,9 +164,11 @@ async function runNonInteractiveCommand(
 
     const { result } = await runConfiguredAgent({
       instruction,
-      workspacePath: cliConfig.workspace,
+      workspacePath,
       provider: cliConfig.provider,
       model: cliConfig.model,
+      parentSessionId: overrides.parentSessionId,
+      forkedFromSessionId: overrides.forkedFromSessionId,
       modelClientFactory: factory,
       maxTurns: cliConfig.maxTurns,
       maxWallTimeSec: cliConfig.maxWallTimeSec,
@@ -220,4 +231,12 @@ export async function runRunCommand(argv: string[], deps: SolveCommandDeps = {})
 
 export async function runSolveCommand(argv: string[], deps: SolveCommandDeps = {}): Promise<number> {
   return await runNonInteractiveCommand(argv, deps, "solve");
+}
+
+export async function runRunCommandWithOverrides(
+  argv: string[],
+  deps: SolveCommandDeps = {},
+  overrides: RunCommandOverrides = {}
+): Promise<number> {
+  return await runNonInteractiveCommand(argv, deps, "run", overrides);
 }

--- a/packages/agent-cli/src/index.ts
+++ b/packages/agent-cli/src/index.ts
@@ -2,6 +2,12 @@
 import { runChatCommand } from "./commands/chat.js";
 import { runDoctorCommand } from "./commands/doctor.js";
 import { runReplayCommand } from "./commands/replay.js";
+import {
+  runCheckpointCommand,
+  runCheckpointsCommand,
+  runSessionCommand,
+  runSessionsCommand
+} from "./commands/session.js";
 import { runRunCommand, runSolveCommand } from "./commands/solve.js";
 
 function printHelp(): void {
@@ -11,6 +17,11 @@ Commands:
   run      Run the autonomous coding agent once
   solve    Compatibility alias for run
   chat     Start a minimal plain-terminal chat session
+  sessions List recent durable sessions
+  history  Compatibility alias for sessions
+  session  Show, search, resume, or fork sessions
+  checkpoints List checkpoints for a session
+  checkpoint  Show or restore a checkpoint
   doctor   Check local configuration
   replay   Summarize a trace JSONL file
 
@@ -47,6 +58,10 @@ async function main(): Promise<number> {
   if (command === "run") return await runRunCommand(rest);
   if (command === "solve") return await runSolveCommand(rest);
   if (command === "chat") return await runChatCommand(rest);
+  if (command === "sessions" || command === "history") return await runSessionsCommand(rest);
+  if (command === "session") return await runSessionCommand(rest);
+  if (command === "checkpoints") return await runCheckpointsCommand(rest);
+  if (command === "checkpoint") return await runCheckpointCommand(rest);
   if (command === "doctor") return await runDoctorCommand(rest);
   if (command === "replay") return await runReplayCommand(rest);
 

--- a/packages/agent-cli/src/output.ts
+++ b/packages/agent-cli/src/output.ts
@@ -14,6 +14,7 @@ export function printRunResult(
   const lines = [
     `status=${result.status}`,
     `finish_reason=${result.finishReason}`,
+    ...(result.sessionId ? [`session_id=${result.sessionId}`] : []),
     `turns=${result.turns}`,
     `tool_calls=${result.toolCalls}`,
     `commands_executed=${result.commandsExecuted}`,

--- a/packages/agent-core/src/agent.ts
+++ b/packages/agent-core/src/agent.ts
@@ -5,6 +5,7 @@ import type { AgentMessage, ToolCall } from "agent-ai";
 import { DEFAULT_SYSTEM_PROMPT } from "./prompts.js";
 import { truncateMiddle } from "./compaction.js";
 import { JsonlSessionStore } from "./session/jsonl-session-store.js";
+import { createSessionManager, type SessionManager } from "./session/session-manager.js";
 import { createDefaultToolRegistry, filterToolRegistry } from "./tools/registry.js";
 import { formatProjectInstructionsBlock, loadProjectInstructions } from "./context/project-instructions.js";
 import { formatRepoMapBlock, generateRepoMap } from "./context/repo-map.js";
@@ -55,13 +56,15 @@ function event(
   provider: string,
   model: string,
   metadata?: Record<string, unknown>,
-  parentId?: string
+  parentId?: string,
+  sessionId?: string
 ): AgentEvent {
   return {
     id: randomUUID(),
     timestamp: nowIso(),
     type,
     runId,
+    sessionId,
     parentId,
     provider,
     model,
@@ -171,6 +174,7 @@ async function resolveRunToolRegistry(config: AgentRunConfig): Promise<ToolRegis
 
 export function summaryJsonFromRunResult(result: AgentRunResult): SummaryJson {
   const summary: SummaryJson = {
+    ...(result.sessionId ? { session_id: result.sessionId } : {}),
     status: result.status,
     finish_reason: result.finishReason,
     turns: result.turns,
@@ -246,12 +250,30 @@ export async function runAgent(config: AgentRunConfig): Promise<AgentRunResult> 
     runState: {
       todos: [],
       nextTodoId: 1,
-      changedFiles: new Set<string>()
+      changedFiles: new Set<string>(),
+      contextIndexes: new Map<string, unknown>()
     },
-    alwaysAllowTools: new Set<string>()
+    alwaysAllowTools: new Set<string>(),
+    ...(config.abortSignal ? { abortSignal: config.abortSignal } : {})
   };
   const traceStore = config.traceJsonlPath ? new JsonlSessionStore(config.traceJsonlPath) : undefined;
   const sessionStore = config.sessionJsonlPath ? new JsonlSessionStore(config.sessionJsonlPath) : undefined;
+  const durableSession: SessionManager | null = config.durableSession === false
+    ? null
+    : await createSessionManager({
+        sessionId: config.sessionId,
+        runId,
+        instruction: config.instruction,
+        workspacePath: context.workspacePath,
+        provider,
+        model,
+        sessionRootDir: config.sessionRootDir,
+        traceJsonlPath: config.traceJsonlPath,
+        sessionJsonlPath: config.sessionJsonlPath,
+        summaryJsonPath: config.summaryJsonPath,
+        parentSessionId: config.parentSessionId,
+        forkedFromSessionId: config.forkedFromSessionId
+      });
   const workflow = createWorkflowState();
   const finalEvidenceMode = config.finalEvidenceMode ?? "off";
   let finalGateStatus = createInitialFinalGateStatus(finalEvidenceMode);
@@ -264,6 +286,7 @@ export async function runAgent(config: AgentRunConfig): Promise<AgentRunResult> 
     if (config.sessionJsonlPath !== config.traceJsonlPath) {
       await sessionStore?.append(safeEvent);
     }
+    await durableSession?.appendEvent(safeEvent);
   };
 
   const usage: TokenTotals = { inputTokens: 0, outputTokens: 0, cacheTokens: 0, totalTokens: 0 };
@@ -313,6 +336,9 @@ export async function runAgent(config: AgentRunConfig): Promise<AgentRunResult> 
 
   await recordEvent(
     event(runId, "run_start", provider, model, {
+      sessionId: durableSession?.sessionId,
+      parentSessionId: config.parentSessionId,
+      forkedFromSessionId: config.forkedFromSessionId,
       workspacePath: context.workspacePath,
       maxTurns,
       maxWallTimeSec,
@@ -322,7 +348,7 @@ export async function runAgent(config: AgentRunConfig): Promise<AgentRunResult> 
       contextMode: config.contextMode,
       repoMapChars: repoMap?.chars,
       selectedSkills: selectedSkills.map((skill) => ({ name: skill.name, source: skill.source }))
-    })
+    }, undefined, durableSession?.sessionId)
   );
 
   try {
@@ -342,16 +368,23 @@ export async function runAgent(config: AgentRunConfig): Promise<AgentRunResult> 
       if (compactedMessages !== messages) {
         messages.splice(0, messages.length, ...compactedMessages);
       }
-      await recordEvent(event(runId, "model_start", provider, model, { turn: turns }));
+      if (config.abortSignal?.aborted) {
+        finishReason = "error";
+        lastError = "Run aborted before model request.";
+        await recordEvent(event(runId, "run_abort", provider, model, { turn: turns }, undefined, durableSession?.sessionId));
+        break;
+      }
+
+      await recordEvent(event(runId, "model_start", provider, model, { turn: turns }, undefined, durableSession?.sessionId));
       const response = await config.modelClient.complete({
         messages,
         tools: registry.definitions,
         toolChoice: "auto"
       });
       addUsage(usage, response.usage);
-      await recordEvent(event(runId, "model_end", provider, model, { turn: turns, usage: response.usage }));
+      await recordEvent(event(runId, "model_end", provider, model, { turn: turns, usage: response.usage }, undefined, durableSession?.sessionId));
       if (response.usage) {
-        await recordEvent(event(runId, "usage", provider, model, { turn: turns, usage: response.usage }));
+        await recordEvent(event(runId, "usage", provider, model, { turn: turns, usage: response.usage }, undefined, durableSession?.sessionId));
       }
 
       messages.push(response.message);
@@ -362,7 +395,7 @@ export async function runAgent(config: AgentRunConfig): Promise<AgentRunResult> 
           content: response.message.content,
           reasoningContent: response.message.reasoningContent,
           toolCalls: response.message.toolCalls
-        })
+        }, undefined, durableSession?.sessionId)
       );
 
       const calls = response.message.toolCalls ?? [];
@@ -391,7 +424,7 @@ export async function runAgent(config: AgentRunConfig): Promise<AgentRunResult> 
       }
 
       for (const call of calls) {
-        const toolStart = event(runId, "tool_start", provider, model, { toolCall: call }, undefined);
+        const toolStart = event(runId, "tool_start", provider, model, { toolCall: call }, undefined, durableSession?.sessionId);
         await recordEvent(toolStart);
         toolCalls += 1;
         if (toolCallCountsAsCommand(call as ToolCall)) {
@@ -399,6 +432,8 @@ export async function runAgent(config: AgentRunConfig): Promise<AgentRunResult> 
         }
 
         let result: ToolResult;
+        const pendingCheckpoint = await durableSession?.checkpoints.beforeTool(call as ToolCall) ?? null;
+        let checkpointId: string | undefined;
         try {
           result = await registry.execute(call as ToolCall, context);
         } catch (error) {
@@ -407,6 +442,8 @@ export async function runAgent(config: AgentRunConfig): Promise<AgentRunResult> 
             content: error instanceof Error ? error.message : String(error)
           };
         }
+        const checkpoint = await durableSession?.checkpoints.afterTool(pendingCheckpoint, result) ?? null;
+        checkpointId = checkpoint?.id;
 
         await recordEvent(
           event(
@@ -414,8 +451,9 @@ export async function runAgent(config: AgentRunConfig): Promise<AgentRunResult> 
             "tool_end",
             provider,
             model,
-            { toolCallId: call.id, toolName: call.function.name, result },
-            toolStart.id
+            { toolCallId: call.id, toolName: call.function.name, result, ...(checkpointId ? { checkpointId } : {}) },
+            toolStart.id,
+            durableSession?.sessionId
           )
         );
         const evidence = inferEvidenceRecord({
@@ -445,12 +483,13 @@ export async function runAgent(config: AgentRunConfig): Promise<AgentRunResult> 
   } catch (error) {
     finishReason = "error";
     lastError = error instanceof Error ? error.message : String(error);
-    await recordEvent(event(runId, "error", provider, model, { message: lastError }));
+    await recordEvent(event(runId, "error", provider, model, { message: lastError }, undefined, durableSession?.sessionId));
   }
 
   const status = finishReason === "error" ? "error" : finishReason === "assistant_stop" ? "completed" : "stopped";
   const changedFiles = [...context.runState.changedFiles].sort((a, b) => a.localeCompare(b, "en"));
   const result: AgentRunResult = {
+    ...(durableSession?.sessionId ? { sessionId: durableSession.sessionId } : {}),
     status,
     finishReason,
     turns,
@@ -475,10 +514,11 @@ export async function runAgent(config: AgentRunConfig): Promise<AgentRunResult> 
     selectedSkills: selectedSkills.map((skill) => ({ name: skill.name, source: skill.source }))
   };
 
-  await recordEvent(event(runId, "run_end", provider, model, { result }));
+  await recordEvent(event(runId, "run_end", provider, model, { result }, undefined, durableSession?.sessionId));
   if (config.summaryJsonPath) {
     await writeRunSummary(result, config.summaryJsonPath);
   }
+  await durableSession?.complete(result, summaryJsonFromRunResult(result));
   await registry.close?.();
 
   return result;

--- a/packages/agent-core/src/agent.ts
+++ b/packages/agent-core/src/agent.ts
@@ -192,6 +192,9 @@ export function summaryJsonFromRunResult(result: AgentRunResult): SummaryJson {
   if (result.finalMessage) {
     summary.final_message = result.finalMessage;
   }
+  if (result.harness) {
+    summary.harness = result.harness;
+  }
   if (result.toolsAvailable && result.toolsAvailable.length > 0) {
     summary.tools_available = result.toolsAvailable;
   }

--- a/packages/agent-core/src/context/code-index.ts
+++ b/packages/agent-core/src/context/code-index.ts
@@ -229,7 +229,7 @@ export async function getCodeIndexForTool(
     path: options.path ?? ".",
     maxFiles: options.maxFiles ?? DEFAULT_MAX_FILES,
     maxFileBytes: options.maxFileBytes ?? DEFAULT_MAX_FILE_BYTES,
-    changedFiles: context.runState.changedFiles.size
+    version: context.runState.contextIndexVersion ?? 0
   });
   context.runState.contextIndexes ??= new Map<string, unknown>();
   const cached = context.runState.contextIndexes.get(cacheKey);
@@ -237,4 +237,9 @@ export async function getCodeIndexForTool(
   const index = await buildCodeIndex({ workspacePath: context.workspacePath, ...options });
   context.runState.contextIndexes.set(cacheKey, index);
   return index;
+}
+
+export function invalidateContextIndexes(context: ToolExecutionContext): void {
+  context.runState.contextIndexVersion = (context.runState.contextIndexVersion ?? 0) + 1;
+  context.runState.contextIndexes?.clear();
 }

--- a/packages/agent-core/src/context/code-index.ts
+++ b/packages/agent-core/src/context/code-index.ts
@@ -1,0 +1,240 @@
+import { readFile, stat } from "node:fs/promises";
+import path from "node:path";
+import type { ToolExecutionContext } from "../types.js";
+import { workspaceRelativePath } from "../policy.js";
+import {
+  explicitPathIncludesIgnored,
+  resolveWorkspaceRelativePath,
+  walkFiles,
+  type WalkFile
+} from "../tools/workspace-utils.js";
+
+export type CodeSymbolKind = "function" | "class" | "interface" | "type" | "const" | "method" | "test" | "unknown";
+
+export interface CodeSymbol {
+  name: string;
+  kind: CodeSymbolKind;
+  line: number;
+  exported: boolean;
+}
+
+export interface CodeIndexFile {
+  path: string;
+  absolutePath: string;
+  size: number;
+  mtimeMs: number;
+  ext: string;
+  language: string;
+  symbols: CodeSymbol[];
+  imports: string[];
+  isTest: boolean;
+  isConfig: boolean;
+}
+
+export interface CodeIndex {
+  workspacePath: string;
+  rootPath: string;
+  files: CodeIndexFile[];
+  truncated: boolean;
+  generatedAt: string;
+}
+
+export interface BuildCodeIndexOptions {
+  workspacePath: string;
+  path?: string;
+  maxFiles?: number;
+  maxFileBytes?: number;
+}
+
+const DEFAULT_MAX_FILES = 20000;
+const DEFAULT_MAX_FILE_BYTES = 256000;
+
+const CONFIG_BASE_NAMES = new Set([
+  "package.json",
+  "tsconfig.json",
+  "jsconfig.json",
+  "pyproject.toml",
+  "requirements.txt",
+  "setup.py",
+  "pytest.ini",
+  "go.mod",
+  "Cargo.toml",
+  "pom.xml",
+  "build.gradle",
+  "build.gradle.kts",
+  "Makefile",
+  "makefile",
+  "eslint.config.js",
+  "vite.config.ts",
+  "vitest.config.ts"
+]);
+
+function languageForPath(filePath: string): string {
+  const ext = path.posix.extname(filePath).toLowerCase();
+  const base = path.posix.basename(filePath);
+  if (base === "Makefile" || base === "makefile") return "make";
+  const mapping: Record<string, string> = {
+    ".ts": "typescript",
+    ".tsx": "typescript",
+    ".js": "javascript",
+    ".jsx": "javascript",
+    ".mjs": "javascript",
+    ".cjs": "javascript",
+    ".py": "python",
+    ".go": "go",
+    ".rs": "rust",
+    ".java": "java",
+    ".kt": "kotlin",
+    ".kts": "kotlin",
+    ".json": "json",
+    ".toml": "toml",
+    ".yaml": "yaml",
+    ".yml": "yaml",
+    ".md": "markdown",
+    ".sh": "shell"
+  };
+  return mapping[ext] ?? (ext.replace(/^\./, "") || "text");
+}
+
+function isBinary(buffer: Buffer): boolean {
+  return buffer.subarray(0, Math.min(buffer.length, 4096)).includes(0);
+}
+
+export function isTestPath(filePath: string): boolean {
+  return /(^|\/)(test|tests|__tests__)(\/|$)|[._-](test|spec)\.[A-Za-z0-9]+$/.test(filePath);
+}
+
+export function isConfigPath(filePath: string): boolean {
+  const normalized = filePath.replace(/\\/g, "/");
+  const base = normalized.split("/").pop() ?? normalized;
+  return CONFIG_BASE_NAMES.has(base) ||
+    /(^|\/)\.(github|agent|vscode|config)(\/|$)/.test(normalized) ||
+    /(^|\/)(eslint|prettier|vitest|vite|webpack|rollup|babel|jest|mocha|pytest|ruff|mypy|tsup|turbo|nx)\.config\./i.test(normalized);
+}
+
+function pushSymbol(symbols: CodeSymbol[], match: RegExpMatchArray | null, kind: CodeSymbolKind, line: number): void {
+  if (!match) return;
+  const name = match[1] ?? match[2];
+  if (!name) return;
+  symbols.push({
+    name,
+    kind,
+    line,
+    exported: /\bexport\b/.test(match[0])
+  });
+}
+
+function parseSymbolsAndImports(text: string, language: string): { symbols: CodeSymbol[]; imports: string[] } {
+  const symbols: CodeSymbol[] = [];
+  const imports = new Set<string>();
+  const lines = text.split(/\r?\n/);
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    const lineNo = index + 1;
+
+    if (language === "typescript" || language === "javascript") {
+      pushSymbol(symbols, line.match(/^\s*(?:export\s+)?(?:async\s+)?function\s+([A-Za-z_$][\w$]*)\s*\(/), "function", lineNo);
+      pushSymbol(symbols, line.match(/^\s*(?:export\s+)?class\s+([A-Za-z_$][\w$]*)\b/), "class", lineNo);
+      pushSymbol(symbols, line.match(/^\s*(?:export\s+)?interface\s+([A-Za-z_$][\w$]*)\b/), "interface", lineNo);
+      pushSymbol(symbols, line.match(/^\s*(?:export\s+)?type\s+([A-Za-z_$][\w$]*)\b/), "type", lineNo);
+      pushSymbol(symbols, line.match(/^\s*(?:export\s+)?const\s+([A-Za-z_$][\w$]*)\s*=/), "const", lineNo);
+      pushSymbol(symbols, line.match(/^\s*(?:describe|it|test)\s*\(\s*["'`]([^"'`]+)["'`]/), "test", lineNo);
+      const fromMatch = line.match(/\bfrom\s+["']([^"']+)["']/);
+      const requireMatch = line.match(/\brequire\(\s*["']([^"']+)["']\s*\)/);
+      if (fromMatch) imports.add(fromMatch[1]);
+      if (requireMatch) imports.add(requireMatch[1]);
+    } else if (language === "python") {
+      pushSymbol(symbols, line.match(/^\s*def\s+([A-Za-z_]\w*)\s*\(/), "function", lineNo);
+      pushSymbol(symbols, line.match(/^\s*class\s+([A-Za-z_]\w*)\b/), "class", lineNo);
+      const importMatch = line.match(/^\s*(?:from\s+([A-Za-z0-9_.$]+)\s+import|import\s+([A-Za-z0-9_.$]+))/);
+      if (importMatch) imports.add(importMatch[1] ?? importMatch[2]);
+    } else if (language === "go") {
+      pushSymbol(symbols, line.match(/^\s*func\s+(?:\([^)]+\)\s*)?([A-Za-z_]\w*)\s*\(/), "function", lineNo);
+      pushSymbol(symbols, line.match(/^\s*type\s+([A-Za-z_]\w*)\s+(?:struct|interface)\b/), "type", lineNo);
+      const importMatch = line.match(/^\s*import\s+(?:[A-Za-z_]\w*\s+)?["`]([^"`]+)["`]/);
+      if (importMatch) imports.add(importMatch[1]);
+    } else if (language === "rust") {
+      pushSymbol(symbols, line.match(/^\s*(?:pub\s+)?fn\s+([A-Za-z_]\w*)\s*\(/), "function", lineNo);
+      pushSymbol(symbols, line.match(/^\s*(?:pub\s+)?(?:struct|enum|trait)\s+([A-Za-z_]\w*)\b/), "type", lineNo);
+      const useMatch = line.match(/^\s*use\s+([^;]+);/);
+      if (useMatch) imports.add(useMatch[1]);
+    }
+  }
+  return { symbols, imports: [...imports].sort((a, b) => a.localeCompare(b, "en")) };
+}
+
+async function indexFile(file: WalkFile, maxFileBytes: number): Promise<CodeIndexFile | null> {
+  const info = await stat(file.absolutePath);
+  const ext = path.posix.extname(file.relativePath).toLowerCase();
+  const language = languageForPath(file.relativePath);
+  let symbols: CodeSymbol[] = [];
+  let imports: string[] = [];
+  if (info.size <= maxFileBytes) {
+    const buffer = await readFile(file.absolutePath);
+    if (!isBinary(buffer)) {
+      const parsed = parseSymbolsAndImports(buffer.toString("utf8"), language);
+      symbols = parsed.symbols;
+      imports = parsed.imports;
+    }
+  }
+  return {
+    path: file.relativePath,
+    absolutePath: file.absolutePath,
+    size: info.size,
+    mtimeMs: info.mtimeMs,
+    ext,
+    language,
+    symbols,
+    imports,
+    isTest: isTestPath(file.relativePath),
+    isConfig: isConfigPath(file.relativePath)
+  };
+}
+
+export async function buildCodeIndex(options: BuildCodeIndexOptions): Promise<CodeIndex> {
+  const workspacePath = path.resolve(options.workspacePath);
+  const requestedPath = options.path ?? ".";
+  const resolved = resolveWorkspaceRelativePath(workspacePath, requestedPath);
+  const rootInfo = await stat(resolved.absolutePath);
+  const walked = rootInfo.isFile()
+    ? {
+        files: [{ absolutePath: resolved.absolutePath, relativePath: workspaceRelativePath(workspacePath, resolved.absolutePath) }],
+        truncated: false
+      }
+    : await walkFiles({
+        workspacePath,
+        rootPath: resolved.absolutePath,
+        maxFiles: options.maxFiles ?? DEFAULT_MAX_FILES,
+        explicitIncludesIgnored: explicitPathIncludesIgnored(resolved.relativePath)
+      });
+  const files: CodeIndexFile[] = [];
+  for (const file of walked.files) {
+    const indexed = await indexFile(file, options.maxFileBytes ?? DEFAULT_MAX_FILE_BYTES);
+    if (indexed) files.push(indexed);
+  }
+  return {
+    workspacePath,
+    rootPath: resolved.absolutePath,
+    files,
+    truncated: walked.truncated,
+    generatedAt: new Date().toISOString()
+  };
+}
+
+export async function getCodeIndexForTool(
+  context: ToolExecutionContext,
+  options: Omit<BuildCodeIndexOptions, "workspacePath"> = {}
+): Promise<CodeIndex> {
+  const cacheKey = JSON.stringify({
+    path: options.path ?? ".",
+    maxFiles: options.maxFiles ?? DEFAULT_MAX_FILES,
+    maxFileBytes: options.maxFileBytes ?? DEFAULT_MAX_FILE_BYTES,
+    changedFiles: context.runState.changedFiles.size
+  });
+  context.runState.contextIndexes ??= new Map<string, unknown>();
+  const cached = context.runState.contextIndexes.get(cacheKey);
+  if (cached) return cached as CodeIndex;
+  const index = await buildCodeIndex({ workspacePath: context.workspacePath, ...options });
+  context.runState.contextIndexes.set(cacheKey, index);
+  return index;
+}

--- a/packages/agent-core/src/controller/evidence.ts
+++ b/packages/agent-core/src/controller/evidence.ts
@@ -111,5 +111,22 @@ export function inferEvidenceRecord(options: {
     };
   }
 
+  if (options.toolName === "validate") {
+    const command = typeof options.result.metadata?.command === "string" ? options.result.metadata.command : undefined;
+    return {
+      kind: command ? evidenceKindForCommand(command) : "unknown",
+      toolName: options.toolName,
+      ok: true,
+      executable: true,
+      command,
+      relatedFiles: Array.isArray(options.result.metadata?.relatedFiles)
+        ? options.result.metadata.relatedFiles.filter((item): item is string => typeof item === "string")
+        : undefined,
+      exitCode: numberMetadata(options.result, "exitCode"),
+      summary: summarizeResult(options.result),
+      timestamp
+    };
+  }
+
   return null;
 }

--- a/packages/agent-core/src/harness/runner.ts
+++ b/packages/agent-core/src/harness/runner.ts
@@ -1,7 +1,8 @@
 import { copyFile, mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
-import { runAgent } from "../agent.js";
+import { runAgent, summaryJsonFromRunResult } from "../agent.js";
+import { createSessionManager } from "../session/session-manager.js";
 import type {
   AgentHarnessConfig,
   AgentHarnessSummary,
@@ -179,6 +180,7 @@ function finalResultForHarness(options: {
   harness: AgentHarnessSummary;
   failed: HarnessCommandResult[];
   failureMessage: string | null;
+  sessionId?: string;
 }): AgentRunResult {
   const aggregate = aggregateAttemptResults(options.attempts);
   const firstFailure = options.failed[0];
@@ -197,7 +199,7 @@ function finalResultForHarness(options: {
     ])
   ];
   return {
-    sessionId: options.finalAttempt.sessionId,
+    sessionId: options.sessionId ?? options.finalAttempt.sessionId,
     status,
     finishReason,
     turns: aggregate.turns,
@@ -239,9 +241,26 @@ export async function runAgentHarness(config: AgentHarnessConfig): Promise<Agent
   }
 
   const startedAtMs = Date.now();
+  const workspacePath = path.resolve(config.workspacePath);
   const summaryDir = path.dirname(path.resolve(config.summaryJsonPath ?? path.join(config.workspacePath, ".agent", "summary.json")));
   const attemptsDir = path.resolve(config.attemptsDir ?? path.join(summaryDir, "attempts"));
   await mkdir(attemptsDir, { recursive: true });
+  const durableSession = config.durableSession === false
+    ? null
+    : await createSessionManager({
+        sessionId: config.sessionId,
+        runId: randomUUID(),
+        instruction: config.instruction,
+        workspacePath,
+        provider: config.modelClient.provider,
+        model: config.modelClient.model,
+        sessionRootDir: config.sessionRootDir,
+        traceJsonlPath: config.traceJsonlPath,
+        sessionJsonlPath: config.sessionJsonlPath,
+        summaryJsonPath: config.summaryJsonPath,
+        parentSessionId: config.parentSessionId,
+        forkedFromSessionId: config.forkedFromSessionId
+      });
 
   const attempts: AgentRunResult[] = [];
   const validationResults: HarnessCommandResult[] = [];
@@ -273,7 +292,8 @@ export async function runAgentHarness(config: AgentHarnessConfig): Promise<Agent
       ...config,
       instruction: activeInstruction,
       summaryJsonPath: attemptSummaryPath,
-      traceJsonlPath: attemptTracePath
+      traceJsonlPath: attemptTracePath,
+      durableSession: false
     });
     attempts.push(attemptResult);
     finalTracePath = attemptTracePath;
@@ -342,7 +362,8 @@ export async function runAgentHarness(config: AgentHarnessConfig): Promise<Agent
     finalAttempt,
     harness,
     failed: lastFailed,
-    failureMessage
+    failureMessage,
+    sessionId: durableSession?.sessionId
   });
 
   await writeHarnessSummary(finalResult, config.summaryJsonPath);
@@ -350,6 +371,7 @@ export async function runAgentHarness(config: AgentHarnessConfig): Promise<Agent
     await mkdir(path.dirname(path.resolve(config.traceJsonlPath)), { recursive: true });
     await copyFile(finalTracePath, config.traceJsonlPath);
   }
+  await durableSession?.complete(finalResult, summaryJsonFromRunResult(finalResult));
 
   return finalResult;
 }

--- a/packages/agent-core/src/harness/runner.ts
+++ b/packages/agent-core/src/harness/runner.ts
@@ -197,6 +197,7 @@ function finalResultForHarness(options: {
     ])
   ];
   return {
+    sessionId: options.finalAttempt.sessionId,
     status,
     finishReason,
     turns: aggregate.turns,

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -15,10 +15,52 @@ export {
   loadProjectInstructions
 } from "./context/project-instructions.js";
 export { formatRepoMapBlock, generateRepoMap } from "./context/repo-map.js";
+export {
+  buildCodeIndex,
+  getCodeIndexForTool,
+  isConfigPath,
+  isTestPath
+} from "./context/code-index.js";
+export type {
+  CodeIndex,
+  CodeIndexFile,
+  CodeSymbol,
+  CodeSymbolKind
+} from "./context/code-index.js";
 export { DEFAULT_SYSTEM_PROMPT } from "./prompts.js";
 export { redactSecrets, redactSecretText } from "./redaction.js";
 export { AgentEventBus } from "./events.js";
 export { JsonlSessionStore } from "./session/jsonl-session-store.js";
+export {
+  buildResumeInstruction,
+  defaultSessionRootDir,
+  listSessions,
+  loadSessionMeta,
+  loadSessionResumeContext,
+  readSessionEventsText,
+  readSessionIndex,
+  readSessionSummaryText,
+  searchSessions
+} from "./session/session-index.js";
+export {
+  createSessionManager,
+  generateSessionId,
+  SessionManager
+} from "./session/session-manager.js";
+export {
+  listCheckpoints,
+  loadCheckpoint,
+  restoreCheckpoint,
+  GitCheckpointManager
+} from "./session/checkpoints.js";
+export type {
+  CheckpointRecord,
+  CheckpointRestoreResult,
+  DurableSessionMeta,
+  SessionIndexRecord,
+  SessionResumeContext,
+  SessionSearchResult
+} from "./session/session-types.js";
 export { truncateMiddle } from "./compaction.js";
 export {
   isPathInside,
@@ -39,6 +81,8 @@ export {
   executeGlobTool,
   executeGrepTool,
   executeRepoQueryTool,
+  executeSymbolSearchTool,
+  executeValidateTool,
   executeListTool,
   executeReadTool,
   executeServiceTool,

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -18,6 +18,7 @@ export { formatRepoMapBlock, generateRepoMap } from "./context/repo-map.js";
 export {
   buildCodeIndex,
   getCodeIndexForTool,
+  invalidateContextIndexes,
   isConfigPath,
   isTestPath
 } from "./context/code-index.js";

--- a/packages/agent-core/src/run-controller.ts
+++ b/packages/agent-core/src/run-controller.ts
@@ -25,6 +25,11 @@ export interface RunConfiguredAgentOptions {
   model?: string;
   modelClient?: ModelClient;
   modelClientFactory?: (provider: ProviderName, options: ProviderOptions) => ModelClient;
+  sessionId?: string;
+  sessionRootDir?: string;
+  durableSession?: boolean;
+  parentSessionId?: string;
+  forkedFromSessionId?: string;
   permissionMode?: PermissionMode;
   maxTurns?: number;
   maxWallTimeSec?: number;
@@ -61,6 +66,7 @@ export interface RunConfiguredAgentOptions {
   permissionDecider?: PermissionDecider;
   toolRegistry?: ToolRegistry;
   onMcpServers?: (servers: McpServerRunSummary[]) => void;
+  abortSignal?: AbortSignal;
 }
 
 export interface RunConfiguredAgentResult {
@@ -100,6 +106,11 @@ function baseRunConfig(options: RunConfiguredAgentOptions, modelClient: ModelCli
     instruction: options.instruction,
     workspacePath: options.workspacePath,
     modelClient,
+    ...(defined(options.sessionId) ? { sessionId: options.sessionId } : {}),
+    ...(defined(options.sessionRootDir) ? { sessionRootDir: options.sessionRootDir } : {}),
+    ...(defined(options.durableSession) ? { durableSession: options.durableSession } : {}),
+    ...(defined(options.parentSessionId) ? { parentSessionId: options.parentSessionId } : {}),
+    ...(defined(options.forkedFromSessionId) ? { forkedFromSessionId: options.forkedFromSessionId } : {}),
     ...(defined(options.maxTurns) ? { maxTurns: options.maxTurns } : {}),
     ...(defined(options.maxWallTimeSec) ? { maxWallTimeSec: options.maxWallTimeSec } : {}),
     ...(defined(options.commandTimeoutSec) ? { commandTimeoutSec: options.commandTimeoutSec } : {}),
@@ -123,7 +134,8 @@ function baseRunConfig(options: RunConfiguredAgentOptions, modelClient: ModelCli
     ...(defined(options.finalEvidenceMode) ? { finalEvidenceMode: options.finalEvidenceMode } : {}),
     ...(defined(options.skillsMode) ? { skillsMode: options.skillsMode } : {}),
     ...(defined(options.skillsMaxChars) ? { skillsMaxChars: options.skillsMaxChars } : {}),
-    ...(defined(options.eventBus) ? { eventBus: options.eventBus } : {})
+    ...(defined(options.eventBus) ? { eventBus: options.eventBus } : {}),
+    ...(defined(options.abortSignal) ? { abortSignal: options.abortSignal } : {})
   };
 }
 

--- a/packages/agent-core/src/session/checkpoints.ts
+++ b/packages/agent-core/src/session/checkpoints.ts
@@ -1,0 +1,289 @@
+import { mkdtemp, mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { ToolCall } from "agent-ai";
+import { truncateMiddle } from "../compaction.js";
+import { runCommand } from "../command-runner.js";
+import type { ToolResult } from "../types.js";
+import { gitCommandSpec } from "../tools/git-command.js";
+import type { CheckpointRecord, CheckpointRestoreResult } from "./session-types.js";
+
+interface GitSnapshot {
+  tree: string;
+}
+
+interface PendingCheckpoint {
+  sequence: number;
+  toolCall: ToolCall;
+  before: GitSnapshot;
+}
+
+export interface GitCheckpointManagerOptions {
+  sessionId: string;
+  workspacePath: string;
+  checkpointsDir: string;
+}
+
+const CHECKPOINTED_TOOLS = new Set(["write", "edit", "apply_patch", "bash", "shell_session", "service"]);
+const EMPTY_TREE = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function checkpointId(sequence: number): string {
+  return String(sequence).padStart(4, "0");
+}
+
+function isCheckpointedTool(call: ToolCall): boolean {
+  if (!CHECKPOINTED_TOOLS.has(call.function.name)) return false;
+  if (call.function.name === "shell_session") {
+    return argsObject(call.function.arguments)?.action === "send";
+  }
+  if (call.function.name === "service") {
+    const action = argsObject(call.function.arguments)?.action;
+    return action === "start" || action === "stop";
+  }
+  return true;
+}
+
+function argsObject(args: unknown): Record<string, unknown> | null {
+  if (!args || typeof args !== "object") return null;
+  return args as Record<string, unknown>;
+}
+
+function trimOutput(value: string, maxChars = 4000): string {
+  return value.length <= maxChars ? value : value.slice(-maxChars);
+}
+
+function parsePatchChangedFiles(patch: string): string[] {
+  const files = new Set<string>();
+  for (const line of patch.split(/\r?\n/)) {
+    if (!line.startsWith("diff --git ")) continue;
+    const match = line.match(/^diff --git (?:a\/)?(.+?) (?:b\/)?(.+)$/);
+    if (!match) continue;
+    for (const raw of [match[1], match[2]]) {
+      const normalized = raw.replace(/^"|"$/g, "").replace(/\\/g, "/");
+      if (normalized && normalized !== "/dev/null") files.add(normalized);
+    }
+  }
+  return [...files].sort((a, b) => a.localeCompare(b, "en"));
+}
+
+async function gitOutput(options: {
+  workspacePath: string;
+  args: string[];
+  stdin?: string;
+  env?: NodeJS.ProcessEnv;
+  timeoutMs?: number;
+}): Promise<{ ok: boolean; stdout: string; stderr: string; exitCode: number | null; durationMs: number }> {
+  const git = gitCommandSpec();
+  const result = await runCommand({
+    command: git.command,
+    args: [...git.argsPrefix, ...options.args],
+    cwd: options.workspacePath,
+    stdin: options.stdin,
+    env: options.env ?? process.env,
+    timeoutMs: options.timeoutMs ?? 30000
+  });
+  return {
+    ok: !result.error && !result.timedOut && result.exitCode === 0,
+    stdout: result.stdout.toString("utf8"),
+    stderr: result.error ? result.error.message : result.stderr.toString("utf8"),
+    exitCode: result.error ? 127 : result.timedOut ? 124 : result.exitCode,
+    durationMs: result.durationMs
+  };
+}
+
+async function isGitWorkspace(workspacePath: string): Promise<boolean> {
+  const result = await gitOutput({ workspacePath, args: ["rev-parse", "--is-inside-work-tree"], timeoutMs: 5000 });
+  return result.ok && result.stdout.trim() === "true";
+}
+
+async function hasHead(workspacePath: string): Promise<boolean> {
+  return (await gitOutput({ workspacePath, args: ["rev-parse", "--verify", "HEAD"], timeoutMs: 5000 })).ok;
+}
+
+async function snapshotTree(workspacePath: string): Promise<GitSnapshot | null> {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "sigma-git-index-"));
+  const indexPath = path.join(tempDir, "index");
+  const env = { ...process.env, GIT_INDEX_FILE: indexPath };
+  try {
+    const readTreeArgs = await hasHead(workspacePath) ? ["read-tree", "HEAD"] : ["read-tree", "--empty"];
+    const readTree = await gitOutput({ workspacePath, args: readTreeArgs, env, timeoutMs: 10000 });
+    if (!readTree.ok) return null;
+    const add = await gitOutput({ workspacePath, args: ["add", "-A", "--", "."], env, timeoutMs: 30000 });
+    if (!add.ok) return null;
+    const tree = await gitOutput({ workspacePath, args: ["write-tree"], env, timeoutMs: 10000 });
+    if (!tree.ok) return null;
+    return { tree: tree.stdout.trim() || EMPTY_TREE };
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+async function diffTrees(workspacePath: string, beforeTree: string, afterTree: string): Promise<string | null> {
+  const diff = await gitOutput({
+    workspacePath,
+    args: ["diff", "--binary", "--no-ext-diff", "--find-renames", beforeTree, afterTree, "--"],
+    timeoutMs: 30000
+  });
+  return diff.ok ? diff.stdout : null;
+}
+
+async function readCheckpointRecord(filePath: string): Promise<CheckpointRecord | null> {
+  try {
+    return JSON.parse(await readFile(filePath, "utf8")) as CheckpointRecord;
+  } catch {
+    return null;
+  }
+}
+
+export class GitCheckpointManager {
+  readonly sessionId: string;
+  readonly workspacePath: string;
+  readonly checkpointsDir: string;
+  private sequence = 0;
+  private gitWorkspace: boolean | null = null;
+
+  constructor(options: GitCheckpointManagerOptions) {
+    this.sessionId = options.sessionId;
+    this.workspacePath = path.resolve(options.workspacePath);
+    this.checkpointsDir = path.resolve(options.checkpointsDir);
+  }
+
+  async beforeTool(toolCall: ToolCall): Promise<PendingCheckpoint | null> {
+    if (!isCheckpointedTool(toolCall)) return null;
+    if (this.gitWorkspace === null) {
+      this.gitWorkspace = await isGitWorkspace(this.workspacePath);
+    }
+    if (!this.gitWorkspace) return null;
+    const before = await snapshotTree(this.workspacePath);
+    if (!before) return null;
+    this.sequence += 1;
+    return { sequence: this.sequence, toolCall, before };
+  }
+
+  async afterTool(pending: PendingCheckpoint | null, result: ToolResult): Promise<CheckpointRecord | null> {
+    if (!pending) return null;
+    const after = await snapshotTree(this.workspacePath);
+    if (!after) return null;
+    if (after.tree === pending.before.tree) return null;
+    const patch = await diffTrees(this.workspacePath, pending.before.tree, after.tree);
+    if (!patch || patch.trim().length === 0) return null;
+
+    await mkdir(this.checkpointsDir, { recursive: true });
+    const id = checkpointId(pending.sequence);
+    const patchPath = path.join(this.checkpointsDir, `${id}.patch`);
+    const metaPath = path.join(this.checkpointsDir, `${id}.json`);
+    const record: CheckpointRecord = {
+      id,
+      sessionId: this.sessionId,
+      sequence: pending.sequence,
+      createdAt: nowIso(),
+      workspacePath: this.workspacePath,
+      toolName: pending.toolCall.function.name,
+      toolCallId: pending.toolCall.id,
+      ok: result.ok,
+      changedFiles: parsePatchChangedFiles(patch),
+      patchPath,
+      beforeTree: pending.before.tree,
+      afterTree: after.tree,
+      resultSummary: truncateMiddle(result.content.replace(/\s+/g, " ").trim(), 500).text
+    };
+    await writeFile(patchPath, patch, "utf8");
+    await writeFile(metaPath, `${JSON.stringify(record, null, 2)}\n`, "utf8");
+    return record;
+  }
+}
+
+export async function listCheckpoints(options: {
+  sessionId: string;
+  workspacePath?: string;
+  sessionRootDir?: string;
+  checkpointsDir?: string;
+}): Promise<CheckpointRecord[]> {
+  const checkpointsDir = options.checkpointsDir ??
+    path.join(path.resolve(options.sessionRootDir ?? path.join(options.workspacePath ?? process.cwd(), ".agent", "sessions")), options.sessionId, "checkpoints");
+  let entries: string[] = [];
+  try {
+    entries = await readdir(checkpointsDir);
+  } catch {
+    return [];
+  }
+  const records = await Promise.all(
+    entries
+      .filter((entry) => entry.endsWith(".json"))
+      .sort((a, b) => a.localeCompare(b, "en"))
+      .map((entry) => readCheckpointRecord(path.join(checkpointsDir, entry)))
+  );
+  return records.filter((record): record is CheckpointRecord => Boolean(record));
+}
+
+export async function loadCheckpoint(options: {
+  sessionId: string;
+  checkpointId: string;
+  workspacePath?: string;
+  sessionRootDir?: string;
+  checkpointsDir?: string;
+}): Promise<CheckpointRecord | null> {
+  const id = options.checkpointId.padStart(4, "0");
+  const checkpointsDir = options.checkpointsDir ??
+    path.join(path.resolve(options.sessionRootDir ?? path.join(options.workspacePath ?? process.cwd(), ".agent", "sessions")), options.sessionId, "checkpoints");
+  return await readCheckpointRecord(path.join(checkpointsDir, `${id}.json`));
+}
+
+export async function restoreCheckpoint(options: {
+  sessionId: string;
+  checkpointId: string;
+  workspacePath?: string;
+  sessionRootDir?: string;
+  checkpointsDir?: string;
+}): Promise<CheckpointRestoreResult> {
+  const record = await loadCheckpoint(options);
+  if (!record) {
+    return {
+      ok: false,
+      checkpointId: options.checkpointId,
+      command: "git apply -R --check",
+      exitCode: 1,
+      stdout: "",
+      stderr: "checkpoint not found",
+      durationMs: 0
+    };
+  }
+  const workspacePath = path.resolve(options.workspacePath ?? record.workspacePath);
+  const patch = await readFile(record.patchPath, "utf8");
+  const check = await gitOutput({
+    workspacePath,
+    args: ["apply", "-R", "--check", "--whitespace=nowarn"],
+    stdin: patch,
+    timeoutMs: 30000
+  });
+  if (!check.ok) {
+    return {
+      ok: false,
+      checkpointId: record.id,
+      command: "git apply -R --check --whitespace=nowarn",
+      exitCode: check.exitCode,
+      stdout: trimOutput(check.stdout),
+      stderr: trimOutput(check.stderr),
+      durationMs: check.durationMs
+    };
+  }
+  const applied = await gitOutput({
+    workspacePath,
+    args: ["apply", "-R", "--whitespace=nowarn"],
+    stdin: patch,
+    timeoutMs: 30000
+  });
+  return {
+    ok: applied.ok,
+    checkpointId: record.id,
+    command: "git apply -R --whitespace=nowarn",
+    exitCode: applied.exitCode,
+    stdout: trimOutput(applied.stdout),
+    stderr: trimOutput(applied.stderr),
+    durationMs: applied.durationMs
+  };
+}

--- a/packages/agent-core/src/session/checkpoints.ts
+++ b/packages/agent-core/src/session/checkpoints.ts
@@ -253,7 +253,20 @@ export async function restoreCheckpoint(options: {
     };
   }
   const workspacePath = path.resolve(options.workspacePath ?? record.workspacePath);
-  const patch = await readFile(record.patchPath, "utf8");
+  let patch: string;
+  try {
+    patch = await readFile(record.patchPath, "utf8");
+  } catch (error) {
+    return {
+      ok: false,
+      checkpointId: record.id,
+      command: "git apply -R --check --whitespace=nowarn",
+      exitCode: 1,
+      stdout: "",
+      stderr: `checkpoint patch is unreadable: ${record.patchPath}: ${error instanceof Error ? error.message : String(error)}`,
+      durationMs: 0
+    };
+  }
   const check = await gitOutput({
     workspacePath,
     args: ["apply", "-R", "--check", "--whitespace=nowarn"],

--- a/packages/agent-core/src/session/session-index.ts
+++ b/packages/agent-core/src/session/session-index.ts
@@ -1,0 +1,245 @@
+import { appendFile, mkdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { redactSecrets, redactSecretText } from "../redaction.js";
+import type {
+  DurableSessionMeta,
+  SessionIndexRecord,
+  SessionResumeContext,
+  SessionSearchResult
+} from "./session-types.js";
+
+export function defaultSessionRootDir(workspacePath: string): string {
+  return path.join(path.resolve(workspacePath), ".agent", "sessions");
+}
+
+export function sessionIndexPath(rootDir: string): string {
+  return path.join(path.resolve(rootDir), "index.jsonl");
+}
+
+export function sessionDir(rootDir: string, sessionId: string): string {
+  return path.join(path.resolve(rootDir), sessionId);
+}
+
+export async function appendSessionIndexRecord(rootDir: string, record: SessionIndexRecord): Promise<void> {
+  const indexPath = sessionIndexPath(rootDir);
+  await mkdir(path.dirname(indexPath), { recursive: true });
+  await appendFile(indexPath, `${JSON.stringify(redactSecrets(record))}\n`, "utf8");
+}
+
+async function readJsonFile<T>(filePath: string): Promise<T | null> {
+  try {
+    return JSON.parse(await readFile(filePath, "utf8")) as T;
+  } catch {
+    return null;
+  }
+}
+
+export async function readSessionIndex(rootDir: string): Promise<SessionIndexRecord[]> {
+  let content = "";
+  try {
+    content = await readFile(sessionIndexPath(rootDir), "utf8");
+  } catch {
+    return [];
+  }
+  const latest = new Map<string, SessionIndexRecord>();
+  for (const line of content.split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    try {
+      const record = JSON.parse(line) as SessionIndexRecord;
+      if (typeof record.sessionId === "string") latest.set(record.sessionId, record);
+    } catch {
+      // A partially written JSONL line should not make the whole history unreadable.
+    }
+  }
+  return [...latest.values()].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+}
+
+export async function listSessions(options: {
+  workspacePath?: string;
+  sessionRootDir?: string;
+  limit?: number;
+} = {}): Promise<SessionIndexRecord[]> {
+  const rootDir = options.sessionRootDir ?? defaultSessionRootDir(options.workspacePath ?? process.cwd());
+  const workspace = options.workspacePath ? path.resolve(options.workspacePath) : null;
+  const limit = Math.max(1, Math.floor(options.limit ?? 50));
+  return (await readSessionIndex(rootDir))
+    .filter((record) => (workspace ? path.resolve(record.workspacePath) === workspace : true))
+    .slice(0, limit);
+}
+
+export async function loadSessionMeta(options: {
+  sessionId: string;
+  workspacePath?: string;
+  sessionRootDir?: string;
+}): Promise<DurableSessionMeta | null> {
+  const rootDir = options.sessionRootDir ?? defaultSessionRootDir(options.workspacePath ?? process.cwd());
+  const direct = await readJsonFile<DurableSessionMeta>(path.join(sessionDir(rootDir, options.sessionId), "meta.json"));
+  if (direct) return direct;
+
+  const indexed = (await readSessionIndex(rootDir)).find((record) => record.sessionId === options.sessionId);
+  if (!indexed) return null;
+  return await readJsonFile<DurableSessionMeta>(path.join(path.dirname(indexed.eventsPath), "meta.json"));
+}
+
+export async function readSessionEventsText(eventsPath: string): Promise<string> {
+  try {
+    return await readFile(eventsPath, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+export async function readSessionSummaryText(summaryPath: string): Promise<string> {
+  try {
+    return await readFile(summaryPath, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function compactText(value: string, maxChars: number): string {
+  const normalized = redactSecretText(value).replace(/\s+/g, " ").trim();
+  if (normalized.length <= maxChars) return normalized;
+  return `${normalized.slice(0, Math.max(0, maxChars - 15))}...[truncated]`;
+}
+
+function eventSearchText(rawEventLine: string): string {
+  try {
+    const event = JSON.parse(rawEventLine) as {
+      type?: string;
+      timestamp?: string;
+      metadata?: Record<string, unknown>;
+    };
+    return compactText(JSON.stringify({
+      type: event.type,
+      timestamp: event.timestamp,
+      metadata: event.metadata
+    }), 800);
+  } catch {
+    return compactText(rawEventLine, 800);
+  }
+}
+
+export async function searchSessions(options: {
+  query: string;
+  workspacePath?: string;
+  sessionRootDir?: string;
+  limit?: number;
+}): Promise<SessionSearchResult[]> {
+  const tokens = options.query.toLowerCase().split(/\s+/).map((token) => token.trim()).filter(Boolean);
+  if (tokens.length === 0) return [];
+  const sessions = await listSessions({
+    workspacePath: options.workspacePath,
+    sessionRootDir: options.sessionRootDir,
+    limit: 500
+  });
+  const results: SessionSearchResult[] = [];
+  for (const session of sessions) {
+    const summaryText = await readSessionSummaryText(session.summaryPath);
+    const eventsText = await readSessionEventsText(session.eventsPath);
+    const haystacks = [
+      { label: "title", text: session.title },
+      { label: "instruction", text: session.instruction },
+      { label: "final", text: session.finalMessage ?? "" },
+      { label: "error", text: session.lastError ?? "" },
+      { label: "summary", text: summaryText },
+      { label: "events", text: eventsText }
+    ];
+    let score = 0;
+    const matches: string[] = [];
+    for (const haystack of haystacks) {
+      const lower = haystack.text.toLowerCase();
+      const hits = tokens.filter((token) => lower.includes(token));
+      if (hits.length === 0) continue;
+      score += hits.length * (haystack.label === "title" || haystack.label === "instruction" ? 6 : 2);
+      matches.push(`${haystack.label}: ${compactText(haystack.text, 220)}`);
+    }
+    if (score > 0) results.push({ session, score, matches });
+  }
+  return results
+    .sort((a, b) => b.score - a.score || b.session.updatedAt.localeCompare(a.session.updatedAt))
+    .slice(0, Math.max(1, Math.floor(options.limit ?? 20)));
+}
+
+export async function loadSessionResumeContext(options: {
+  sessionId: string;
+  workspacePath?: string;
+  sessionRootDir?: string;
+  maxEvents?: number;
+}): Promise<SessionResumeContext | null> {
+  const session = await loadSessionMeta(options);
+  if (!session) return null;
+  const summaryText = await readSessionSummaryText(session.summaryPath);
+  const eventLines = (await readSessionEventsText(session.eventsPath)).trim().split(/\r?\n/).filter(Boolean);
+  const recentEvents = eventLines.slice(-Math.max(1, Math.floor(options.maxEvents ?? 12))).map((line) => {
+    try {
+      const event = JSON.parse(line) as { type?: string; timestamp?: string };
+      return {
+        type: event.type ?? "event",
+        timestamp: event.timestamp,
+        text: eventSearchText(line)
+      };
+    } catch {
+      return { type: "event", text: eventSearchText(line) };
+    }
+  });
+  return {
+    session,
+    summaryText: compactText(summaryText, 4000),
+    finalMessage: session.finalMessage ? compactText(session.finalMessage, 1200) : undefined,
+    recentEvents
+  };
+}
+
+export function buildResumeInstruction(options: {
+  context: SessionResumeContext;
+  instruction: string;
+  mode: "resume" | "fork";
+}): string {
+  const lines = [
+    `Previous Sigma session context (${options.mode}):`,
+    `- sessionId: ${options.context.session.sessionId}`,
+    `- workspacePath: ${options.context.session.workspacePath}`,
+    `- status: ${options.context.session.status}`,
+    options.context.session.finishReason ? `- finishReason: ${options.context.session.finishReason}` : "",
+    options.context.session.changedFiles.length > 0
+      ? `- changedFiles: ${options.context.session.changedFiles.join(", ")}`
+      : "",
+    "",
+    "Prior final message:",
+    options.context.finalMessage ?? "(none recorded)",
+    "",
+    "Prior summary:",
+    options.context.summaryText || "(none recorded)",
+    "",
+    "Recent prior events:",
+    ...options.context.recentEvents.map((event) => `- ${event.timestamp ?? ""} ${event.type}: ${event.text}`.trim()),
+    "",
+    "New instruction:",
+    options.instruction
+  ].filter((line) => line !== "");
+  return lines.join("\n");
+}
+
+export function sessionIndexRecordFromMeta(meta: DurableSessionMeta): SessionIndexRecord {
+  return {
+    sessionId: meta.sessionId,
+    title: meta.title,
+    instruction: meta.instruction,
+    workspacePath: meta.workspacePath,
+    provider: meta.provider,
+    model: meta.model,
+    status: meta.status,
+    ...(meta.finishReason ? { finishReason: meta.finishReason } : {}),
+    createdAt: meta.createdAt,
+    updatedAt: meta.updatedAt,
+    ...(meta.durationMs !== undefined ? { durationMs: meta.durationMs } : {}),
+    changedFiles: meta.changedFiles,
+    summaryPath: meta.summaryPath,
+    eventsPath: meta.eventsPath,
+    ...(meta.parentSessionId ? { parentSessionId: meta.parentSessionId } : {}),
+    ...(meta.forkedFromSessionId ? { forkedFromSessionId: meta.forkedFromSessionId } : {}),
+    ...(meta.finalMessage ? { finalMessage: meta.finalMessage } : {}),
+    ...(meta.lastError !== undefined ? { lastError: meta.lastError } : {})
+  };
+}

--- a/packages/agent-core/src/session/session-manager.ts
+++ b/packages/agent-core/src/session/session-manager.ts
@@ -1,0 +1,149 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+import { redactSecrets, redactSecretText } from "../redaction.js";
+import type { AgentEvent, AgentRunResult, SummaryJson } from "../types.js";
+import { JsonlSessionStore } from "./jsonl-session-store.js";
+import {
+  appendSessionIndexRecord,
+  defaultSessionRootDir,
+  sessionDir,
+  sessionIndexPath,
+  sessionIndexRecordFromMeta
+} from "./session-index.js";
+import type { DurableSessionMeta, SessionPaths } from "./session-types.js";
+import { GitCheckpointManager } from "./checkpoints.js";
+
+export interface CreateSessionManagerOptions {
+  sessionId?: string;
+  runId: string;
+  instruction: string;
+  workspacePath: string;
+  provider: string;
+  model: string;
+  sessionRootDir?: string;
+  traceJsonlPath?: string;
+  sessionJsonlPath?: string;
+  summaryJsonPath?: string;
+  parentSessionId?: string;
+  forkedFromSessionId?: string;
+}
+
+function safeSessionId(value: string): string {
+  return value.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 120) || randomUUID();
+}
+
+export function generateSessionId(date = new Date()): string {
+  const stamp = date.toISOString().replace(/[-:]/g, "").replace(/\.\d{3}Z$/, "Z");
+  return `${stamp}-${randomUUID().slice(0, 8)}`;
+}
+
+function titleFromInstruction(instruction: string): string {
+  const first = redactSecretText(instruction).split(/\r?\n/).map((line) => line.trim()).find(Boolean);
+  if (!first) return "Untitled run";
+  return first.length <= 90 ? first : `${first.slice(0, 87)}...`;
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function pathsForSession(rootDir: string, sessionId: string): SessionPaths {
+  const sessionPath = sessionDir(rootDir, sessionId);
+  return {
+    rootDir,
+    sessionDir: sessionPath,
+    metaPath: path.join(sessionPath, "meta.json"),
+    eventsPath: path.join(sessionPath, "events.jsonl"),
+    summaryPath: path.join(sessionPath, "summary.json"),
+    checkpointsDir: path.join(sessionPath, "checkpoints"),
+    indexPath: sessionIndexPath(rootDir)
+  };
+}
+
+export class SessionManager {
+  readonly sessionId: string;
+  readonly paths: SessionPaths;
+  readonly eventStore: JsonlSessionStore;
+  readonly checkpoints: GitCheckpointManager;
+  private meta: DurableSessionMeta;
+
+  private constructor(meta: DurableSessionMeta, paths: SessionPaths) {
+    this.sessionId = meta.sessionId;
+    this.paths = paths;
+    this.meta = meta;
+    this.eventStore = new JsonlSessionStore(paths.eventsPath);
+    this.checkpoints = new GitCheckpointManager({
+      sessionId: meta.sessionId,
+      workspacePath: meta.workspacePath,
+      checkpointsDir: paths.checkpointsDir
+    });
+  }
+
+  static async create(options: CreateSessionManagerOptions): Promise<SessionManager> {
+    const rootDir = path.resolve(options.sessionRootDir ?? defaultSessionRootDir(options.workspacePath));
+    const sessionId = safeSessionId(options.sessionId ?? generateSessionId());
+    const paths = pathsForSession(rootDir, sessionId);
+    const timestamp = nowIso();
+    const meta: DurableSessionMeta = {
+      sessionId,
+      runId: options.runId,
+      title: titleFromInstruction(options.instruction),
+      instruction: redactSecretText(options.instruction),
+      workspacePath: path.resolve(options.workspacePath),
+      provider: options.provider,
+      model: options.model,
+      status: "running",
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      changedFiles: [],
+      summaryPath: paths.summaryPath,
+      eventsPath: paths.eventsPath,
+      checkpointsDir: paths.checkpointsDir,
+      ...(options.traceJsonlPath ? { traceJsonlPath: path.resolve(options.traceJsonlPath) } : {}),
+      ...(options.sessionJsonlPath ? { sessionJsonlPath: path.resolve(options.sessionJsonlPath) } : {}),
+      ...(options.summaryJsonPath ? { compatibilitySummaryPath: path.resolve(options.summaryJsonPath) } : {}),
+      ...(options.parentSessionId ? { parentSessionId: options.parentSessionId } : {}),
+      ...(options.forkedFromSessionId ? { forkedFromSessionId: options.forkedFromSessionId } : {})
+    };
+    const manager = new SessionManager(meta, paths);
+    await manager.writeMeta();
+    await manager.writeIndex();
+    return manager;
+  }
+
+  async appendEvent(agentEvent: AgentEvent): Promise<void> {
+    await this.eventStore.append({ ...agentEvent, sessionId: this.sessionId });
+  }
+
+  async complete(result: AgentRunResult, summary: SummaryJson): Promise<void> {
+    this.meta = {
+      ...this.meta,
+      status: result.status,
+      finishReason: result.finishReason,
+      updatedAt: nowIso(),
+      durationMs: result.durationMs,
+      changedFiles: result.changedFiles ?? [],
+      finalMessage: result.finalMessage ? redactSecretText(result.finalMessage) : undefined,
+      lastError: result.lastError,
+      toolsAvailable: result.toolsAvailable
+    };
+    await mkdir(this.paths.sessionDir, { recursive: true });
+    await writeFile(this.paths.summaryPath, `${JSON.stringify(redactSecrets(summary), null, 2)}\n`, "utf8");
+    await this.writeMeta();
+    await this.writeIndex();
+  }
+
+  private async writeMeta(): Promise<void> {
+    await mkdir(this.paths.sessionDir, { recursive: true });
+    await writeFile(this.paths.metaPath, `${JSON.stringify(redactSecrets(this.meta), null, 2)}\n`, "utf8");
+  }
+
+  private async writeIndex(): Promise<void> {
+    await appendSessionIndexRecord(this.paths.rootDir, sessionIndexRecordFromMeta(this.meta));
+  }
+}
+
+export async function createSessionManager(options: CreateSessionManagerOptions): Promise<SessionManager> {
+  return await SessionManager.create(options);
+}

--- a/packages/agent-core/src/session/session-types.ts
+++ b/packages/agent-core/src/session/session-types.ts
@@ -1,0 +1,102 @@
+import type { AgentRunStatus, AgentFinishReason } from "../types.js";
+
+export interface SessionPaths {
+  rootDir: string;
+  sessionDir: string;
+  metaPath: string;
+  eventsPath: string;
+  summaryPath: string;
+  checkpointsDir: string;
+  indexPath: string;
+}
+
+export interface DurableSessionMeta {
+  sessionId: string;
+  runId: string;
+  title: string;
+  instruction: string;
+  workspacePath: string;
+  provider: string;
+  model: string;
+  status: AgentRunStatus | "running";
+  finishReason?: AgentFinishReason;
+  createdAt: string;
+  updatedAt: string;
+  durationMs?: number;
+  changedFiles: string[];
+  summaryPath: string;
+  eventsPath: string;
+  checkpointsDir: string;
+  traceJsonlPath?: string;
+  sessionJsonlPath?: string;
+  compatibilitySummaryPath?: string;
+  parentSessionId?: string;
+  forkedFromSessionId?: string;
+  finalMessage?: string;
+  lastError?: string | null;
+  toolsAvailable?: string[];
+}
+
+export interface SessionIndexRecord {
+  sessionId: string;
+  title: string;
+  instruction: string;
+  workspacePath: string;
+  provider: string;
+  model: string;
+  status: DurableSessionMeta["status"];
+  finishReason?: AgentFinishReason;
+  createdAt: string;
+  updatedAt: string;
+  durationMs?: number;
+  changedFiles: string[];
+  summaryPath: string;
+  eventsPath: string;
+  parentSessionId?: string;
+  forkedFromSessionId?: string;
+  finalMessage?: string;
+  lastError?: string | null;
+}
+
+export interface SessionSearchResult {
+  session: SessionIndexRecord;
+  score: number;
+  matches: string[];
+}
+
+export interface SessionResumeContext {
+  session: DurableSessionMeta;
+  summaryText: string;
+  finalMessage?: string;
+  recentEvents: Array<{
+    type: string;
+    timestamp?: string;
+    text: string;
+  }>;
+}
+
+export interface CheckpointRecord {
+  id: string;
+  sessionId: string;
+  sequence: number;
+  createdAt: string;
+  workspacePath: string;
+  toolName: string;
+  toolCallId: string;
+  ok: boolean;
+  changedFiles: string[];
+  patchPath: string;
+  beforeTree: string;
+  afterTree: string;
+  resultSummary: string;
+}
+
+export interface CheckpointRestoreResult {
+  ok: boolean;
+  checkpointId: string;
+  command: string;
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  durationMs: number;
+}

--- a/packages/agent-core/src/tools/edit.ts
+++ b/packages/agent-core/src/tools/edit.ts
@@ -77,7 +77,7 @@ export async function executeEditTool(args: unknown, context: ToolExecutionConte
     return {
       ok: true,
       content: `Edited ${relativePath} (${replacements} replacement(s))`,
-      metadata: { path: filePath, relativePath, replacements }
+      metadata: { path: filePath, relativePath, changedFiles: [relativePath], replacements }
     };
   } catch (error) {
     return { ok: false, content: error instanceof Error ? error.message : String(error) };

--- a/packages/agent-core/src/tools/index.ts
+++ b/packages/agent-core/src/tools/index.ts
@@ -7,6 +7,8 @@ export { executeListTool } from "./list.js";
 export { executeGlobTool, matchesSimpleGlob } from "./glob.js";
 export { executeGrepTool } from "./grep.js";
 export { executeRepoQueryTool } from "./repo-query.js";
+export { executeSymbolSearchTool } from "./symbol-search.js";
+export { executeValidateTool } from "./validate.js";
 export { executeGitStatusTool, executeGitDiffTool } from "./git.js";
 export { executeApplyPatchTool } from "./apply-patch.js";
 export { executeTodoTool } from "./todo.js";

--- a/packages/agent-core/src/tools/registry.ts
+++ b/packages/agent-core/src/tools/registry.ts
@@ -19,6 +19,8 @@ import { executeGitStatusTool, executeGitDiffTool } from "./git.js";
 import { executeApplyPatchTool } from "./apply-patch.js";
 import { executeTodoTool } from "./todo.js";
 import { executeRepoQueryTool } from "./repo-query.js";
+import { executeSymbolSearchTool } from "./symbol-search.js";
+import { executeValidateTool } from "./validate.js";
 import { createShellSessionToolController } from "./shell-session.js";
 
 const bashTool: RegisteredTool = {
@@ -234,6 +236,55 @@ const repoQueryTool: RegisteredTool = {
   risk: "read"
 };
 
+const symbolSearchTool: RegisteredTool = {
+  definition: {
+    type: "function",
+    function: {
+      name: "symbol_search",
+      description:
+        "Search declared functions, classes, interfaces, types, constants, and tests using Sigma's lightweight local code index.",
+      parameters: {
+        type: "object",
+        properties: {
+          query: { type: "string" },
+          kind: { type: "string", enum: ["function", "class", "interface", "type", "const", "method", "test", "unknown"] },
+          path: { type: "string" },
+          maxResults: { type: "number" },
+          maxChars: { type: "number" }
+        },
+        required: ["query"],
+        additionalProperties: false
+      }
+    }
+  },
+  execute: executeSymbolSearchTool,
+  risk: "read"
+};
+
+const validateTool: RegisteredTool = {
+  definition: {
+    type: "function",
+    function: {
+      name: "validate",
+      description:
+        "Run an in-loop validation command or infer a project validation command for changed files, a file, or the whole project.",
+      parameters: {
+        type: "object",
+        properties: {
+          kind: { type: "string", enum: ["auto", "test", "lint", "typecheck", "build"] },
+          scope: { type: "string", enum: ["changed", "project", "file"] },
+          path: { type: "string" },
+          command: { type: "string" },
+          timeoutSec: { type: "number" }
+        },
+        additionalProperties: false
+      }
+    }
+  },
+  execute: executeValidateTool,
+  risk: "execute"
+};
+
 function createShellSessionTool(): RegisteredTool & { registryClose: ToolRegistry["close"] } {
   const controller = createShellSessionToolController();
   return {
@@ -397,9 +448,11 @@ export function createDefaultToolRegistry(_options: ToolRegistryOptions = {}): T
       globTool,
       grepTool,
       repoQueryTool,
+      symbolSearchTool,
       gitStatusTool,
       gitDiffTool,
       applyPatchTool,
+      validateTool,
       todoTool,
       createShellSessionTool()
     ],

--- a/packages/agent-core/src/tools/registry.ts
+++ b/packages/agent-core/src/tools/registry.ts
@@ -5,7 +5,8 @@ import type {
   ToolRegistry,
   ToolRegistryFilter,
   ToolRegistryOptions,
-  ToolResult
+  ToolResult,
+  WorkspaceManifest
 } from "../types.js";
 import { executeBashTool } from "./bash.js";
 import { executeReadTool } from "./read.js";
@@ -22,6 +23,60 @@ import { executeRepoQueryTool } from "./repo-query.js";
 import { executeSymbolSearchTool } from "./symbol-search.js";
 import { executeValidateTool } from "./validate.js";
 import { createShellSessionToolController } from "./shell-session.js";
+import { invalidateContextIndexes } from "../context/code-index.js";
+import { changedWorkspaceFiles, listWorkspaceManifest } from "../harness/manifest.js";
+
+const FILE_MUTATING_TOOLS = new Set(["write", "edit", "apply_patch", "bash", "shell_session", "service"]);
+
+function resultChangedFiles(result: ToolResult): string[] {
+  const metadata = result.metadata ?? {};
+  if (metadata.checkOnly === true) return [];
+  const changedFiles = metadata.changedFiles;
+  if (Array.isArray(changedFiles)) return changedFiles.filter((file): file is string => typeof file === "string" && file.length > 0);
+  if (typeof metadata.relativePath === "string" && metadata.relativePath.length > 0) return [metadata.relativePath];
+  return [];
+}
+
+function contextIndexCacheActive(context: ToolExecutionContext): boolean {
+  return (context.runState.contextIndexes?.size ?? 0) > 0;
+}
+
+async function safeWorkspaceManifest(context: ToolExecutionContext): Promise<WorkspaceManifest | null> {
+  try {
+    return await listWorkspaceManifest(context.workspacePath);
+  } catch {
+    return null;
+  }
+}
+
+function manifestChangedFiles(before: WorkspaceManifest, after: WorkspaceManifest): string[] {
+  const changed = new Set(changedWorkspaceFiles(before, after));
+  for (const filePath of Object.keys(before)) {
+    if (!after[filePath]) changed.add(filePath);
+  }
+  return [...changed].sort((a, b) => a.localeCompare(b, "en"));
+}
+
+async function executeWithContextIndexInvalidation(
+  tool: RegisteredTool,
+  toolCall: ToolCall,
+  context: ToolExecutionContext
+): Promise<ToolResult> {
+  const toolName = toolCall.function.name;
+  const shouldWatchManifest = FILE_MUTATING_TOOLS.has(toolName) && contextIndexCacheActive(context);
+  const beforeManifest = shouldWatchManifest ? await safeWorkspaceManifest(context) : null;
+  const result = await tool.execute(toolCall.function.arguments, context);
+  if (!result.ok || !FILE_MUTATING_TOOLS.has(toolName)) return result;
+
+  const changedFiles = resultChangedFiles(result);
+  const manifestChanges = beforeManifest
+    ? manifestChangedFiles(beforeManifest, await safeWorkspaceManifest(context) ?? beforeManifest)
+    : [];
+  if (changedFiles.length > 0 || manifestChanges.length > 0) {
+    invalidateContextIndexes(context);
+  }
+  return result;
+}
 
 const bashTool: RegisteredTool = {
   definition: {
@@ -423,7 +478,7 @@ export function createToolRegistryFromTools(
       if (!tool) {
         return { ok: false, content: `Unknown tool: ${toolCall.function.name}` };
       }
-      return await tool.execute(toolCall.function.arguments, context);
+      return await executeWithContextIndexInvalidation(tool, toolCall, context);
     },
     async close(): Promise<void> {
       const closers = new Set<ToolRegistry["close"]>();

--- a/packages/agent-core/src/tools/repo-query.ts
+++ b/packages/agent-core/src/tools/repo-query.ts
@@ -1,14 +1,11 @@
-import { readFile, stat } from "node:fs/promises";
-import path from "node:path";
+import { readFile } from "node:fs/promises";
 import { truncateMiddle } from "../compaction.js";
-import type { ToolExecutionContext, ToolResult } from "../types.js";
-import { workspaceRelativePath } from "../policy.js";
 import {
-  explicitPathIncludesIgnored,
-  resolveWorkspaceRelativePath,
-  walkFiles,
-  type WalkFile
-} from "./workspace-utils.js";
+  getCodeIndexForTool,
+  type CodeIndexFile,
+  type CodeSymbol
+} from "../context/code-index.js";
+import type { ToolExecutionContext, ToolResult } from "../types.js";
 
 type RepoQueryKind = "text" | "symbol" | "test" | "config" | "path";
 
@@ -20,30 +17,17 @@ interface RepoQueryArgs {
   maxChars?: unknown;
 }
 
-interface RepoQueryMatch {
+export interface RepoQueryMatch {
   path: string;
   lineStart: number;
   lineEnd: number;
   score: number;
+  reasons: string[];
   snippet: string;
 }
 
 const MAX_FILE_BYTES = 256000;
 const MAX_FILES = 20000;
-const CONFIG_NAMES = new Set([
-  "package.json",
-  "tsconfig.json",
-  "pyproject.toml",
-  "requirements.txt",
-  "go.mod",
-  "Cargo.toml",
-  "pom.xml",
-  "build.gradle",
-  "build.gradle.kts",
-  "Makefile",
-  ".eslintrc",
-  ".prettierrc"
-]);
 
 function numberOrDefault(value: unknown, fallback: number, min: number, max: number): number {
   if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
@@ -55,45 +39,75 @@ function kindValue(value: unknown): RepoQueryKind {
 }
 
 function tokenize(text: string): string[] {
-  return text
+  const tokens = text
     .toLowerCase()
-    .split(/[^a-z0-9_.+-]+/)
+    .split(/[^a-z0-9_.@/$+-]+/)
     .map((token) => token.trim())
     .filter((token) => token.length >= 2);
+  return [...new Set(tokens)];
 }
 
-function isBinary(buffer: Buffer): boolean {
-  return buffer.subarray(0, Math.min(buffer.length, 4096)).includes(0);
+function fileMentions(query: string): string[] {
+  return query
+    .split(/\s+/)
+    .map((token) => token.trim().replace(/^["'`]|["'`,.;:]$/g, ""))
+    .filter((token) => /(?:^|\/)[A-Za-z0-9_.-]+\.[A-Za-z0-9]+$/.test(token) || token.includes("/"))
+    .map((token) => token.replace(/\\/g, "/").toLowerCase());
 }
 
-function isTestPath(filePath: string): boolean {
-  return /(^|\/)(test|tests|__tests__)(\/|$)|[._-](test|spec)\.[A-Za-z0-9]+$/.test(filePath);
+function tokenHits(text: string, tokens: string[]): number {
+  const lower = text.toLowerCase();
+  return tokens.filter((token) => lower.includes(token)).length;
 }
 
-function isConfigPath(filePath: string): boolean {
-  const base = filePath.split("/").pop() ?? filePath;
-  return CONFIG_NAMES.has(base) || /(^|\/)\.(github|agent|vscode|config)(\/|$)/.test(filePath);
-}
-
-function looksLikeSymbolLine(line: string): boolean {
-  return /^\s*(export\s+)?(async\s+)?(function|class|interface|type|const|let|var|def|struct|enum|trait|impl)\s+[A-Za-z0-9_$]+/.test(
-    line
-  );
-}
-
-function looksLikeTestLine(line: string): boolean {
-  return /\b(describe|it|test)\s*\(|\b(assert|expect)\s*\(/.test(line);
-}
-
-function pathScore(file: WalkFile, tokens: string[], kind: RepoQueryKind): number {
-  const lowerPath = file.relativePath.toLowerCase();
+function symbolScore(symbol: CodeSymbol, tokens: string[]): { score: number; reasons: string[] } {
+  const lowerName = symbol.name.toLowerCase();
   let score = 0;
+  const reasons: string[] = [];
   for (const token of tokens) {
-    if (lowerPath.includes(token)) score += 8;
+    if (lowerName === token) {
+      score += 36;
+      reasons.push("symbol:exact");
+    } else if (lowerName.includes(token)) {
+      score += 18;
+      reasons.push("symbol:partial");
+    }
   }
-  if (kind === "test" && isTestPath(file.relativePath)) score += 20;
-  if (kind === "config" && isConfigPath(file.relativePath)) score += 20;
-  return score;
+  if (symbol.exported && score > 0) {
+    score += 6;
+    reasons.push("symbol:exported");
+  }
+  return { score, reasons };
+}
+
+function fileBaseScore(file: CodeIndexFile, tokens: string[], mentions: string[], kind: RepoQueryKind): {
+  score: number;
+  reasons: string[];
+} {
+  let score = 0;
+  const reasons: string[] = [];
+  const lowerPath = file.path.toLowerCase();
+  for (const token of tokens) {
+    if (lowerPath.includes(token)) {
+      score += 9;
+      reasons.push("path");
+    }
+  }
+  for (const mention of mentions) {
+    if (lowerPath.endsWith(mention) || lowerPath.includes(mention)) {
+      score += 30;
+      reasons.push("file-mention");
+    }
+  }
+  if (kind === "test" && file.isTest) {
+    score += 24;
+    reasons.push("test-file");
+  }
+  if (kind === "config" && file.isConfig) {
+    score += 24;
+    reasons.push("config-file");
+  }
+  return { score, reasons: [...new Set(reasons)] };
 }
 
 function snippetForLines(lines: string[], index: number, radius: number): { lineStart: number; lineEnd: number; snippet: string } {
@@ -106,64 +120,97 @@ function snippetForLines(lines: string[], index: number, radius: number): { line
   };
 }
 
-async function scoreFile(options: {
-  file: WalkFile;
+function pathOnlyMatch(file: CodeIndexFile, base: { score: number; reasons: string[] }): RepoQueryMatch | null {
+  if (base.score <= 0) return null;
+  return {
+    path: file.path,
+    lineStart: 1,
+    lineEnd: 1,
+    score: base.score,
+    reasons: base.reasons,
+    snippet: file.path
+  };
+}
+
+async function textMatches(options: {
+  file: CodeIndexFile;
   tokens: string[];
+  baseScore: number;
+  baseReasons: string[];
   kind: RepoQueryKind;
 }): Promise<RepoQueryMatch[]> {
-  const matches: RepoQueryMatch[] = [];
-  const basePathScore = pathScore(options.file, options.tokens, options.kind);
-
-  if (options.kind === "path" && basePathScore > 0) {
-    matches.push({
-      path: options.file.relativePath,
-      lineStart: 1,
-      lineEnd: 1,
-      score: basePathScore,
-      snippet: options.file.relativePath
-    });
-    return matches;
-  }
-  if (options.kind === "path") return [];
-
-  const info = await stat(options.file.absolutePath);
-  if (info.size > MAX_FILE_BYTES) return [];
-  const buffer = await readFile(options.file.absolutePath);
-  if (isBinary(buffer)) return [];
-  const text = buffer.toString("utf8");
+  if (options.file.size > MAX_FILE_BYTES) return [];
+  const text = await readFile(options.file.absolutePath, "utf8");
   const lines = text.split(/\r?\n/);
-  const isConfigFile = isConfigPath(options.file.relativePath);
-  const isTestFile = isTestPath(options.file.relativePath);
-
+  const matches: RepoQueryMatch[] = [];
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index];
-    const lowerLine = line.toLowerCase();
-    const tokenHits = options.tokens.filter((token) => lowerLine.includes(token)).length;
-    const isSymbolLine = looksLikeSymbolLine(line);
-    const isTestLine = looksLikeTestLine(line);
+    const hits = tokenHits(line, options.tokens);
+    if (hits === 0) continue;
+    if (options.kind === "test" && !options.file.isTest && !/\b(describe|it|test|expect|assert)\b/.test(line)) continue;
+    if (options.kind === "config" && !options.file.isConfig) continue;
+    if (options.kind === "symbol" && !/^\s*(?:export\s+)?(?:async\s+)?(?:function|class|interface|type|const|def|func|struct|enum|trait)\b/.test(line)) continue;
 
-    if (options.kind === "text" && tokenHits === 0) continue;
-    if (options.kind === "symbol" && (tokenHits === 0 || !isSymbolLine)) continue;
-    if (options.kind === "config" && (tokenHits === 0 || !isConfigFile)) continue;
-    if (options.kind === "test" && (tokenHits === 0 || (!isTestFile && !isTestLine))) continue;
-
-    let score = basePathScore + tokenHits * 10;
-    for (const token of options.tokens) {
-      if (lowerLine === token) score += 4;
-    }
-    if (options.kind === "symbol") score += 18;
-    if (options.kind === "config") score += 8;
+    const reasons = [...options.baseReasons, "text"];
+    let score = options.baseScore + hits * 10;
+    if (options.kind === "symbol") score += 12;
     if (options.kind === "test") score += 8;
-    if (score <= 0) continue;
+    if (options.kind === "config") score += 8;
     const snippet = snippetForLines(lines, index, options.kind === "symbol" ? 1 : 2);
     matches.push({
-      path: options.file.relativePath,
+      path: options.file.path,
       lineStart: snippet.lineStart,
       lineEnd: snippet.lineEnd,
       score,
+      reasons: [...new Set(reasons)],
       snippet: snippet.snippet
     });
   }
+  return matches;
+}
+
+function symbolMatches(options: {
+  file: CodeIndexFile;
+  tokens: string[];
+  baseScore: number;
+  baseReasons: string[];
+  kind: RepoQueryKind;
+}): RepoQueryMatch[] {
+  const matches: RepoQueryMatch[] = [];
+  for (const symbol of options.file.symbols) {
+    const scored = symbolScore(symbol, options.tokens);
+    if (scored.score <= 0) continue;
+    if (options.kind === "test" && symbol.kind !== "test" && !options.file.isTest) continue;
+    const reasons = [...options.baseReasons, ...scored.reasons];
+    matches.push({
+      path: options.file.path,
+      lineStart: symbol.line,
+      lineEnd: symbol.line,
+      score: options.baseScore + scored.score,
+      reasons: [...new Set(reasons)],
+      snippet: `${symbol.exported ? "export " : ""}${symbol.kind} ${symbol.name}`
+    });
+  }
+  return matches;
+}
+
+function importReferenceMatches(options: {
+  file: CodeIndexFile;
+  tokens: string[];
+  baseScore: number;
+  baseReasons: string[];
+}): RepoQueryMatch[] {
+  const matches: RepoQueryMatch[] = [];
+  const imports = options.file.imports.filter((item) => tokenHits(item, options.tokens) > 0);
+  if (imports.length === 0) return matches;
+  matches.push({
+    path: options.file.path,
+    lineStart: 1,
+    lineEnd: 1,
+    score: options.baseScore + imports.length * 14,
+    reasons: [...new Set([...options.baseReasons, "import/reference"])],
+    snippet: `imports: ${imports.join(", ")}`
+  });
   return matches;
 }
 
@@ -177,40 +224,34 @@ export async function executeRepoQueryTool(args: unknown, context: ToolExecution
   const maxSnippets = numberOrDefault(parsed.maxSnippets, 8, 1, 50);
   const maxChars = numberOrDefault(parsed.maxChars, context.maxToolOutputChars, 500, 50000);
   const tokens = tokenize(parsed.query);
-  if (tokens.length === 0) return { ok: false, content: "repo_query query did not contain searchable tokens" };
-
-  let rootPath: string;
-  let rootRelative: string;
-  try {
-    const resolved = resolveWorkspaceRelativePath(context.workspacePath, requestedPath);
-    rootPath = resolved.absolutePath;
-    rootRelative = resolved.relativePath;
-  } catch (error) {
-    return { ok: false, content: error instanceof Error ? error.message : String(error) };
+  const mentions = fileMentions(parsed.query);
+  if (tokens.length === 0 && mentions.length === 0) {
+    return { ok: false, content: "repo_query query did not contain searchable tokens" };
   }
 
   try {
-    const rootInfo = await stat(rootPath);
-    const walked = rootInfo.isFile()
-      ? {
-          files: [{ absolutePath: rootPath, relativePath: workspaceRelativePath(context.workspacePath, rootPath) }],
-          truncated: false
-        }
-      : await walkFiles({
-          workspacePath: context.workspacePath,
-          rootPath,
-          maxFiles: MAX_FILES,
-          explicitIncludesIgnored: explicitPathIncludesIgnored(rootRelative)
-        });
+    const index = await getCodeIndexForTool(context, {
+      path: requestedPath,
+      maxFiles: MAX_FILES,
+      maxFileBytes: MAX_FILE_BYTES
+    });
     const matches: RepoQueryMatch[] = [];
-    for (const file of walked.files) {
-      matches.push(...(await scoreFile({ file, tokens, kind })));
+    for (const file of index.files) {
+      const base = fileBaseScore(file, tokens, mentions, kind);
+      if (kind === "path") {
+        const pathMatch = pathOnlyMatch(file, base);
+        if (pathMatch) matches.push(pathMatch);
+        continue;
+      }
+      matches.push(...symbolMatches({ file, tokens, baseScore: base.score, baseReasons: base.reasons, kind }));
+      matches.push(...importReferenceMatches({ file, tokens, baseScore: base.score, baseReasons: base.reasons }));
+      matches.push(...(await textMatches({ file, tokens, baseScore: base.score, baseReasons: base.reasons, kind })));
     }
     matches.sort((a, b) => b.score - a.score || a.path.localeCompare(b.path, "en") || a.lineStart - b.lineStart);
     const selected: RepoQueryMatch[] = [];
     const seen = new Set<string>();
     for (const match of matches) {
-      const key = `${match.path}:${match.lineStart}:${match.lineEnd}`;
+      const key = `${match.path}:${match.lineStart}:${match.lineEnd}:${match.snippet}`;
       if (seen.has(key)) continue;
       seen.add(key);
       selected.push(match);
@@ -221,7 +262,7 @@ export async function executeRepoQueryTool(args: unknown, context: ToolExecution
         query: parsed.query,
         kind,
         matches: selected,
-        truncated: walked.truncated || matches.length > selected.length
+        truncated: index.truncated || matches.length > selected.length
       },
       null,
       2
@@ -232,7 +273,7 @@ export async function executeRepoQueryTool(args: unknown, context: ToolExecution
       content: truncated.text,
       metadata: {
         matches: selected,
-        truncated: walked.truncated || matches.length > selected.length || truncated.truncated
+        truncated: index.truncated || matches.length > selected.length || truncated.truncated
       }
     };
   } catch (error) {

--- a/packages/agent-core/src/tools/symbol-search.ts
+++ b/packages/agent-core/src/tools/symbol-search.ts
@@ -1,0 +1,97 @@
+import { truncateMiddle } from "../compaction.js";
+import { getCodeIndexForTool, type CodeSymbol } from "../context/code-index.js";
+import type { ToolExecutionContext, ToolResult } from "../types.js";
+
+interface SymbolSearchArgs {
+  query?: unknown;
+  kind?: unknown;
+  path?: unknown;
+  maxResults?: unknown;
+  maxChars?: unknown;
+}
+
+interface SymbolSearchMatch {
+  path: string;
+  name: string;
+  kind: CodeSymbol["kind"];
+  line: number;
+  score: number;
+  exported: boolean;
+}
+
+function numberOrDefault(value: unknown, fallback: number, min: number, max: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+  return Math.max(min, Math.min(max, Math.floor(value)));
+}
+
+function tokenize(text: string): string[] {
+  return [...new Set(text.toLowerCase().split(/[^a-z0-9_$.-]+/).map((token) => token.trim()).filter((token) => token.length >= 2))];
+}
+
+function scoreSymbol(symbol: CodeSymbol, filePath: string, tokens: string[]): number {
+  const name = symbol.name.toLowerCase();
+  const lowerPath = filePath.toLowerCase();
+  let score = 0;
+  for (const token of tokens) {
+    if (name === token) score += 50;
+    else if (name.includes(token)) score += 24;
+    if (lowerPath.includes(token)) score += 8;
+  }
+  if (symbol.exported) score += 5;
+  return score;
+}
+
+export async function executeSymbolSearchTool(args: unknown, context: ToolExecutionContext): Promise<ToolResult> {
+  const parsed = (args && typeof args === "object" ? args : {}) as SymbolSearchArgs;
+  if (typeof parsed.query !== "string" || parsed.query.trim().length === 0) {
+    return { ok: false, content: "symbol_search requires a non-empty query string" };
+  }
+  const tokens = tokenize(parsed.query);
+  if (tokens.length === 0) return { ok: false, content: "symbol_search query did not contain searchable tokens" };
+  const kind = typeof parsed.kind === "string" && parsed.kind.length > 0 ? parsed.kind : null;
+  const requestedPath = typeof parsed.path === "string" && parsed.path.length > 0 ? parsed.path : ".";
+  const maxResults = numberOrDefault(parsed.maxResults, 20, 1, 100);
+  const maxChars = numberOrDefault(parsed.maxChars, context.maxToolOutputChars, 500, 50000);
+
+  try {
+    const index = await getCodeIndexForTool(context, { path: requestedPath });
+    const matches: SymbolSearchMatch[] = [];
+    for (const file of index.files) {
+      for (const symbol of file.symbols) {
+        if (kind && symbol.kind !== kind) continue;
+        const score = scoreSymbol(symbol, file.path, tokens);
+        if (score <= 0) continue;
+        matches.push({
+          path: file.path,
+          name: symbol.name,
+          kind: symbol.kind,
+          line: symbol.line,
+          score,
+          exported: symbol.exported
+        });
+      }
+    }
+    matches.sort((a, b) => b.score - a.score || a.path.localeCompare(b.path, "en") || a.line - b.line);
+    const selected = matches.slice(0, maxResults);
+    const content = JSON.stringify(
+      {
+        query: parsed.query,
+        matches: selected,
+        truncated: index.truncated || matches.length > selected.length
+      },
+      null,
+      2
+    );
+    const truncated = truncateMiddle(content, maxChars);
+    return {
+      ok: true,
+      content: truncated.text,
+      metadata: {
+        matches: selected,
+        truncated: index.truncated || matches.length > selected.length || truncated.truncated
+      }
+    };
+  } catch (error) {
+    return { ok: false, content: error instanceof Error ? error.message : String(error) };
+  }
+}

--- a/packages/agent-core/src/tools/symbol-search.ts
+++ b/packages/agent-core/src/tools/symbol-search.ts
@@ -37,7 +37,7 @@ function scoreSymbol(symbol: CodeSymbol, filePath: string, tokens: string[]): nu
     else if (name.includes(token)) score += 24;
     if (lowerPath.includes(token)) score += 8;
   }
-  if (symbol.exported) score += 5;
+  if (symbol.exported && score > 0) score += 5;
   return score;
 }
 

--- a/packages/agent-core/src/tools/validate.ts
+++ b/packages/agent-core/src/tools/validate.ts
@@ -1,0 +1,168 @@
+import { truncateMiddle } from "../compaction.js";
+import { evidenceKindForCommand } from "../controller/evidence.js";
+import { planValidationCommandSpecs } from "../harness/validation-planner.js";
+import { runHarnessCommand } from "../harness/validation.js";
+import { requestToolPermission } from "../policy.js";
+import type { ToolExecutionContext, ToolResult } from "../types.js";
+
+type ValidateKind = "auto" | "test" | "lint" | "typecheck" | "build";
+type ValidateScope = "changed" | "project" | "file";
+
+interface ValidateArgs {
+  kind?: unknown;
+  scope?: unknown;
+  path?: unknown;
+  command?: unknown;
+  timeoutSec?: unknown;
+}
+
+interface Diagnostic {
+  file?: string;
+  line?: number;
+  column?: number;
+  severity: "error" | "warning" | "info";
+  message: string;
+}
+
+function kindValue(value: unknown): ValidateKind {
+  return value === "test" || value === "lint" || value === "typecheck" || value === "build" ? value : "auto";
+}
+
+function scopeValue(value: unknown): ValidateScope {
+  return value === "project" || value === "file" ? value : "changed";
+}
+
+function numberValue(value: unknown, fallback: number, min: number, max: number): number {
+  const parsed = typeof value === "number" ? value : typeof value === "string" ? Number(value) : Number.NaN;
+  return Number.isFinite(parsed) ? Math.max(min, Math.min(max, Math.floor(parsed))) : fallback;
+}
+
+function tailText(value: string, limit = 4000): string {
+  return value.length <= limit ? value : value.slice(-limit);
+}
+
+function projectScopeSeedFiles(kind: ValidateKind): string[] {
+  if (kind === "test") return ["package.json", "pyproject.toml", "go.mod", "Cargo.toml", "pom.xml", "build.gradle"];
+  if (kind === "build" || kind === "typecheck" || kind === "lint") return ["package.json", "tsconfig.json", "pyproject.toml"];
+  return ["package.json", "pyproject.toml", "go.mod", "Cargo.toml", "pom.xml", "build.gradle"];
+}
+
+function parseDiagnostics(text: string): Diagnostic[] {
+  const diagnostics: Diagnostic[] = [];
+  for (const line of text.split(/\r?\n/)) {
+    const ts = line.match(/^(.+?)\((\d+),(\d+)\):\s+(error|warning)\s+([^:]+):\s+(.+)$/);
+    if (ts) {
+      diagnostics.push({
+        file: ts[1],
+        line: Number(ts[2]),
+        column: Number(ts[3]),
+        severity: ts[4] === "warning" ? "warning" : "error",
+        message: `${ts[5]}: ${ts[6]}`
+      });
+      continue;
+    }
+    const pytest = line.match(/^(.+?):(\d+):\s*(.+)$/);
+    if (pytest && /(failed|error|assert|syntaxerror|traceback)/i.test(line)) {
+      diagnostics.push({
+        file: pytest[1],
+        line: Number(pytest[2]),
+        severity: "error",
+        message: pytest[3]
+      });
+    }
+  }
+  return diagnostics.slice(0, 50);
+}
+
+function commandMatchesKind(command: string, kind: ValidateKind): boolean {
+  if (kind === "auto") return true;
+  return evidenceKindForCommand(command) === kind;
+}
+
+async function inferCommand(options: {
+  args: ValidateArgs;
+  kind: ValidateKind;
+  scope: ValidateScope;
+  context: ToolExecutionContext;
+}): Promise<{ command: string; source: string; relatedFiles: string[] } | null> {
+  const changedFiles = options.scope === "file"
+    ? typeof options.args.path === "string" ? [options.args.path] : []
+    : options.scope === "project"
+      ? projectScopeSeedFiles(options.kind)
+      : [...options.context.runState.changedFiles];
+  const specs = await planValidationCommandSpecs({
+    workspacePath: options.context.workspacePath,
+    changedFiles
+  });
+  return specs.find((spec) => commandMatchesKind(spec.command, options.kind)) ?? specs[0] ?? null;
+}
+
+export async function executeValidateTool(args: unknown, context: ToolExecutionContext): Promise<ToolResult> {
+  const parsed = (args && typeof args === "object" ? args : {}) as ValidateArgs;
+  const kind = kindValue(parsed.kind);
+  const scope = scopeValue(parsed.scope);
+  const explicitCommand = typeof parsed.command === "string" && parsed.command.trim().length > 0
+    ? parsed.command.trim()
+    : null;
+  const timeoutSec = numberValue(parsed.timeoutSec, context.commandTimeoutSec, 1, 3600);
+  const inferred = explicitCommand
+    ? { command: explicitCommand, source: "explicit", relatedFiles: typeof parsed.path === "string" ? [parsed.path] : [] }
+    : await inferCommand({ args: parsed, kind, scope, context });
+
+  if (!inferred) {
+    return {
+      ok: false,
+      content: JSON.stringify({
+        ok: false,
+        kind,
+        scope,
+        command: null,
+        diagnostics: [],
+        message: "No validation command could be inferred. Provide command explicitly."
+      }, null, 2)
+    };
+  }
+
+  const denied = await requestToolPermission(context, {
+    toolName: "validate",
+    arguments: { ...parsed, command: inferred.command },
+    risk: "execute",
+    reason: `Run validation command: ${inferred.command}`
+  });
+  if (denied) return denied;
+
+  const result = await runHarnessCommand({
+    kind: "validation",
+    source: inferred.source,
+    command: inferred.command,
+    workspacePath: context.workspacePath,
+    attempt: 1,
+    timeoutSec,
+    relatedFiles: inferred.relatedFiles
+  });
+  const stdoutTail = tailText(result.stdout_tail);
+  const stderrTail = tailText(result.stderr_tail);
+  const diagnostics = parseDiagnostics(`${stdoutTail}\n${stderrTail}`);
+  const payload = {
+    ok: result.exit_code === 0,
+    command: result.command,
+    kind: kind === "auto" ? evidenceKindForCommand(result.command) : kind,
+    scope,
+    exitCode: result.exit_code,
+    durationMs: result.duration_ms,
+    stdoutTail,
+    stderrTail,
+    relatedFiles: result.related_files,
+    diagnostics
+  };
+  const content = JSON.stringify(payload, null, 2);
+  const truncated = truncateMiddle(content, context.maxToolOutputChars);
+  return {
+    ok: result.exit_code === 0,
+    content: truncated.text,
+    metadata: {
+      ...payload,
+      truncated: truncated.truncated
+    }
+  };
+}

--- a/packages/agent-core/src/tools/write.ts
+++ b/packages/agent-core/src/tools/write.ts
@@ -47,6 +47,7 @@ export async function executeWriteTool(args: unknown, context: ToolExecutionCont
       metadata: {
         path: filePath,
         relativePath,
+        changedFiles: [relativePath],
         bytes: Buffer.byteLength(parsed.content, "utf8")
       }
     };

--- a/packages/agent-core/src/types.ts
+++ b/packages/agent-core/src/types.ts
@@ -138,6 +138,7 @@ export interface AgentRunState {
   nextTodoId: number;
   changedFiles: Set<string>;
   contextIndexes?: Map<string, unknown>;
+  contextIndexVersion?: number;
 }
 
 export type ContextMode = "off" | "repo-map";

--- a/packages/agent-core/src/types.ts
+++ b/packages/agent-core/src/types.ts
@@ -96,6 +96,7 @@ export interface ToolExecutionContext {
   permissionDecider?: PermissionDecider;
   runState: AgentRunState;
   alwaysAllowTools: Set<string>;
+  abortSignal?: AbortSignal;
 }
 
 export interface ToolHandler {
@@ -136,6 +137,7 @@ export interface AgentRunState {
   todos: TodoItem[];
   nextTodoId: number;
   changedFiles: Set<string>;
+  contextIndexes?: Map<string, unknown>;
 }
 
 export type ContextMode = "off" | "repo-map";
@@ -151,6 +153,11 @@ export interface AgentRunConfig {
   instruction: string;
   workspacePath: string;
   modelClient: ModelClient;
+  sessionId?: string;
+  sessionRootDir?: string;
+  durableSession?: boolean;
+  parentSessionId?: string;
+  forkedFromSessionId?: string;
   maxTurns?: number;
   maxWallTimeSec?: number;
   commandTimeoutSec?: number;
@@ -176,6 +183,7 @@ export interface AgentRunConfig {
   finalEvidenceMode?: AgentFinalEvidenceMode;
   skillsMode?: AgentSkillsMode;
   skillsMaxChars?: number;
+  abortSignal?: AbortSignal;
 }
 
 export interface AgentHarnessConfig extends AgentRunConfig {
@@ -200,6 +208,11 @@ export interface AgentEvent {
   timestamp: string;
   type:
     | "run_start"
+    | "assistant_delta"
+    | "reasoning_delta"
+    | "tool_call_delta"
+    | "model_heartbeat"
+    | "run_abort"
     | "model_start"
     | "model_end"
     | "assistant_message"
@@ -211,6 +224,7 @@ export interface AgentEvent {
     | "error"
     | "run_end";
   runId: string;
+  sessionId?: string;
   parentId?: string;
   provider?: string;
   model?: string;
@@ -225,6 +239,7 @@ export interface TokenTotals {
 }
 
 export interface AgentRunResult {
+  sessionId?: string;
   status: AgentRunStatus;
   finishReason: AgentFinishReason;
   turns: number;
@@ -326,6 +341,7 @@ export type RunControllerCleanupResult = HarnessCleanupResult;
 export type RunControllerServiceCleanupResult = HarnessServiceCleanupResult;
 
 export interface SummaryJson {
+  session_id?: string;
   status: AgentRunStatus;
   finish_reason: AgentFinishReason;
   turns: number;

--- a/tests/agent-cli.sessions.test.ts
+++ b/tests/agent-cli.sessions.test.ts
@@ -1,0 +1,109 @@
+import { mkdir, mkdtemp, readFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { Writable } from "node:stream";
+import { describe, expect, it } from "vitest";
+import type { ModelClient, ModelRequest, ModelResponse, ProviderName, ProviderOptions } from "../packages/agent-ai/src/index.js";
+import { loadSessionMeta } from "../packages/agent-core/src/index.js";
+import { runSessionCommand, runSessionsCommand } from "../packages/agent-cli/src/commands/session.js";
+import { runRunCommand } from "../packages/agent-cli/src/commands/solve.js";
+
+class FinalModel implements ModelClient {
+  readonly provider = "deepseek" as const;
+  readonly model = "fake-cli-session-model";
+
+  async complete(_req: ModelRequest): Promise<ModelResponse> {
+    return { message: { role: "assistant", content: "cli session done" } };
+  }
+}
+
+class MemoryWritable extends Writable {
+  readonly chunks: string[] = [];
+  isTTY = true;
+
+  _write(chunk: Buffer | string, _encoding: BufferEncoding, callback: (error?: Error | null) => void): void {
+    this.chunks.push(Buffer.isBuffer(chunk) ? chunk.toString("utf8") : chunk);
+    callback();
+  }
+
+  text(): string {
+    return this.chunks.join("");
+  }
+}
+
+async function workspace(): Promise<string> {
+  return await mkdtemp(path.join(os.tmpdir(), "sigma-cli-session-"));
+}
+
+function fakeFactory(_provider: ProviderName, _options: ProviderOptions): ModelClient {
+  return new FinalModel();
+}
+
+describe("agent-cli sessions", () => {
+  it("lists, shows, and searches durable sessions", async () => {
+    const dir = await workspace();
+    const runStdout = new MemoryWritable();
+    const code = await runRunCommand(
+      ["Investigate flaky parser", "--workspace", dir, "--provider", "deepseek", "--permission-mode", "yolo", "--no-stream-ui"],
+      { stdout: runStdout, modelClientFactory: fakeFactory }
+    );
+    expect(code).toBe(0);
+
+    const sessionsStdout = new MemoryWritable();
+    await expect(runSessionsCommand(["--workspace", dir], { stdout: sessionsStdout })).resolves.toBe(0);
+    expect(sessionsStdout.text()).toContain("Investigate flaky parser");
+
+    const records = JSON.parse(await readFile(path.join(dir, ".agent", "sessions", "index.jsonl"), "utf8")
+      .then((text) => `[${text.trim().split(/\r?\n/).join(",")}]`)) as Array<{ sessionId: string }>;
+    const sessionId = records[records.length - 1].sessionId;
+
+    const showStdout = new MemoryWritable();
+    await expect(runSessionCommand(["show", sessionId, "--workspace", dir, "--json"], { stdout: showStdout })).resolves.toBe(0);
+    expect(JSON.parse(showStdout.text())).toMatchObject({
+      meta: { sessionId, title: "Investigate flaky parser" },
+      eventCount: expect.any(Number)
+    });
+
+    const searchStdout = new MemoryWritable();
+    await expect(runSessionCommand(["search", "flaky parser", "--workspace", dir], { stdout: searchStdout })).resolves.toBe(0);
+    expect(searchStdout.text()).toContain(sessionId);
+  });
+
+  it("resumes a session by starting a linked child run", async () => {
+    const dir = await workspace();
+    await mkdir(path.join(dir, ".agent"), { recursive: true });
+    const createStdout = new MemoryWritable();
+    await runRunCommand(
+      ["Initial work", "--workspace", dir, "--provider", "deepseek", "--permission-mode", "yolo", "--no-stream-ui"],
+      { stdout: createStdout, modelClientFactory: fakeFactory }
+    );
+    const records = JSON.parse(await readFile(path.join(dir, ".agent", "sessions", "index.jsonl"), "utf8")
+      .then((text) => `[${text.trim().split(/\r?\n/).join(",")}]`)) as Array<{ sessionId: string }>;
+    const parentSessionId = records[records.length - 1].sessionId;
+
+    const resumeStdout = new MemoryWritable();
+    const resumeCode = await runSessionCommand(
+      [
+        "resume",
+        parentSessionId,
+        "Continue carefully",
+        "--workspace",
+        dir,
+        "--provider",
+        "deepseek",
+        "--permission-mode",
+        "yolo",
+        "--no-stream-ui"
+      ],
+      { stdout: resumeStdout, modelClientFactory: fakeFactory }
+    );
+
+    expect(resumeCode).toBe(0);
+    const updatedRecords = JSON.parse(await readFile(path.join(dir, ".agent", "sessions", "index.jsonl"), "utf8")
+      .then((text) => `[${text.trim().split(/\r?\n/).join(",")}]`)) as Array<{ sessionId: string }>;
+    const childSessionId = updatedRecords[updatedRecords.length - 1].sessionId;
+    expect(childSessionId).not.toBe(parentSessionId);
+    const childMeta = await loadSessionMeta({ sessionId: childSessionId, workspacePath: dir });
+    expect(childMeta?.parentSessionId).toBe(parentSessionId);
+  });
+});

--- a/tests/agent-core.checkpoints.test.ts
+++ b/tests/agent-core.checkpoints.test.ts
@@ -1,0 +1,89 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import type { ToolCall, ModelClient, ModelRequest, ModelResponse } from "../packages/agent-ai/src/index.js";
+import { listCheckpoints, restoreCheckpoint, runAgent } from "../packages/agent-core/src/index.js";
+
+class WriteModel implements ModelClient {
+  readonly provider = "deepseek" as const;
+  readonly model = "fake-checkpoint-model";
+  private index = 0;
+
+  async complete(_req: ModelRequest): Promise<ModelResponse> {
+    const call: ToolCall = {
+      id: "write-note",
+      type: "function",
+      function: {
+        name: "write",
+        arguments: { path: "note.txt", content: "changed\n", createDirs: true }
+      }
+    };
+    const responses: ModelResponse[] = [
+      { message: { role: "assistant", toolCalls: [call] } },
+      { message: { role: "assistant", content: "done" } }
+    ];
+    const response = responses[Math.min(this.index, responses.length - 1)];
+    this.index += 1;
+    return response;
+  }
+}
+
+function git(dir: string, args: string[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.env.AGENT_GIT_PATH || "git", args, { cwd: dir, windowsHide: true });
+    let stderr = "";
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`git ${args.join(" ")} failed: ${stderr}`));
+    });
+  });
+}
+
+async function gitWorkspace(): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "sigma-checkpoint-"));
+  await git(dir, ["init"]);
+  await git(dir, ["config", "user.email", "sigma@example.test"]);
+  await git(dir, ["config", "user.name", "Sigma Test"]);
+  await writeFile(path.join(dir, ".gitignore"), ".agent/\n", "utf8");
+  await writeFile(path.join(dir, "note.txt"), "original\n", "utf8");
+  await git(dir, ["add", "."]);
+  await git(dir, ["commit", "-m", "initial"]);
+  return dir;
+}
+
+describe("git checkpoints", () => {
+  it("creates, lists, shows, and safely restores a mutating tool checkpoint", async () => {
+    const dir = await gitWorkspace();
+    const result = await runAgent({
+      instruction: "change note",
+      workspacePath: dir,
+      modelClient: new WriteModel(),
+      permissionMode: "yolo"
+    });
+
+    await expect(readFile(path.join(dir, "note.txt"), "utf8")).resolves.toBe("changed\n");
+    const checkpoints = await listCheckpoints({ sessionId: result.sessionId as string, workspacePath: dir });
+    expect(checkpoints).toHaveLength(1);
+    expect(checkpoints[0]).toMatchObject({
+      id: "0001",
+      toolName: "write",
+      changedFiles: ["note.txt"]
+    });
+    await expect(readFile(checkpoints[0].patchPath, "utf8")).resolves.toContain("changed");
+
+    const restored = await restoreCheckpoint({
+      sessionId: result.sessionId as string,
+      checkpointId: checkpoints[0].id,
+      workspacePath: dir
+    });
+
+    expect(restored.ok).toBe(true);
+    await expect(readFile(path.join(dir, "note.txt"), "utf8").then((text) => text.replace(/\r\n/g, "\n"))).resolves.toBe("original\n");
+  });
+});

--- a/tests/agent-core.checkpoints.test.ts
+++ b/tests/agent-core.checkpoints.test.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
@@ -85,5 +85,28 @@ describe("git checkpoints", () => {
 
     expect(restored.ok).toBe(true);
     await expect(readFile(path.join(dir, "note.txt"), "utf8").then((text) => text.replace(/\r\n/g, "\n"))).resolves.toBe("original\n");
+  });
+
+  it("fails checkpoint restore cleanly when the patch file is missing", async () => {
+    const dir = await gitWorkspace();
+    const result = await runAgent({
+      instruction: "change note",
+      workspacePath: dir,
+      modelClient: new WriteModel(),
+      permissionMode: "yolo"
+    });
+    const checkpoints = await listCheckpoints({ sessionId: result.sessionId as string, workspacePath: dir });
+    await rm(checkpoints[0].patchPath, { force: true });
+
+    const restored = await restoreCheckpoint({
+      sessionId: result.sessionId as string,
+      checkpointId: checkpoints[0].id,
+      workspacePath: dir
+    });
+
+    expect(restored.ok).toBe(false);
+    expect(restored.exitCode).toBe(1);
+    expect(restored.stderr).toContain("checkpoint patch is unreadable");
+    await expect(readFile(path.join(dir, "note.txt"), "utf8")).resolves.toBe("changed\n");
   });
 });

--- a/tests/agent-core.context-tools.test.ts
+++ b/tests/agent-core.context-tools.test.ts
@@ -2,7 +2,9 @@ import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import type { ToolCall } from "../packages/agent-ai/src/index.js";
 import {
+  createDefaultToolRegistry,
   executeRepoQueryTool,
   executeSymbolSearchTool,
   executeValidateTool,
@@ -22,6 +24,10 @@ async function workspace(): Promise<{ dir: string; context: ToolExecutionContext
       alwaysAllowTools: new Set<string>()
     }
   };
+}
+
+function toolCall(id: string, name: string, args: Record<string, unknown>): ToolCall {
+  return { id, type: "function", function: { name, arguments: args } };
 }
 
 describe("repo context tools", () => {
@@ -56,6 +62,39 @@ describe("repo context tools", () => {
     expect(result.ok).toBe(true);
     const matches = result.metadata?.matches as Array<{ name: string; kind: string; path: string }>;
     expect(matches[0]).toMatchObject({ name: "RunConfig", kind: "interface", path: "src/index.ts" });
+  });
+
+  it("invalidates symbol_search cache after a same-file mutation", async () => {
+    const { dir, context } = await workspace();
+    await mkdir(path.join(dir, "src"), { recursive: true });
+    await writeFile(path.join(dir, "src", "index.ts"), "export function oldName() { return 1; }\n", "utf8");
+
+    const oldResult = await executeSymbolSearchTool({ query: "oldName" }, context);
+    expect(oldResult.ok).toBe(true);
+    expect((oldResult.metadata?.matches as Array<{ name: string }>)[0]).toMatchObject({ name: "oldName" });
+
+    const registry = createDefaultToolRegistry();
+    try {
+      const writeResult = await registry.execute(
+        toolCall("write-new-name", "write", {
+          path: "src/index.ts",
+          content: "export function newName() { return 2; }\n",
+          createDirs: true
+        }),
+        context
+      );
+      expect(writeResult.ok).toBe(true);
+
+      const newResult = await executeSymbolSearchTool({ query: "newName" }, context);
+      expect(newResult.ok).toBe(true);
+      expect((newResult.metadata?.matches as Array<{ name: string }>)[0]).toMatchObject({ name: "newName" });
+
+      const staleResult = await executeSymbolSearchTool({ query: "oldName" }, context);
+      expect(staleResult.ok).toBe(true);
+      expect(staleResult.metadata?.matches).toEqual([]);
+    } finally {
+      await registry.close?.();
+    }
   });
 });
 

--- a/tests/agent-core.context-tools.test.ts
+++ b/tests/agent-core.context-tools.test.ts
@@ -1,0 +1,87 @@
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  executeRepoQueryTool,
+  executeSymbolSearchTool,
+  executeValidateTool,
+  type ToolExecutionContext
+} from "../packages/agent-core/src/index.js";
+
+async function workspace(): Promise<{ dir: string; context: ToolExecutionContext }> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "sigma-context-tools-"));
+  return {
+    dir,
+    context: {
+      workspacePath: dir,
+      permissionMode: "yolo",
+      commandTimeoutSec: 5,
+      maxToolOutputChars: 12000,
+      runState: { todos: [], nextTodoId: 1, changedFiles: new Set<string>(), contextIndexes: new Map<string, unknown>() },
+      alwaysAllowTools: new Set<string>()
+    }
+  };
+}
+
+describe("repo context tools", () => {
+  it("scores repo_query matches using symbols, paths, imports, and structured reasons", async () => {
+    const { dir, context } = await workspace();
+    await mkdir(path.join(dir, "src"), { recursive: true });
+    await writeFile(
+      path.join(dir, "src", "session-manager.ts"),
+      [
+        "import { readFile } from 'node:fs/promises';",
+        "export class SessionManager {}",
+        "export function createSessionManager() { return new SessionManager(); }"
+      ].join("\n"),
+      "utf8"
+    );
+    await writeFile(path.join(dir, "src", "session-manager.test.ts"), "test('creates session manager', () => {});\n", "utf8");
+
+    const result = await executeRepoQueryTool({ query: "createSessionManager session-manager.ts", kind: "symbol" }, context);
+    expect(result.ok).toBe(true);
+    const matches = result.metadata?.matches as Array<{ path: string; reasons: string[]; score: number }>;
+    expect(matches[0].path).toBe("src/session-manager.ts");
+    expect(matches[0].reasons).toEqual(expect.arrayContaining(["symbol:exact", "file-mention"]));
+    expect(matches[0].score).toBeGreaterThan(40);
+  });
+
+  it("searches symbols directly", async () => {
+    const { dir, context } = await workspace();
+    await mkdir(path.join(dir, "src"), { recursive: true });
+    await writeFile(path.join(dir, "src", "index.ts"), "export interface RunConfig {}\nexport function runAgent() {}\n", "utf8");
+
+    const result = await executeSymbolSearchTool({ query: "RunConfig" }, context);
+    expect(result.ok).toBe(true);
+    const matches = result.metadata?.matches as Array<{ name: string; kind: string; path: string }>;
+    expect(matches[0]).toMatchObject({ name: "RunConfig", kind: "interface", path: "src/index.ts" });
+  });
+});
+
+describe("validate tool", () => {
+  it("runs explicit validation commands and returns structured results", async () => {
+    const { context } = await workspace();
+    const result = await executeValidateTool({ command: "node -e \"console.log('ok')\"", kind: "test" }, context);
+
+    expect(result.ok).toBe(true);
+    expect(result.metadata).toMatchObject({
+      ok: true,
+      command: "node -e \"console.log('ok')\"",
+      exitCode: 0,
+      diagnostics: []
+    });
+  });
+
+  it("infers changed-file validation commands", async () => {
+    const { dir, context } = await workspace();
+    await writeFile(path.join(dir, "bad.js"), "function nope(\n", "utf8");
+    context.runState.changedFiles.add("bad.js");
+
+    const result = await executeValidateTool({ kind: "auto", scope: "changed", timeoutSec: 5 }, context);
+
+    expect(result.ok).toBe(false);
+    expect(result.metadata?.command).toContain("node --check bad.js");
+    expect(result.metadata?.exitCode).not.toBe(0);
+  });
+});

--- a/tests/agent-core.harness.test.ts
+++ b/tests/agent-core.harness.test.ts
@@ -11,6 +11,7 @@ import {
 import {
   runAgentHarness,
   runAgentWithController,
+  listSessions,
   type AgentRunControllerConfig,
   type AgentRunControllerSummary,
   type RunControllerCleanupResult,
@@ -263,6 +264,81 @@ describe("agent-core harness", () => {
 
     expect(result.status).toBe("error");
     expect(result.finishReason).toBe("validation_failed");
+  });
+
+  it("records validation failure as the final durable session status", async () => {
+    const dir = await tempWorkspace();
+    const model = new SequenceModel([finalResponse("attempt completed")]);
+
+    const result = await runAgentHarness({
+      instruction: "finish but fail validation",
+      workspacePath: dir,
+      modelClient: model,
+      validationMode: "auto",
+      validationCommands: ["node -e \"process.stderr.write('validation failed'); process.exit(1)\""],
+      validationRetryLimit: 0,
+      validationTimeoutSec: 5,
+      permissionMode: "yolo"
+    });
+
+    expect(result.status).toBe("error");
+    expect(result.finishReason).toBe("validation_failed");
+    expect(result.sessionId).toEqual(expect.any(String));
+
+    const sessions = await listSessions({ workspacePath: dir });
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]).toMatchObject({
+      sessionId: result.sessionId,
+      status: "error",
+      finishReason: "validation_failed"
+    });
+    const summary = JSON.parse(await readFile(sessions[0].summaryPath, "utf8"));
+    expect(summary).toMatchObject({
+      status: "error",
+      finish_reason: "validation_failed",
+      harness: {
+        validation_results: [
+          expect.objectContaining({
+            kind: "validation",
+            exit_code: 1
+          })
+        ]
+      }
+    });
+  });
+
+  it("records precheck failure as the final durable session status", async () => {
+    const dir = await tempWorkspace();
+    const model = new SequenceModel([finalResponse("attempt completed")]);
+
+    const result = await runAgentHarness({
+      instruction: "finish but fail precheck",
+      workspacePath: dir,
+      modelClient: model,
+      validationMode: "off",
+      validationRetryLimit: 0,
+      precheckCommand: "node -e \"process.stderr.write('precheck failed'); process.exit(1)\"",
+      precheckTimeoutSec: 5,
+      permissionMode: "yolo"
+    });
+
+    expect(result.status).toBe("error");
+    expect(result.finishReason).toBe("precheck_failed");
+
+    const sessions = await listSessions({ workspacePath: dir });
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]).toMatchObject({
+      sessionId: result.sessionId,
+      status: "error",
+      finishReason: "precheck_failed"
+    });
+    const summary = JSON.parse(await readFile(sessions[0].summaryPath, "utf8"));
+    expect(summary.harness.precheck_results).toEqual([
+      expect.objectContaining({
+        kind: "precheck",
+        exit_code: 1
+      })
+    ]);
   });
 
   it("adds precheck failure details to retry feedback", async () => {

--- a/tests/agent-core.sessions.test.ts
+++ b/tests/agent-core.sessions.test.ts
@@ -1,0 +1,113 @@
+import { mkdtemp, readFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import type { ModelClient, ModelRequest, ModelResponse } from "../packages/agent-ai/src/index.js";
+import {
+  buildResumeInstruction,
+  listSessions,
+  loadSessionMeta,
+  loadSessionResumeContext,
+  runAgent,
+  searchSessions
+} from "../packages/agent-core/src/index.js";
+
+class FinalModel implements ModelClient {
+  readonly provider = "deepseek" as const;
+  readonly model = "fake-session-model";
+
+  constructor(private readonly content = "all set") {}
+
+  async complete(_req: ModelRequest): Promise<ModelResponse> {
+    return { message: { role: "assistant", content: this.content } };
+  }
+}
+
+async function workspace(): Promise<string> {
+  return await mkdtemp(path.join(os.tmpdir(), "sigma-session-"));
+}
+
+describe("durable sessions", () => {
+  it("writes a durable session index, meta, events, and redacted summary by default", async () => {
+    const dir = await workspace();
+    const secret = "session-secret-value-123456";
+    process.env.SIGMA_SESSION_TOKEN = secret;
+    try {
+      const result = await runAgent({
+        instruction: "Fix the login flow",
+        workspacePath: dir,
+        modelClient: new FinalModel(`all set token=${secret}`)
+      });
+
+      expect(result.sessionId).toEqual(expect.any(String));
+      const sessions = await listSessions({ workspacePath: dir });
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0]).toMatchObject({
+        sessionId: result.sessionId,
+        title: "Fix the login flow",
+        status: "completed",
+        provider: "deepseek",
+        model: "fake-session-model"
+      });
+
+      const meta = await loadSessionMeta({ sessionId: result.sessionId as string, workspacePath: dir });
+      expect(meta?.eventsPath).toContain(path.join(".agent", "sessions"));
+      const indexText = await readFile(path.join(dir, ".agent", "sessions", "index.jsonl"), "utf8");
+      const eventsText = await readFile(meta?.eventsPath as string, "utf8");
+      const summaryText = await readFile(meta?.summaryPath as string, "utf8");
+      expect(indexText).not.toContain(secret);
+      expect(eventsText).not.toContain(secret);
+      expect(summaryText).not.toContain(secret);
+      expect(summaryText).toContain("[REDACTED]");
+
+      const found = await searchSessions({ query: "login all set", workspacePath: dir });
+      expect(found[0]?.session.sessionId).toBe(result.sessionId);
+    } finally {
+      delete process.env.SIGMA_SESSION_TOKEN;
+    }
+  });
+
+  it("builds resume/fork context without replaying provider-specific tool messages", async () => {
+    const dir = await workspace();
+    const result = await runAgent({
+      instruction: "Investigate parser bug",
+      workspacePath: dir,
+      modelClient: new FinalModel("Parser bug is isolated.")
+    });
+
+    const context = await loadSessionResumeContext({ sessionId: result.sessionId as string, workspacePath: dir });
+    expect(context?.session.sessionId).toBe(result.sessionId);
+    const instruction = buildResumeInstruction({
+      context: context!,
+      instruction: "Continue with a fix",
+      mode: "fork"
+    });
+
+    expect(instruction).toContain(`sessionId: ${result.sessionId}`);
+    expect(instruction).toContain("Parser bug is isolated.");
+    expect(instruction).toContain("New instruction:");
+    expect(instruction).toContain("Continue with a fix");
+  });
+
+  it("records linked parent and fork metadata on new sessions", async () => {
+    const dir = await workspace();
+    const parent = await runAgent({
+      instruction: "Parent run",
+      workspacePath: dir,
+      modelClient: new FinalModel("parent done")
+    });
+    const child = await runAgent({
+      instruction: "Child run",
+      workspacePath: dir,
+      modelClient: new FinalModel("child done"),
+      parentSessionId: parent.sessionId,
+      forkedFromSessionId: parent.sessionId
+    });
+
+    const childMeta = await loadSessionMeta({ sessionId: child.sessionId as string, workspacePath: dir });
+    expect(childMeta).toMatchObject({
+      parentSessionId: parent.sessionId,
+      forkedFromSessionId: parent.sessionId
+    });
+  });
+});


### PR DESCRIPTION
﻿## What changed

- Added durable local sessions under `.agent/sessions` with an index, per-session metadata, event logs, summaries, and linked parent/fork metadata.
- Added CLI session commands: `sessions`, `history`, `session show`, `session search`, `session resume`, and `session fork`.
- Added git-backed checkpoint capture for mutating tools and CLI commands to list, show, and conservatively restore checkpoints.
- Added a lightweight code index, upgraded `repo_query`, and introduced `symbol_search`.
- Added a model-callable `validate` tool that reuses the existing validation planner/runner.
- Updated docs and added focused tests for sessions, checkpoints, context tools, validate, and CLI session flows.

## Why

Sigma needed stronger local-agent fundamentals: durable run history, a way to inspect and continue previous work, safer file-change recovery, better code discovery, and in-loop verification without adding external services or benchmark-specific behavior.

## User impact

Users can now inspect recent runs, search prior sessions, resume/fork with concise context, and restore git workspace changes from checkpoint patches. Agents also get better repo navigation and a first-class validation tool.

## Validation

- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm test:harbor`

## Limitations

- Checkpoint restore is currently git-backed only; non-git workspaces still get durable sessions but no restoreable checkpoints.
- Streaming is foundation-level only: event types and abort plumbing exist, but provider/TUI token streaming is not wired yet.
