### PR TITLE
refactor agent strategy layers

### DIFF
--- a/packages/agent-core/src/agent.ts
+++ b/packages/agent-core/src/agent.ts
@@ -3,10 +3,11 @@ import path from "node:path";
 import { randomUUID } from "node:crypto";
 import { parseToolArguments, type AgentMessage, type ModelEvent, type ModelResponse, type ToolCall, type ToolDefinition } from "agent-ai";
 import { DEFAULT_SYSTEM_PROMPT } from "./prompts.js";
-import { compactLargeText, truncateMiddle } from "./compaction.js";
+import { compactLargeText } from "./compaction.js";
 import { JsonlSessionStore } from "./session/jsonl-session-store.js";
 import { createSessionManager, type SessionManager } from "./session/session-manager.js";
 import { createDefaultToolRegistry, filterToolRegistry } from "./tools/registry.js";
+import { ContextManager } from "./context/context-manager.js";
 import { formatProjectInstructionsBlock, loadProjectInstructions } from "./context/project-instructions.js";
 import { formatRepoMapBlock, generateRepoMap } from "./context/repo-map.js";
 import { detectProjectProfile } from "./harness/project-detector.js";
@@ -40,12 +41,9 @@ const DEFAULT_MAX_TURNS = 20;
 const DEFAULT_MAX_WALL_TIME_SEC = 900;
 const DEFAULT_COMMAND_TIMEOUT_SEC = 60;
 const DEFAULT_MAX_TOOL_OUTPUT_CHARS = 12000;
-const DEFAULT_MESSAGE_HISTORY_RETAIN = 24;
-const DEFAULT_COMPACTION_SUMMARY_CHARS = 30000;
 const DEFAULT_PROJECT_DOC_MAX_BYTES = 32768;
 const DEFAULT_REPO_MAP_MAX_CHARS = 20000;
 const DEFAULT_SKILLS_MAX_CHARS = 8000;
-const COMPACTION_MARKER = "Previous agent conversation compacted by the run controller.";
 const TOOL_ARGUMENT_HISTORY_MAX_CHARS = 4000;
 const EVENT_METADATA_MAX_CHARS = 6000;
 
@@ -183,70 +181,6 @@ function compactEventForTrace(agentEvent: AgentEvent): AgentEvent {
   };
 }
 
-function messageHistoryChars(messages: AgentMessage[]): number {
-  return messages.reduce((total, message) => total + JSON.stringify(message).length, 0);
-}
-
-function compactMessageForSummary(message: AgentMessage): string {
-  if (message.role === "assistant") {
-    const pieces = ["assistant:"];
-    if (message.reasoningContent) pieces.push(`reasoning=${truncateMiddle(message.reasoningContent, 600).text}`);
-    if (message.content) pieces.push(`content=${truncateMiddle(message.content, 600).text}`);
-    if (message.toolCalls && message.toolCalls.length > 0) {
-      const calls = message.toolCalls.map((call) => `${call.function.name}(${JSON.stringify(call.function.arguments)})`);
-      pieces.push(`tool_calls=${truncateMiddle(calls.join("; "), 1200).text}`);
-    }
-    return pieces.join(" ");
-  }
-
-  if (message.role === "tool") {
-    return `tool ${message.name ?? message.toolCallId}: ${truncateMiddle(message.content, 1200).text}`;
-  }
-
-  return `${message.role}: ${truncateMiddle(message.content, 1200).text}`;
-}
-
-function summarizeMessages(messages: AgentMessage[], maxChars: number): string {
-  const body = messages.map(compactMessageForSummary).join("\n\n");
-  return `${COMPACTION_MARKER}\n\n${truncateMiddle(body, Math.max(1, maxChars)).text}`;
-}
-
-function compactMessagesIfNeeded(
-  messages: AgentMessage[],
-  options: {
-    maxMessageHistoryChars?: number;
-    messageHistoryRetain?: number;
-    compactionSummaryChars?: number;
-  }
-): AgentMessage[] {
-  const maxChars = options.maxMessageHistoryChars;
-  if (!maxChars || maxChars <= 0 || messageHistoryChars(messages) <= maxChars || messages.length <= 3) {
-    return messages;
-  }
-
-  const retainCount = Math.max(0, Math.floor(options.messageHistoryRetain ?? DEFAULT_MESSAGE_HISTORY_RETAIN));
-  let tailStart = Math.max(2, messages.length - retainCount);
-  while (tailStart < messages.length && messages[tailStart].role === "tool") {
-    tailStart += 1;
-  }
-
-  if (tailStart <= 2 || tailStart >= messages.length) {
-    return messages;
-  }
-
-  const protectedMessages = messages.slice(0, 2);
-  const compactedMessages = messages.slice(2, tailStart);
-  const tailMessages = messages.slice(tailStart);
-  const summary: AgentMessage = {
-    role: "user",
-    content: summarizeMessages(
-      compactedMessages,
-      options.compactionSummaryChars ?? DEFAULT_COMPACTION_SUMMARY_CHARS
-    )
-  };
-  return [...protectedMessages, summary, ...tailMessages];
-}
-
 async function resolveRunToolRegistry(config: AgentRunConfig): Promise<ToolRegistry> {
   if (config.toolRegistry && config.toolRegistryFactory) {
     throw new Error("Configure either toolRegistry or toolRegistryFactory, not both.");
@@ -364,6 +298,7 @@ export async function runAgent(config: AgentRunConfig): Promise<AgentRunResult> 
         forkedFromSessionId: config.forkedFromSessionId
       });
   const workflow = createWorkflowState();
+  const contextManager = new ContextManager();
   const finalEvidenceMode = config.finalEvidenceMode ?? "off";
   let finalGateStatus = createInitialFinalGateStatus(finalEvidenceMode);
   let finalGateAlreadyNudged = false;
@@ -528,13 +463,20 @@ export async function runAgent(config: AgentRunConfig): Promise<AgentRunResult> 
       }
 
       turns += 1;
