### PR TITLE
Fix TUI Sigma logo direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,11 @@ Type a task and press Enter to start one run. The TUI opens as a transcript-firs
 
 ```text
   ███████████
-        ██        ∑ Sigma Code v0.1.0
-      ██          DeepSeek · deepseek-v4-pro
-    ██            ./agent-tui
-      ██
-        ██
+  ██              ∑ Sigma Code v0.1.0
+    ██            DeepSeek · deepseek-v4-pro
+      ██          ./agent-tui
+    ██
+  ██
   ███████████
 
 * Ready in agent-tui

--- a/packages/agent-tui/src/ui/brand.ts
+++ b/packages/agent-tui/src/ui/brand.ts
@@ -38,21 +38,21 @@ export function sigmaWelcome(options: SigmaWelcomeOptions): string[] {
   if (!supportsUnicode()) {
     return [
       "  SSSSSSSSSSS",
-      `        SS        S Sigma Code ${VERSION}`,
-      `      SS          ${provider} ${g.separator} ${model}`,
-      `    SS            ${options.workspacePath}`,
-      "      SS",
-      "        SS",
+      `  SS              S Sigma Code ${VERSION}`,
+      `    SS            ${provider} ${g.separator} ${model}`,
+      `      SS          ${options.workspacePath}`,
+      "    SS",
+      "  SS",
       "  SSSSSSSSSSS"
     ];
   }
   return [
     "  \u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588",
-    `        \u2588\u2588        ${g.sigma} Sigma Code ${VERSION}`,
-    `      \u2588\u2588          ${provider} ${g.separator} ${model}`,
-    `    \u2588\u2588            ${options.workspacePath}`,
-    "      \u2588\u2588",
-    "        \u2588\u2588",
+    `  \u2588\u2588              ${g.sigma} Sigma Code ${VERSION}`,
+    `    \u2588\u2588            ${provider} ${g.separator} ${model}`,
+    `      \u2588\u2588          ${options.workspacePath}`,
+    "    \u2588\u2588",
+    "  \u2588\u2588",
     "  \u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588"
   ];
 }

--- a/tests/agent-tui.app.test.ts
+++ b/tests/agent-tui.app.test.ts
@@ -128,8 +128,8 @@ describe("agent-tui app lifecycle and local terminal input", () => {
 
       const plain = stripAnsi(stdout.last());
       expect(calls).toHaveLength(0);
-      expect(plain).toContain("\u2588\u2588        \u2211 Sigma Code v0.1.0");
-      expect(plain).toContain("\u2588\u2588          DeepSeek \u00b7 default");
+      expect(plain).toContain("\u2588\u2588              \u2211 Sigma Code v0.1.0");
+      expect(plain).toContain("\u2588\u2588            DeepSeek \u00b7 default");
       expect(plain).not.toContain("\u203a_");
       expect(plain).toContain("help");
     } finally {

--- a/tests/agent-tui.render.test.ts
+++ b/tests/agent-tui.render.test.ts
@@ -69,8 +69,8 @@ describe("agent-tui stream rendering", () => {
 
     expect(rendered).toContain("Sigma Code v0.1.0");
     expect(rendered).toContain("\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588");
-    expect(rendered).toContain("\u2588\u2588        \u2211 Sigma Code v0.1.0");
-    expect(rendered).toContain("\u2588\u2588          DeepSeek \u00b7 default");
+    expect(rendered).toContain("\u2588\u2588              \u2211 Sigma Code v0.1.0");
+    expect(rendered).toContain("\u2588\u2588            DeepSeek \u00b7 default");
     expect(rendered).not.toContain("\u203a_");
     expect(rendered).toContain("DeepSeek \u00b7 default");
     expect(rendered).toContain("D:\\software\\sigma\\packages\\agent-tui");
@@ -231,7 +231,7 @@ describe("agent-tui stream rendering", () => {
       color: false
     });
 
-    expect(rendered).toContain("\u2588\u2588        \u2211 Sigma Code v0.1.0");
+    expect(rendered).toContain("\u2588\u2588              \u2211 Sigma Code v0.1.0");
     expect(rendered).not.toContain("S sigma");
   });
 
@@ -299,8 +299,8 @@ describe("agent-tui stream rendering", () => {
     });
 
     expect(rendered).toContain("SSSSSSSSSSS");
-    expect(rendered).toContain("SS        S Sigma Code v0.1.0");
-    expect(rendered).toContain("SS          DeepSeek | default");
+    expect(rendered).toContain("SS              S Sigma Code v0.1.0");
+    expect(rendered).toContain("SS            DeepSeek | default");
     expect(rendered).not.toContain(">_");
     expect(rendered).toContain("DeepSeek | default");
     expect(rendered).toContain("/tmp/sigma");
@@ -328,8 +328,8 @@ describe("agent-tui stream rendering", () => {
       color: false
     });
 
-    expect(ascii).toContain("SS        S Sigma Code v0.1.0");
-    expect(ascii).toContain("SS          DeepSeek | default");
+    expect(ascii).toContain("SS              S Sigma Code v0.1.0");
+    expect(ascii).toContain("SS            DeepSeek | default");
     expect(ascii).not.toContain(">_");
     expect(ascii).not.toContain("\u2211 Sigma Code");
 
@@ -352,7 +352,7 @@ describe("agent-tui stream rendering", () => {
       color: false
     });
 
-    expect(forced).toContain("\u2588\u2588        \u2211 Sigma Code v0.1.0");
+    expect(forced).toContain("\u2588\u2588              \u2211 Sigma Code v0.1.0");
     expect(forced).not.toContain("S Sigma Code");
   });
 


### PR DESCRIPTION
## Summary

Fixes the TUI welcome Sigma mark so its pixel direction matches the official Sigma Code mark asset. The previous block-art shape had the middle angle mirrored compared with `assets/sigma-code-mark.png`.

## Changes

- Flipped the Unicode and ASCII TUI welcome mark in `sigmaWelcome()`.
- Updated README's TUI example to show the corrected mark.
- Updated TUI render/app tests for the corrected lockup spacing.

## Validation

- `pnpm --filter agent-tui build`
- `pnpm test -- tests/agent-tui.render.test.ts tests/agent-tui.app.test.ts`
- Launched `pnpm --filter agent-tui start -- --workspace . --provider deepseek --model deepseek-v4-pro` and verified the corrected mark renders.