-      const compactedMessages = compactMessagesIfNeeded(messages, {
+      const changedFilesForContext = [...context.runState.changedFiles].sort((a, b) => a.localeCompare(b, "en"));
+      const preparedMessages = await contextManager.prepareMessages({
+        messages,
         maxMessageHistoryChars: config.maxMessageHistoryChars,
         messageHistoryRetain: config.messageHistoryRetain,
-        compactionSummaryChars: config.compactionSummaryChars
+        compactionSummaryChars: config.compactionSummaryChars,
+        objective: config.instruction,
+        workflow: summarizeWorkflowState(workflow, changedFilesForContext),
+        evidenceRecords: workflow.evidenceRecords,
+        changedFiles: changedFilesForContext,
+        todos: context.runState.todos
       });
-      if (compactedMessages !== messages) {
-        messages.splice(0, messages.length, ...compactedMessages);
+      if (preparedMessages.messages !== messages) {
+        messages.splice(0, messages.length, ...preparedMessages.messages);
       }
       if (config.abortSignal?.aborted) {
         finishReason = "cancelled";

--- a/packages/agent-core/src/context/compaction-service.ts
+++ b/packages/agent-core/src/context/compaction-service.ts
@@ -1,0 +1,300 @@
+import type { AgentMessage } from "agent-ai";
+import { truncateMiddle } from "../compaction.js";
+import type { EvidenceRecord, TodoItem, WorkflowStateSummary } from "../types.js";
+
+export const DEFAULT_MESSAGE_HISTORY_RETAIN = 24;
+export const DEFAULT_COMPACTION_SUMMARY_CHARS = 30000;
+export const COMPACTION_MARKER = "Previous agent conversation compacted by the run controller.";
+
+export type CompactionStrategyName = "deterministic" | "model_sub_session";
+
+export interface CompactionArtifact {
+  objective: string;
+  current_plan: string[];
+  changed_files: string[];
+  key_decisions: string[];
+  failed_attempts: string[];
+  validation_evidence: string[];
+  unresolved_questions: string[];
+  next_actions: string[];
+}
+
+export interface CompactionRequest {
+  messages: AgentMessage[];
+  maxMessageHistoryChars?: number;
+  messageHistoryRetain?: number;
+  compactionSummaryChars?: number;
+  objective?: string;
+  workflow?: WorkflowStateSummary;
+  evidenceRecords?: EvidenceRecord[];
+  changedFiles?: string[];
+  todos?: TodoItem[];
+  traceTail?: string;
+}
+
+export interface ModelCompactionRequest extends CompactionRequest {
+  protectedMessages: AgentMessage[];
+  compactedMessages: AgentMessage[];
+  tailMessages: AgentMessage[];
+  fallbackArtifact: CompactionArtifact;
+}
+
+export interface ModelCompactionProvider {
+  compact(request: ModelCompactionRequest): Promise<CompactionArtifact>;
+}
+
+export interface CompactionResult {
+  messages: AgentMessage[];
+  compacted: boolean;
+  strategy: CompactionStrategyName;
+  artifact: CompactionArtifact | null;
+}
+
+export interface CompactionStrategy {
+  readonly name: CompactionStrategyName;
+  compact(request: CompactionRequest): Promise<CompactionResult> | CompactionResult;
+}
+
+interface CompactionWindow {
+  shouldCompact: boolean;
+  protectedMessages: AgentMessage[];
+  compactedMessages: AgentMessage[];
+  tailMessages: AgentMessage[];
+}
+
+function firstUserContent(messages: AgentMessage[]): string {
+  const firstUser = messages.find((message) => message.role === "user");
+  return firstUser?.content ?? "";
+}
+
+function formatTodo(todo: TodoItem): string {
+  return `${todo.status}: ${todo.text}${todo.note ? ` (${todo.note})` : ""}`;
+}
+
+function compactLine(text: string, maxChars = 240): string {
+  return truncateMiddle(text.replace(/\s+/g, " ").trim(), maxChars).text;
+}
+
+function messageText(message: AgentMessage): string {
+  if (message.role === "assistant") {
+    const content = message.content ? `content=${message.content}` : "";
+    const reasoning = message.reasoningContent ? `reasoning=${message.reasoningContent}` : "";
+    return compactLine([content, reasoning].filter(Boolean).join(" "));
+  }
+  if (message.role === "tool") {
+    return compactLine(message.content);
+  }
+  return compactLine(message.content);
+}
+
+function tailHighlights(messages: AgentMessage[], role: AgentMessage["role"], maxItems: number): string[] {
+  return messages
+    .filter((message) => message.role === role)
+    .map(messageText)
+    .filter(Boolean)
+    .slice(-maxItems);
+}
+
+export function createDeterministicCompactionArtifact(request: CompactionRequest): CompactionArtifact {
+  const workflow = request.workflow;
+  const todos = request.todos ?? [];
+  const evidence = request.evidenceRecords ?? [];
+  const changedFiles = request.changedFiles ?? workflow?.changed_files ?? [];
+  const pendingTodos = todos.filter((todo) => todo.status !== "done");
+  const completedTodos = todos.filter((todo) => todo.status === "done");
+  const failurePatterns = workflow?.failure_patterns ?? [];
+  const validationEvidence = evidence
+    .filter((record) => record.executable || record.kind !== "unknown")
+    .slice(-8)
+    .map((record) => {
+      const pieces = [
+        record.ok ? "ok" : "failed",
+        record.kind,
+        record.command ? compactLine(record.command, 180) : record.toolName,
+        record.summary ? compactLine(record.summary, 220) : ""
+      ].filter(Boolean);
+      return pieces.join(": ");
+    });
+  const tailDecisions = tailHighlights(request.messages, "assistant", 5);
+
+  return {
+    objective: compactLine(request.objective ?? firstUserContent(request.messages), 1000),
+    current_plan: pendingTodos.length > 0
+      ? pendingTodos.map(formatTodo)
+      : workflow?.phase
+        ? [`workflow phase: ${workflow.phase}`]
+        : [],
+    changed_files: [...changedFiles],
+    key_decisions: [
+      ...completedTodos.slice(-5).map(formatTodo),
+      ...tailDecisions
+    ].slice(-8),
+    failed_attempts: failurePatterns.map((failure) => {
+      const command = failure.last_command ? ` command=${compactLine(failure.last_command, 180)}` : "";
+      return `${failure.category} x${failure.count}:${command} ${compactLine(failure.last_summary, 220)}`.trim();
+    }),
+    validation_evidence: validationEvidence,
+    unresolved_questions: [],
+    next_actions: pendingTodos.length > 0
+      ? pendingTodos.slice(0, 5).map(formatTodo)
+      : ["Continue from the retained conversation tail."]
+  };
+}
+
+export function messageHistoryChars(messages: AgentMessage[]): number {
+  return messages.reduce((total, message) => total + JSON.stringify(message).length, 0);
+}
+
+export function compactMessageForSummary(message: AgentMessage): string {
+  if (message.role === "assistant") {
+    const pieces = ["assistant:"];
+    if (message.reasoningContent) pieces.push(`reasoning=${truncateMiddle(message.reasoningContent, 600).text}`);
+    if (message.content) pieces.push(`content=${truncateMiddle(message.content, 600).text}`);
+    if (message.toolCalls && message.toolCalls.length > 0) {
+      const calls = message.toolCalls.map((call) => `${call.function.name}(${JSON.stringify(call.function.arguments)})`);
+      pieces.push(`tool_calls=${truncateMiddle(calls.join("; "), 1200).text}`);
+    }
+    return pieces.join(" ");
+  }
+
+  if (message.role === "tool") {
+    return `tool ${message.name ?? message.toolCallId}: ${truncateMiddle(message.content, 1200).text}`;
+  }
+
+  return `${message.role}: ${truncateMiddle(message.content, 1200).text}`;
+}
+
+export function summarizeMessages(messages: AgentMessage[], maxChars: number): string {
+  const body = messages.map(compactMessageForSummary).join("\n\n");
+  return `${COMPACTION_MARKER}\n\n${truncateMiddle(body, Math.max(1, maxChars)).text}`;
+}
+
+function compactionWindow(request: CompactionRequest): CompactionWindow {
+  const maxChars = request.maxMessageHistoryChars;
+  if (
+    !maxChars ||
+    maxChars <= 0 ||
+    messageHistoryChars(request.messages) <= maxChars ||
+    request.messages.length <= 3
+  ) {
+    return {
+      shouldCompact: false,
+      protectedMessages: [],
+      compactedMessages: [],
+      tailMessages: []
+    };
+  }
+
+  const retainCount = Math.max(0, Math.floor(request.messageHistoryRetain ?? DEFAULT_MESSAGE_HISTORY_RETAIN));
+  let tailStart = Math.max(2, request.messages.length - retainCount);
+  while (tailStart < request.messages.length && request.messages[tailStart].role === "tool") {
+    tailStart += 1;
+  }
+
+  if (tailStart <= 2 || tailStart >= request.messages.length) {
+    return {
+      shouldCompact: false,
+      protectedMessages: [],
+      compactedMessages: [],
+      tailMessages: []
+    };
+  }
+
+  return {
+    shouldCompact: true,
+    protectedMessages: request.messages.slice(0, 2),
+    compactedMessages: request.messages.slice(2, tailStart),
+    tailMessages: request.messages.slice(tailStart)
+  };
+}
+
+export class DeterministicCompactionStrategy implements CompactionStrategy {
+  readonly name = "deterministic" as const;
+
+  compact(request: CompactionRequest): CompactionResult {
+    const window = compactionWindow(request);
+    if (!window.shouldCompact) {
+      return {
+        messages: request.messages,
+        compacted: false,
+        strategy: this.name,
+        artifact: null
+      };
+    }
+
+    const artifact = createDeterministicCompactionArtifact(request);
+    const summary: AgentMessage = {
+      role: "user",
+      content: summarizeMessages(
+        window.compactedMessages,
+        request.compactionSummaryChars ?? DEFAULT_COMPACTION_SUMMARY_CHARS
+      )
+    };
+
+    return {
+      messages: [...window.protectedMessages, summary, ...window.tailMessages],
+      compacted: true,
+      strategy: this.name,
+      artifact
+    };
+  }
+}
+
+function formatArtifactSummary(artifact: CompactionArtifact, maxChars: number): string {
+  const body = JSON.stringify(artifact, null, 2);
+  return `${COMPACTION_MARKER}\n\nStructured compaction artifact:\n${truncateMiddle(body, Math.max(1, maxChars)).text}`;
+}
+
+export class ModelSubSessionCompactionStrategy implements CompactionStrategy {
+  readonly name = "model_sub_session" as const;
+
+  constructor(private readonly provider: ModelCompactionProvider) {}
+
+  async compact(request: CompactionRequest): Promise<CompactionResult> {
+    const window = compactionWindow(request);
+    if (!window.shouldCompact) {
+      return {
+        messages: request.messages,
+        compacted: false,
+        strategy: this.name,
+        artifact: null
+      };
+    }
+
+    const fallbackArtifact = createDeterministicCompactionArtifact(request);
+    const artifact = await this.provider.compact({
+      ...request,
+      protectedMessages: window.protectedMessages,
+      compactedMessages: window.compactedMessages,
+      tailMessages: window.tailMessages,
+      fallbackArtifact
+    });
+    const summary: AgentMessage = {
+      role: "user",
+      content: formatArtifactSummary(artifact, request.compactionSummaryChars ?? DEFAULT_COMPACTION_SUMMARY_CHARS)
+    };
+
+    return {
+      messages: [...window.protectedMessages, summary, ...window.tailMessages],
+      compacted: true,
+      strategy: this.name,
+      artifact
+    };
+  }
+}
+
+export interface CompactionServiceOptions {
+  strategy?: CompactionStrategy;
+}
+
+export class CompactionService {
+  private readonly strategy: CompactionStrategy;
+
+  constructor(options: CompactionServiceOptions = {}) {
+    this.strategy = options.strategy ?? new DeterministicCompactionStrategy();
+  }
+
+  async compact(request: CompactionRequest): Promise<CompactionResult> {
+    return await this.strategy.compact(request);
+  }
+}

--- a/packages/agent-core/src/context/context-manager.ts
+++ b/packages/agent-core/src/context/context-manager.ts
@@ -1,0 +1,33 @@
+import type { AgentMessage } from "agent-ai";
+import {
+  CompactionService,
+  type CompactionArtifact,
+  type CompactionRequest,
+  type CompactionResult,
+  type CompactionServiceOptions
+} from "./compaction-service.js";
+
+export interface ContextManagerOptions {
+  compactionService?: CompactionService;
+  compaction?: CompactionServiceOptions;
+}
+
+export interface PrepareMessagesRequest extends Omit<CompactionRequest, "messages"> {
+  messages: AgentMessage[];
+}
+
+export interface PrepareMessagesResult extends CompactionResult {
+  artifact: CompactionArtifact | null;
+}
+
+export class ContextManager {
+  private readonly compactionService: CompactionService;
+
+  constructor(options: ContextManagerOptions = {}) {
+    this.compactionService = options.compactionService ?? new CompactionService(options.compaction);
+  }
+
+  async prepareMessages(request: PrepareMessagesRequest): Promise<PrepareMessagesResult> {
+    return await this.compactionService.compact(request);
+  }
+}

--- a/packages/agent-core/src/controller/workflow-state.ts
+++ b/packages/agent-core/src/controller/workflow-state.ts
@@ -1,4 +1,5 @@
 import { compactLargeCommand, truncateMiddle } from "../compaction.js";
+import { analyzeFailure, failureInputFromToolResult, type FailureAnalysis } from "../workflow/failure-analyzer.js";
 import type {
   EvidenceRecord,
   ToolResult,
@@ -35,106 +36,30 @@ function commandFromArgs(toolName: string, args: unknown): string | null {
   return null;
 }
 
-function numberMetadata(result: ToolResult, key: string): number | null | undefined {
-  const value = result.metadata?.[key];
-  if (typeof value === "number") return value;
-  if (value === null) return null;
-  return undefined;
-}
-
-function booleanMetadata(result: ToolResult, key: string): boolean {
-  return result.metadata?.[key] === true;
-}
-
-function signalMetadata(result: ToolResult): string {
-  const signal = result.metadata?.signal;
-  return typeof signal === "string" ? signal : "";
-}
-
 function compactSummary(text: string, maxChars = 300): string {
   return truncateMiddle(text.replace(/\s+/g, " ").trim(), maxChars).text;
 }
 
-function commandLooksCompileLike(command: string): boolean {
-  return /\b(gcc|g\+\+|clang|clang\+\+|cc|c\+\+|javac|tsc|rustc|cargo\s+(?:build|check)|go\s+build|mvn|gradle|make|cmake|npm\s+run\s+build|pnpm\s+(?:run\s+)?build|yarn\s+build|bun\s+run\s+build)\b/i.test(command);
-}
-
-function outputLooksCompileLike(output: string): boolean {
-  return /\b(error:|undefined reference|compilation failed|compile failed|syntaxerror|typeerror|ts\d{4}:|cannot find symbol)\b/i.test(output);
-}
-
-function categorizeFailure(options: {
-  command: string | null;
-  result: ToolResult;
-}): WorkflowFailureCategory | null {
-  if (options.result.ok) return null;
-  const exitCode = numberMetadata(options.result, "exitCode");
-  const output = options.result.content;
-  const signal = signalMetadata(options.result);
-  const combined = `${options.command ?? ""}\n${output}`.toLowerCase();
-
-  if (
-    booleanMetadata(options.result, "timedOut") ||
-    exitCode === 124 ||
-    /\btimedout:\s*true\b|\btimed out\b|\btimeout\b/.test(combined)
-  ) {
-    return "timeout";
-  }
-  if (
-    exitCode === 139 ||
-    exitCode === -11 ||
-    signal === "SIGSEGV" ||
-    /\bsegmentation fault\b|\bsigsegv\b/.test(combined)
-  ) {
-    return "segmentation_fault";
-  }
-  if (
-    exitCode === 127 ||
-    /\bcommand not found\b|\bnot found for validation\b|\bno such file or directory\b/.test(combined)
-  ) {
-    return "missing_tool";
-  }
-  if (
-    commandLooksCompileLike(options.command ?? "") ||
-    (outputLooksCompileLike(output) && /\b(error:|compilation failed|compile failed|syntaxerror|typeerror|cannot find symbol)\b/i.test(output))
-  ) {
-    return "compile_error";
-  }
-  return null;
-}
-
 function recordFailurePattern(options: {
   workflow: WorkflowState;
-  category: WorkflowFailureCategory;
   toolName: string;
   command: string | null;
   result: ToolResult;
+  analysis: FailureAnalysis;
 }): WorkflowFailurePatternSummary {
-  const previous = options.workflow.failurePatterns.get(options.category);
-  const exitCode = numberMetadata(options.result, "exitCode");
+  const previous = options.workflow.failurePatterns.get(options.analysis.category);
   const record: WorkflowFailurePatternSummary = {
-    category: options.category,
+    category: options.analysis.category,
     count: (previous?.count ?? 0) + 1,
     last_tool_name: options.toolName,
     ...(options.command ? { last_command: compactLargeCommand(options.command, 1200).text } : {}),
-    ...(exitCode !== undefined ? { last_exit_code: exitCode } : {}),
-    last_summary: compactSummary(options.result.content)
+    ...(options.analysis.exitCode !== undefined ? { last_exit_code: options.analysis.exitCode } : {}),
+    last_summary: compactSummary(options.analysis.primaryMessage || options.result.content),
+    suggested_next_action: options.analysis.suggestedNextAction,
+    ...(options.analysis.diagnostics.length > 0 ? { diagnostics: options.analysis.diagnostics } : {})
   };
-  options.workflow.failurePatterns.set(options.category, record);
+  options.workflow.failurePatterns.set(options.analysis.category, record);
   return record;
-}
-
-function repairAdvice(category: WorkflowFailureCategory): string {
-  if (category === "compile_error") {
-    return "Use the compiler diagnostics as the repair target, fix the first concrete error, then rerun the same compile or a narrower syntax check.";
-  }
-  if (category === "segmentation_fault") {
-    return "Switch to a focused crash-debug pass: isolate the smallest crashing command, inspect memory bounds and null/error returns, make one targeted change, then rerun that command.";
-  }
-  if (category === "timeout") {
-    return "Reduce the scope before continuing: use a smaller input, shorter smoke command, or log/progress probe, then repair the slow path before broad exploration.";
-  }
-  return "Use an installed alternative or inspect the environment before retrying; do not repeat the same unavailable command.";
 }
 
 export function workflowFailureNudge(
@@ -146,7 +71,7 @@ export function workflowFailureNudge(
   workflow.nudgedFailureCategories.add(failure.category);
   const lines = [
     `Workflow repair signal: the last tool failure was categorized as ${failure.category}.`,
-    repairAdvice(failure.category)
+    failure.suggested_next_action ?? "Inspect the failure summary, make a focused repair, then rerun the relevant check."
   ];
   if (failure.last_command) lines.push(`Failing command summary: ${failure.last_command}`);
   lines.push(`Failure summary: ${failure.last_summary}`);
@@ -164,15 +89,19 @@ export function recordToolInWorkflow(options: {
   if (command) options.workflow.commandsTried.push(compactLargeCommand(command, 1200).text);
   if (options.evidence) options.workflow.evidenceRecords.push(options.evidence);
 
-  const failureCategory = categorizeFailure({ command, result: options.result });
-  if (failureCategory) {
+  const failureAnalysis = analyzeFailure(failureInputFromToolResult({
+    toolName: options.toolName,
+    command,
+    result: options.result
+  }));
+  if (failureAnalysis) {
     options.workflow.phase = "repair";
     return recordFailurePattern({
       workflow: options.workflow,
-      category: failureCategory,
       toolName: options.toolName,
       command,
-      result: options.result
+      result: options.result,
+      analysis: failureAnalysis
     });
   }
 

--- a/packages/agent-core/src/harness/retry.ts
+++ b/packages/agent-core/src/harness/retry.ts
@@ -1,31 +1,27 @@
 import type { AgentRunResult, HarnessCommandResult, HarnessRetryDecision, SummaryJson } from "../types.js";
+import { analyzeFailure, failureInputFromHarnessResult } from "../workflow/failure-analyzer.js";
 
-function tailText(text: string, limit = 1600): string {
+function tailText(text: string, limit = 900): string {
   return text.length <= limit ? text : text.slice(-limit);
-}
-
-function inferFailureCategory(result: HarnessCommandResult): string {
-  const combined = `${result.command}\n${result.stdout_tail}\n${result.stderr_tail}`.toLowerCase();
-  if (result.timed_out || result.exit_code === 124 || combined.includes("timed out")) return "timeout";
-  if (/\b(tsc|typecheck|type-check)\b/.test(combined)) return "typecheck";
-  if (/\b(pytest|go test|cargo test|mvn test|gradle test|npm test|pnpm test|yarn test|bun test)\b/.test(combined)) return "test";
-  if (/\b(eslint|lint)\b/.test(combined)) return "lint";
-  if (/\b(build|compile)\b/.test(combined)) return "build";
-  if (/syntaxerror|parse error|unexpected token|unterminated|syntax error/.test(combined)) return "syntax";
-  if (/enoent|not found|command not found/.test(combined)) return "missing-tool-or-file";
-  return "unknown";
 }
 
 export function formatFailureCard(result: HarnessCommandResult, index: number): string {
   const label = result.kind === "validation" ? "Validation" : "Precheck";
+  const analysis = analyzeFailure(failureInputFromHarnessResult(result));
   const lines = [
     `${label} failure ${index + 1} card:`,
+    `- category: ${analysis?.category ?? "unknown"}`,
     `- command: ${result.command}`,
     `- exit code: ${result.exit_code}`,
-    `- suspected category: ${inferFailureCategory(result)}`
+    `- primary: ${analysis?.primaryMessage ?? result.message}`,
+    `- next action: ${analysis?.suggestedNextAction ?? "Inspect the check output, make a focused repair, then rerun the relevant check."}`
   ];
   if (result.related_files.length > 0) {
     lines.push(`- related files: ${result.related_files.join(", ")}`);
+  }
+  const agentDiagnostics = analysis?.diagnostics.filter((diagnostic) => !diagnostic.startsWith("tool=")) ?? [];
+  if (agentDiagnostics.length) {
+    lines.push(`- diagnostics: ${agentDiagnostics.slice(0, 4).join("; ")}`);
   }
   const stdout = tailText(result.stdout_tail).trim();
   const stderr = tailText(result.stderr_tail).trim();
@@ -108,10 +104,10 @@ export function instructionWithRetryFeedback(options: {
   lines.push(
     JSON.stringify(
       {
-        status: options.previousAttemptResult.status,
-        finish_reason: options.previousAttemptResult.finishReason,
-        turns: options.previousAttemptResult.turns,
-        commands_executed: options.previousAttemptResult.commandsExecuted,
+        status: options.previousAttemptSummary.status,
+        finish_reason: options.previousAttemptSummary.finish_reason,
+        turns: options.previousAttemptSummary.turns,
+        commands_executed: options.previousAttemptSummary.commands_executed,
         last_error: options.previousAttemptResult.lastError
       },
       null,
@@ -122,7 +118,7 @@ export function instructionWithRetryFeedback(options: {
   if (options.traceTail.trim()) {
     lines.push("");
     lines.push("Trace tail key events (truncated):");
-    lines.push(tailText(options.traceTail, 2000));
+    lines.push(tailText(options.traceTail, 1200));
   }
 
   return lines.join("\n");

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -16,6 +16,34 @@ export {
 } from "./context/project-instructions.js";
 export { formatRepoMapBlock, generateRepoMap } from "./context/repo-map.js";
 export {
+  COMPACTION_MARKER,
+  CompactionService,
+  DEFAULT_COMPACTION_SUMMARY_CHARS,
+  DEFAULT_MESSAGE_HISTORY_RETAIN,
+  DeterministicCompactionStrategy,
+  ModelSubSessionCompactionStrategy,
+  createDeterministicCompactionArtifact,
+  compactMessageForSummary,
+  messageHistoryChars,
+  summarizeMessages
+} from "./context/compaction-service.js";
+export type {
+  CompactionArtifact,
+  CompactionRequest,
+  CompactionResult,
+  CompactionServiceOptions,
+  CompactionStrategy,
+  CompactionStrategyName,
+  ModelCompactionProvider,
+  ModelCompactionRequest
+} from "./context/compaction-service.js";
+export { ContextManager } from "./context/context-manager.js";
+export type {
+  ContextManagerOptions,
+  PrepareMessagesRequest,
+  PrepareMessagesResult
+} from "./context/context-manager.js";
+export {
   buildCodeIndex,
   getCodeIndexForTool,
   invalidateContextIndexes,
@@ -66,6 +94,19 @@ export type {
   SessionSearchResult
 } from "./session/session-types.js";
 export { truncateMiddle } from "./compaction.js";
+export {
+  analyzeFailure,
+  BuiltInFailureAnalyzer,
+  defaultFailureAnalyzer,
+  failureInputFromHarnessResult,
+  failureInputFromToolResult,
+  suggestedNextActionForFailure
+} from "./workflow/failure-analyzer.js";
+export type {
+  FailureAnalysis,
+  FailureAnalyzer,
+  FailureAnalyzerInput
+} from "./workflow/failure-analyzer.js";
 export {
   isPathInside,
   isProbablyMutatingCommand,

--- a/packages/agent-core/src/types.ts
+++ b/packages/agent-core/src/types.ts
@@ -47,7 +47,9 @@ export type WorkflowFailureCategory =
   | "compile_error"
   | "segmentation_fault"
   | "timeout"
-  | "missing_tool";
+  | "missing_tool"
+  | "test_failure"
+  | "unknown";
 
 export interface WorkflowFailurePatternSummary {
   category: WorkflowFailureCategory;
@@ -56,6 +58,8 @@ export interface WorkflowFailurePatternSummary {
   last_command?: string;
   last_exit_code?: number | null;
   last_summary: string;
+  suggested_next_action?: string;
+  diagnostics?: string[];
 }
 
 export type EvidenceKind =

--- a/packages/agent-core/src/workflow/failure-analyzer.ts
+++ b/packages/agent-core/src/workflow/failure-analyzer.ts
@@ -1,0 +1,202 @@
+import { compactLargeCommand, truncateMiddle } from "../compaction.js";
+import type { HarnessCommandResult, ToolResult, WorkflowFailureCategory } from "../types.js";
+
+export interface FailureAnalyzerInput {
+  ok?: boolean;
+  toolName?: string;
+  command?: string | null;
+  output?: string;
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number | null;
+  timedOut?: boolean;
+  signal?: string | null;
+}
+
+export interface FailureAnalysis {
+  category: WorkflowFailureCategory;
+  primaryMessage: string;
+  relatedCommand?: string;
+  exitCode?: number | null;
+  suggestedNextAction: string;
+  diagnostics: string[];
+}
+
+export interface FailureAnalyzer {
+  analyze(input: FailureAnalyzerInput): FailureAnalysis | null;
+}
+
+function normalizedCombined(input: FailureAnalyzerInput): string {
+  return [
+    input.toolName ?? "",
+    input.command ?? "",
+    input.output ?? "",
+    input.stdout ?? "",
+    input.stderr ?? ""
+  ].join("\n").toLowerCase();
+}
+
+function combinedOutput(input: FailureAnalyzerInput): string {
+  return [input.stderr ?? "", input.stdout ?? "", input.output ?? ""].filter(Boolean).join("\n");
+}
+
+function compactSingleLine(text: string, maxChars = 500): string {
+  return truncateMiddle(text.replace(/\s+/g, " ").trim(), maxChars).text;
+}
+
+function outputLines(input: FailureAnalyzerInput): string[] {
+  return combinedOutput(input)
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function primaryMessage(input: FailureAnalyzerInput, category: WorkflowFailureCategory): string {
+  const interesting = outputLines(input).find((line) =>
+    /\b(error|failed|failure|assert|exception|panic|fatal|timeout|timed out|not found|no such file|segmentation|sigsegv|ts\d{4}|undefined|cannot)\b/i.test(line)
+  );
+  if (interesting) return compactSingleLine(interesting);
+  if (input.command) return `Command failed: ${compactSingleLine(input.command, 420)}`;
+  return `Failure categorized as ${category}.`;
+}
+
+function commandLooksCompileLike(command: string): boolean {
+  return /\b(gcc|g\+\+|clang|clang\+\+|cc|c\+\+|javac|tsc|rustc|cargo\s+(?:build|check)|go\s+build|mvn\s+(?:compile|package)|gradle\s+(?:build|compile)|make|cmake|npm\s+run\s+build|pnpm\s+(?:run\s+)?build|yarn\s+build|bun\s+run\s+build)\b/i.test(command);
+}
+
+function outputLooksCompileLike(output: string): boolean {
+  return /\b(error:|undefined reference|compilation failed|compile failed|build failed|syntaxerror|typeerror|ts\d{4}:|cannot find symbol|undefined:|expected declaration|parse error|unexpected token|unterminated)\b/i.test(output);
+}
+
+function commandLooksTestLike(command: string): boolean {
+  return /\b(pytest|go\s+test|cargo\s+test|mvn\s+test|gradle\s+test|npm\s+test|pnpm\s+test|yarn\s+test|bun\s+test|vitest|jest)\b/i.test(command);
+}
+
+function outputLooksTestLike(output: string): boolean {
+  return /\b(assertionerror|failed tests?|test failed|tests? failed|failures?:|=== fail|--- fail|test result:\s*failed|not ok|expected .+ received|expected .+ got)\b/i.test(output);
+}
+
+function categoryForInput(input: FailureAnalyzerInput): WorkflowFailureCategory {
+  const exitCode = input.exitCode;
+  const signal = input.signal ?? "";
+  const combined = normalizedCombined(input);
+  const output = combinedOutput(input);
+  const normalizedOutput = output.toLowerCase();
+  const command = input.command ?? "";
+
+  if (
+    input.timedOut ||
+    exitCode === 124 ||
+    /\btimedout:\s*true\b|\btimed out\b|\btimeout\b/.test(combined)
+  ) {
+    return "timeout";
+  }
+  if (
+    exitCode === 139 ||
+    exitCode === -11 ||
+    signal === "SIGSEGV" ||
+    /\bsegmentation fault\b|\bsigsegv\b/.test(combined)
+  ) {
+    return "segmentation_fault";
+  }
+  if (
+    exitCode === 127 ||
+    /\bcommand not found\b|\bnot found for validation\b|\bno such file or directory\b|\benoent\b|\bis not recognized as an internal or external command\b/.test(normalizedOutput)
+  ) {
+    return "missing_tool";
+  }
+  if (
+    commandLooksCompileLike(command) ||
+    (outputLooksCompileLike(output) && /\b(error:|compilation failed|compile failed|build failed|syntaxerror|typeerror|cannot find symbol|ts\d{4}:|undefined:|parse error)\b/i.test(output))
+  ) {
+    return "compile_error";
+  }
+  if (commandLooksTestLike(command) || outputLooksTestLike(output)) {
+    return "test_failure";
+  }
+  return "unknown";
+}
+
+export function suggestedNextActionForFailure(category: WorkflowFailureCategory): string {
+  if (category === "compile_error") {
+    return "Use the compiler diagnostics as the repair target, fix the first concrete error, then rerun the same compile or a narrower syntax check.";
+  }
+  if (category === "test_failure") {
+    return "Use the failing test assertion or test name as the repair target, make one focused change, then rerun the same test or a narrower related test.";
+  }
+  if (category === "segmentation_fault") {
+    return "Switch to a focused crash-debug pass: isolate the smallest crashing command, inspect memory bounds and null/error returns, make one targeted change, then rerun that command.";
+  }
+  if (category === "timeout") {
+    return "Reduce the scope before continuing: use a smaller input, shorter smoke command, or log/progress probe, then repair the slow path before broad exploration.";
+  }
+  if (category === "missing_tool") {
+    return "Use an installed alternative or inspect the environment before retrying; do not repeat the same unavailable command.";
+  }
+  return "Inspect the command output, identify the first actionable diagnostic, make a focused repair, then rerun the relevant check.";
+}
+
+function diagnosticsForInput(input: FailureAnalyzerInput): string[] {
+  const diagnostics: string[] = [];
+  if (input.toolName) diagnostics.push(`tool=${input.toolName}`);
+  if (input.timedOut) diagnostics.push("timed_out=true");
+  if (input.signal) diagnostics.push(`signal=${input.signal}`);
+  if (input.exitCode !== undefined) diagnostics.push(`exit_code=${input.exitCode}`);
+  for (const line of outputLines(input).slice(0, 3)) {
+    diagnostics.push(compactSingleLine(line, 300));
+  }
+  return diagnostics;
+}
+
+export class BuiltInFailureAnalyzer implements FailureAnalyzer {
+  analyze(input: FailureAnalyzerInput): FailureAnalysis | null {
+    if (input.ok) return null;
+    const category = categoryForInput(input);
+    const command = input.command ? compactLargeCommand(input.command, 1200).text : undefined;
+    return {
+      category,
+      primaryMessage: primaryMessage(input, category),
+      ...(command ? { relatedCommand: command } : {}),
+      ...(input.exitCode !== undefined ? { exitCode: input.exitCode } : {}),
+      suggestedNextAction: suggestedNextActionForFailure(category),
+      diagnostics: diagnosticsForInput(input)
+    };
+  }
+}
+
+export const defaultFailureAnalyzer = new BuiltInFailureAnalyzer();
+
+export function analyzeFailure(input: FailureAnalyzerInput, analyzer: FailureAnalyzer = defaultFailureAnalyzer): FailureAnalysis | null {
+  return analyzer.analyze(input);
+}
+
+export function failureInputFromToolResult(options: {
+  toolName: string;
+  command: string | null;
+  result: ToolResult;
+}): FailureAnalyzerInput {
+  const exitCode = options.result.metadata?.exitCode;
+  const signal = options.result.metadata?.signal;
+  return {
+    ok: options.result.ok,
+    toolName: options.toolName,
+    command: options.command,
+    output: options.result.content,
+    exitCode: typeof exitCode === "number" || exitCode === null ? exitCode : undefined,
+    timedOut: options.result.metadata?.timedOut === true,
+    signal: typeof signal === "string" ? signal : undefined
+  };
+}
+
+export function failureInputFromHarnessResult(result: HarnessCommandResult): FailureAnalyzerInput {
+  return {
+    ok: result.exit_code === 0,
+    toolName: `harness.${result.kind}`,
+    command: result.command,
+    stdout: result.stdout_tail,
+    stderr: result.stderr_tail,
+    exitCode: result.exit_code,
+    timedOut: result.timed_out === true,
+    signal: result.signal ?? undefined
+  };
+}

--- a/tests/agent-core.context-manager.test.ts
+++ b/tests/agent-core.context-manager.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+import type { AgentMessage } from "../packages/agent-ai/src/index.js";
+import {
+  COMPACTION_MARKER,
+  CompactionService,
+  ContextManager,
+  DeterministicCompactionStrategy,
+  ModelSubSessionCompactionStrategy,
+  type CompactionArtifact
+} from "../packages/agent-core/src/index.js";
+
+function messagesWithHistory(): AgentMessage[] {
+  return [
+    { role: "system", content: "system rules" },
+    { role: "user", content: "fix the project" },
+    { role: "assistant", content: `old reasoning ${"a".repeat(1200)}` },
+    { role: "tool", name: "bash", toolCallId: "old-tool", content: `old output ${"b".repeat(1200)}` },
+    { role: "assistant", content: "recent decision" },
+    { role: "tool", name: "bash", toolCallId: "recent-tool", content: "recent output" }
+  ];
+}
+
+describe("ContextManager compaction", () => {
+  it("does not compact when history is below the threshold", async () => {
+    const messages: AgentMessage[] = [
+      { role: "system", content: "system" },
+      { role: "user", content: "hello" }
+    ];
+    const result = await new ContextManager().prepareMessages({
+      messages,
+      maxMessageHistoryChars: 10000
+    });
+
+    expect(result.compacted).toBe(false);
+    expect(result.artifact).toBeNull();
+    expect(result.messages).toBe(messages);
+  });
+
+  it("compacts while preserving the initial system/user messages", async () => {
+    const messages = messagesWithHistory();
+    const result = await new ContextManager().prepareMessages({
+      messages,
+      maxMessageHistoryChars: 500,
+      messageHistoryRetain: 2,
+      compactionSummaryChars: 600,
+      objective: "fix the project"
+    });
+
+    expect(result.compacted).toBe(true);
+    expect(result.messages[0]).toBe(messages[0]);
+    expect(result.messages[1]).toBe(messages[1]);
+    expect(result.messages[2]).toMatchObject({ role: "user" });
+    expect(result.messages[2].content).toContain(COMPACTION_MARKER);
+  });
+
+  it("keeps a retained tail without starting on an orphan tool message", async () => {
+    const messages = messagesWithHistory();
+    const result = await new ContextManager().prepareMessages({
+      messages,
+      maxMessageHistoryChars: 500,
+      messageHistoryRetain: 3,
+      compactionSummaryChars: 600
+    });
+
+    expect(result.messages.slice(3)).toEqual(messages.slice(4));
+    expect(result.messages[3].role).toBe("assistant");
+    expect(result.messages[4].role).toBe("tool");
+  });
+
+  it("generates a structured compaction artifact", async () => {
+    const messages = messagesWithHistory();
+    const result = await new ContextManager().prepareMessages({
+      messages,
+      maxMessageHistoryChars: 500,
+      messageHistoryRetain: 2,
+      objective: "ship the refactor",
+      changedFiles: ["src/app.ts"],
+      todos: [{ id: "1", text: "rerun tests", status: "pending" }],
+      workflow: {
+        phase: "repair",
+        commands_tried: ["pnpm test"],
+        changed_files: ["src/app.ts"],
+        failure_patterns: [
+          {
+            category: "test_failure",
+            count: 1,
+            last_tool_name: "bash",
+            last_command: "pnpm test",
+            last_summary: "AssertionError"
+          }
+        ]
+      },
+      evidenceRecords: [
+        {
+          kind: "test",
+          toolName: "bash",
+          ok: false,
+          executable: true,
+          command: "pnpm test",
+          summary: "AssertionError",
+          exitCode: 1,
+          timestamp: "2026-01-01T00:00:00.000Z"
+        }
+      ]
+    });
+
+    expect(result.artifact).toMatchObject({
+      objective: "ship the refactor",
+      changed_files: ["src/app.ts"],
+      current_plan: ["pending: rerun tests"]
+    });
+    expect(result.artifact?.failed_attempts[0]).toContain("test_failure x1");
+    expect(result.artifact?.validation_evidence[0]).toContain("failed: test");
+    expect(result.artifact?.next_actions[0]).toContain("rerun tests");
+  });
+
+  it("keeps deterministic fallback output stable", async () => {
+    const service = new CompactionService({ strategy: new DeterministicCompactionStrategy() });
+    const request = {
+      messages: messagesWithHistory(),
+      maxMessageHistoryChars: 500,
+      messageHistoryRetain: 2,
+      compactionSummaryChars: 600,
+      objective: "fix the project"
+    };
+
+    const first = await service.compact(request);
+    const second = await service.compact(request);
+
+    expect(first.messages).toEqual(second.messages);
+    expect(first.artifact).toEqual(second.artifact);
+  });
+
+  it("allows model sub-session strategies to receive full compaction context", async () => {
+    let capturedChangedFiles: string[] = [];
+    const artifact: CompactionArtifact = {
+      objective: "model objective",
+      current_plan: ["plan"],
+      changed_files: ["src/app.ts"],
+      key_decisions: ["decision"],
+      failed_attempts: ["failure"],
+      validation_evidence: ["evidence"],
+      unresolved_questions: [],
+      next_actions: ["next"]
+    };
+    const service = new CompactionService({
+      strategy: new ModelSubSessionCompactionStrategy({
+        async compact(request) {
+          capturedChangedFiles = request.changedFiles ?? [];
+          expect(request.compactedMessages.length).toBeGreaterThan(0);
+          expect(request.tailMessages.length).toBeGreaterThan(0);
+          expect(request.traceTail).toBe("trace");
+          return artifact;
+        }
+      })
+    });
+
+    const result = await service.compact({
+      messages: messagesWithHistory(),
+      maxMessageHistoryChars: 500,
+      messageHistoryRetain: 2,
+      changedFiles: ["src/app.ts"],
+      traceTail: "trace"
+    });
+
+    expect(capturedChangedFiles).toEqual(["src/app.ts"]);
+    expect(result.strategy).toBe("model_sub_session");
+    expect(result.artifact).toEqual(artifact);
+    expect(result.messages[2].content).toContain("Structured compaction artifact");
+  });
+});

--- a/tests/agent-core.failure-analyzer.test.ts
+++ b/tests/agent-core.failure-analyzer.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { analyzeFailure, failureInputFromHarnessResult } from "../packages/agent-core/src/index.js";
+import type { HarnessCommandResult } from "../packages/agent-core/src/index.js";
+
+function harnessFailure(overrides: Partial<HarnessCommandResult>): HarnessCommandResult {
+  return {
+    kind: "validation",
+    source: "configured",
+    command: "pnpm test",
+    attempt: 1,
+    exit_code: 1,
+    stdout_tail: "",
+    stderr_tail: "",
+    related_files: [],
+    timeout_sec: 60,
+    duration_ms: 10,
+    message: "failed",
+    ...overrides
+  };
+}
+
+describe("FailureAnalyzer", () => {
+  it("classifies TypeScript compiler diagnostics as compile errors", () => {
+    const analysis = analyzeFailure({
+      ok: false,
+      command: "pnpm exec tsc --noEmit",
+      stderr: "src/index.ts(1,7): error TS2322: Type 'string' is not assignable to type 'number'.",
+      exitCode: 2
+    });
+
+    expect(analysis).toMatchObject({
+      category: "compile_error",
+      exitCode: 2
+    });
+    expect(analysis?.primaryMessage).toContain("TS2322");
+  });
+
+  it("classifies pytest assertion output as test failure", () => {
+    const analysis = analyzeFailure({
+      ok: false,
+      command: "pytest tests/test_app.py",
+      stdout: "FAILED tests/test_app.py::test_total - AssertionError: expected 3",
+      exitCode: 1
+    });
+
+    expect(analysis?.category).toBe("test_failure");
+    expect(analysis?.suggestedNextAction).toContain("failing test");
+  });
+
+  it("classifies go test failures", () => {
+    const analysis = analyzeFailure({
+      ok: false,
+      command: "go test ./...",
+      stdout: "--- FAIL: TestTotal (0.00s)\n    total_test.go:10: expected 3 got 2\nFAIL",
+      exitCode: 1
+    });
+
+    expect(analysis?.category).toBe("test_failure");
+  });
+
+  it("classifies cargo test failures", () => {
+    const analysis = analyzeFailure({
+      ok: false,
+      command: "cargo test",
+      stdout: "test result: FAILED. 1 passed; 1 failed",
+      exitCode: 101
+    });
+
+    expect(analysis?.category).toBe("test_failure");
+  });
+
+  it("classifies timeouts, missing commands, and segmentation faults", () => {
+    expect(analyzeFailure({ ok: false, command: "pnpm test", timedOut: true, exitCode: 124 })?.category).toBe(
+      "timeout"
+    );
+    expect(analyzeFailure({ ok: false, command: "does-not-exist", stderr: "command not found", exitCode: 127 })?.category).toBe(
+      "missing_tool"
+    );
+    expect(analyzeFailure({ ok: false, command: "./app", stderr: "Segmentation fault", exitCode: 139 })?.category).toBe(
+      "segmentation_fault"
+    );
+  });
+
+  it("builds analyzer input from harness command results", () => {
+    const analysis = analyzeFailure(failureInputFromHarnessResult(harnessFailure({
+      command: "pytest",
+      stdout_tail: "FAILED test_example.py::test_example - AssertionError",
+      stderr_tail: "",
+      exit_code: 1
+    })));
+
+    expect(analysis).toMatchObject({
+      category: "test_failure",
+      relatedCommand: "pytest",
+      exitCode: 1
+    });
+  });
+
+  it("uses unknown for failed commands without a recognizable pattern", () => {
+    const analysis = analyzeFailure({
+      ok: false,
+      command: "custom-check",
+      stdout: "custom check rejected the output",
+      exitCode: 3
+    });
+
+    expect(analysis?.category).toBe("unknown");
+    expect(analysis?.suggestedNextAction).toContain("Inspect the command output");
+  });
+});

--- a/tests/agent-core.retry-feedback.test.ts
+++ b/tests/agent-core.retry-feedback.test.ts
@@ -27,7 +27,8 @@ describe("retry feedback cards", () => {
     expect(card).toContain("- command: pnpm test");
     expect(card).toContain("- exit code: 1");
     expect(card).toContain("- related files: src/app.ts");
-    expect(card).toContain("- suspected category: test");
+    expect(card).toContain("- category: test_failure");
+    expect(card).toContain("- next action:");
     expect(card.length).toBeLessThan(2500);
   });
 


### PR DESCRIPTION
## Summary

- Extract agent message compaction into `ContextManager` and `CompactionService` with deterministic fallback behavior preserved.
- Add a structured compaction artifact shape and a model/sub-session strategy interface for future model-backed compaction.
- Extract workflow failure classification into `FailureAnalyzer` and reuse it from workflow state and retry feedback.
- Keep retry feedback short and actionable while avoiding benchmark/task/verifier/scoring-specific logic.

## Validation

- `pnpm build`
- `pnpm test`
- `pnpm lint`

## Notes

- Model/sub-session compaction is intentionally an interface-only extension point for now; no live model path is wired in this PR.