### PR TITLE
Add v1 agent runtime foundations

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,12 @@ OpenAI-compatible providers support SSE model streaming. The core run loop prefe
 
 The default tool registry is extensible and can be injected, merged, filtered, or configured with `--allowed-tools` and `--disabled-tools`. Tool names must be unique; duplicate names fail clearly unless an internal override path is used.
 
+Tool calls are dispatched through the core tool runtime. Read-only tools that declare `supportsParallel` can run together within a single model turn; write, shell, service, validation, and subagent tools remain serial barriers. The runtime emits `tool_queued`, `tool_start`, `tool_progress`, `tool_end`, and `tool_aborted` events, returns tool results to the model in the original tool-call order, and records a `tool_runtime` summary in `summary.json`.
+
+Each turn also emits `turn_start` and `context_budget`. The budget is an estimate of current model-visible messages, tool definitions, repo map, and selected skills. Oversized runtime tool output can be saved under `.agent/artifacts/<run-id>/`, with the model receiving a bounded preview plus an artifact reference.
+
+Shell execution now passes through an execution policy classifier before `bash` starts. The classifier records whether a command appears read-only, workspace-changing, git-state-changing, network-using, or code-executing. Policy rules can allow, prompt, or deny command prefixes; the default remains conservative in `ask` and permissive in `yolo`. A policy-only sandbox adapter is included for filesystem/network intent checks, with the interface left open for stronger OS-backed adapters later.
+
 The core loop exposes these default tools:
 
 - `bash`: runs `bash -lc` in the workspace, captures stdout/stderr/exit code/duration, times out safely, and truncates large output with a head/tail strategy. Commands that look mutating require approval in `ask`.

--- a/packages/agent-cli/src/stream-ui.ts
+++ b/packages/agent-cli/src/stream-ui.ts
@@ -55,14 +55,24 @@ export function formatAgentEvent(event: AgentEvent): string | null {
   switch (event.type) {
     case "run_start":
       return `[sigma] run_start provider=${event.provider ?? "unknown"} model=${event.model ?? "unknown"}`;
+    case "turn_start":
+      return `[sigma] turn_start turn=${String(event.metadata?.turn ?? "?")}`;
+    case "context_budget": {
+      const budget = event.metadata?.budget as { estimated_tokens?: unknown; message_count?: unknown; tool_count?: unknown } | undefined;
+      return `[sigma] context_budget turn=${String(event.metadata?.turn ?? "?")} estimated_tokens=${String(budget?.estimated_tokens ?? "?")} messages=${String(budget?.message_count ?? "?")} tools=${String(budget?.tool_count ?? "?")}`;
+    }
     case "model_start":
       return `[sigma] model_start turn=${String(event.metadata?.turn ?? "?")}`;
     case "model_end":
       return `[sigma] model_end turn=${String(event.metadata?.turn ?? "?")} ${usageSummary(event.metadata?.usage)}`;
     case "assistant_message":
       return `[sigma] assistant ${assistantSummary(event)}`;
+    case "tool_queued":
+      return `[sigma] tool_queued ${String(event.metadata?.toolName ?? "tool")}`;
     case "tool_start":
       return `[sigma] tool_start ${toolDetailFromEvent(event)}`;
+    case "tool_aborted":
+      return `[sigma] tool_aborted ${String(event.metadata?.toolName ?? "tool")} reason=${truncateMiddle(redactSecretText(String(event.metadata?.reason ?? "")).replace(/\s+/g, " "), 120).text}`;
     case "tool_end": {
       const result = event.metadata?.result as { ok?: unknown; content?: unknown; metadata?: Record<string, unknown> } | undefined;
       const duration = typeof result?.metadata?.durationMs === "number" ? ` duration_ms=${result.metadata.durationMs}` : "";

--- a/packages/agent-core/src/agent.ts
+++ b/packages/agent-core/src/agent.ts
@@ -324,6 +324,8 @@ export async function runAgent(config: AgentRunConfig): Promise<AgentRunResult> 
     permissionMode: config.permissionMode ?? "ask",
     commandTimeoutSec: config.commandTimeoutSec ?? DEFAULT_COMMAND_TIMEOUT_SEC,
     maxToolOutputChars: config.maxToolOutputChars ?? DEFAULT_MAX_TOOL_OUTPUT_CHARS,
+    ...(config.maxParallelToolCalls !== undefined ? { maxParallelToolCalls: config.maxParallelToolCalls } : {}),
+    ...(config.toolArtifactRootDir !== undefined ? { toolArtifactRootDir: config.toolArtifactRootDir } : {}),
     permissionDecider: config.permissionDecider,
     runState: {
       todos: [],
@@ -731,7 +733,7 @@ export async function runAgent(config: AgentRunConfig): Promise<AgentRunResult> 
             provider,
             model,
             { turn: turns, turnId, toolName: call.function.name, analysis: failureAnalysis },
-            undefined,
+            execution.startEventId,
             durableSession?.sessionId
           ));
         }
@@ -760,7 +762,7 @@ export async function runAgent(config: AgentRunConfig): Promise<AgentRunResult> 
       finishReason = "max_turns";
     }
   } catch (error) {
-    if (config.abortSignal?.aborted || (error instanceof Error && /cancelled|aborted/i.test(error.message))) {
+    if (config.abortSignal?.aborted || (error instanceof Error && error.name === "AbortError")) {
       finishReason = "cancelled";
       lastError = error instanceof Error ? error.message : "Run cancelled.";
       await recordEvent(event(runId, "run_abort", provider, model, { message: lastError }, undefined, durableSession?.sessionId));

--- a/packages/agent-core/src/agent.ts
+++ b/packages/agent-core/src/agent.ts
@@ -10,6 +10,7 @@ import { createDefaultToolRegistry, filterToolRegistry } from "./tools/registry.
 import { CompactionService } from "./context/compaction-service.js";
 import { ContextManager } from "./context/context-manager.js";
 import { ModelSubSessionCompactionProvider } from "./context/model-compaction-provider.js";
+import { summarizeContextBudget } from "./context/token-budget.js";
 import { formatProjectInstructionsBlock, loadProjectInstructions } from "./context/project-instructions.js";
 import { formatRepoMapBlock, generateRepoMap } from "./context/repo-map.js";
 import { DEFAULT_COMPACTION_MODE, DEFAULT_FINAL_EVIDENCE_MODE, DEFAULT_SUBAGENTS_ENABLED } from "./defaults.js";
@@ -27,6 +28,7 @@ import {
   workflowFailureNudge
 } from "./controller/workflow-state.js";
 import { redactSecrets } from "./redaction.js";
+import { ToolRuntime, type ToolRuntimeExecution } from "./tool-runtime.js";
 import type {
   AgentEvent,
   AgentFinishReason,
@@ -37,6 +39,7 @@ import type {
   SummaryJson,
   TokenTotals,
   ToolExecutionContext,
+  ToolRuntimeMetadata,
   ToolRegistry,
   ToolResult
 } from "./types.js";
@@ -292,6 +295,12 @@ export function summaryJsonFromRunResult(result: AgentRunResult): SummaryJson {
   if (result.reviewFindings && result.reviewFindings.length > 0) {
     summary.review_findings = result.reviewFindings;
   }
+  if (result.toolRuntime) {
+    summary.tool_runtime = result.toolRuntime;
+  }
+  if (result.contextBudget) {
+    summary.context_budget = result.contextBudget;
+  }
   return summary;
 }
 
@@ -329,6 +338,9 @@ export async function runAgent(config: AgentRunConfig): Promise<AgentRunResult> 
     model,
     subagentsEnabled,
     subagentDepth: 0,
+    execPolicy: config.execPolicy,
+    sandbox: config.sandbox,
+    sandboxAdapter: config.sandboxAdapter,
     ...(config.abortSignal ? { abortSignal: config.abortSignal } : {})
   };
   const traceStore = config.traceJsonlPath ? new JsonlSessionStore(config.traceJsonlPath) : undefined;
@@ -502,6 +514,7 @@ export async function runAgent(config: AgentRunConfig): Promise<AgentRunResult> 
     { role: "user", content: config.instruction }
   ];
   const registry = await resolveRunToolRegistry(config);
+  const toolRuntime = new ToolRuntime(registry, context);
   const toolsAvailable = registry.definitions.map((definition) => definition.function.name).sort((a, b) => a.localeCompare(b, "en"));
   let turns = 0;
   let toolCalls = 0;
@@ -510,6 +523,13 @@ export async function runAgent(config: AgentRunConfig): Promise<AgentRunResult> 
   let lastError: string | null = null;
   let finalMessage: string | undefined;
   let stoppedByAssistant = false;
+  let lastContextBudget = summarizeContextBudget({
+    messages,
+    tools: registry.definitions,
+    maxMessageHistoryChars: config.maxMessageHistoryChars,
+    repoMapChars: repoMap?.chars,
+    skillsChars: selectedSkills.length > 0 ? formatSelectedSkills(selectedSkills, config.skillsMaxChars ?? DEFAULT_SKILLS_MAX_CHARS).length : 0
+  });
 
   await recordEvent(
     event(runId, "run_start", provider, model, {
@@ -539,6 +559,8 @@ export async function runAgent(config: AgentRunConfig): Promise<AgentRunResult> 
       }
 
       turns += 1;
+      const turnId = `${runId}:turn:${turns}`;
+      await recordEvent(event(runId, "turn_start", provider, model, { turn: turns, turnId }, undefined, durableSession?.sessionId));
       const changedFilesForContext = [...context.runState.changedFiles].sort((a, b) => a.localeCompare(b, "en"));
       const preparedMessages = await contextManager.prepareMessages({
         messages,
@@ -570,6 +592,14 @@ export async function runAgent(config: AgentRunConfig): Promise<AgentRunResult> 
       if (preparedMessages.messages !== messages) {
         messages.splice(0, messages.length, ...preparedMessages.messages);
       }
+      lastContextBudget = summarizeContextBudget({
+        messages,
+        tools: registry.definitions,
+        maxMessageHistoryChars: config.maxMessageHistoryChars,
+        repoMapChars: repoMap?.chars,
+        skillsChars: selectedSkills.length > 0 ? formatSelectedSkills(selectedSkills, config.skillsMaxChars ?? DEFAULT_SKILLS_MAX_CHARS).length : 0
+      });
+      await recordEvent(event(runId, "context_budget", provider, model, { turn: turns, turnId, budget: lastContextBudget }, undefined, durableSession?.sessionId));
       if (config.abortSignal?.aborted) {
         finishReason = "cancelled";
         lastError = "Run cancelled before model request.";
@@ -622,45 +652,58 @@ export async function runAgent(config: AgentRunConfig): Promise<AgentRunResult> 
       }
 
       const workflowNudges: string[] = [];
-      for (const call of calls) {
-        if (config.abortSignal?.aborted) {
-          finishReason = "cancelled";
-          lastError = "Run cancelled before tool execution.";
-          await recordEvent(event(runId, "run_abort", provider, model, { turn: turns, toolName: call.function.name }, undefined, durableSession?.sessionId));
-          break;
-        }
-        const toolStart = event(runId, "tool_start", provider, model, { toolCall: call }, undefined, durableSession?.sessionId);
-        await recordEvent(toolStart);
-        toolCalls += 1;
-        if (toolCallCountsAsCommand(call as ToolCall)) {
-          commandsExecuted += 1;
-        }
-
-        let result: ToolResult;
-        const pendingCheckpoint = await durableSession?.checkpoints.beforeTool(call as ToolCall) ?? null;
-        let checkpointId: string | undefined;
-        try {
-          result = await registry.execute(call as ToolCall, context);
-        } catch (error) {
-          result = {
-            ok: false,
-            content: error instanceof Error ? error.message : String(error)
-          };
-        }
-        const checkpoint = await durableSession?.checkpoints.afterTool(pendingCheckpoint, result) ?? null;
-        checkpointId = checkpoint?.id;
-
-        await recordEvent(
-          event(
+      type ToolExecutionValue = { checkpointId?: string };
+      const executions = await toolRuntime.executeBatch<ToolExecutionValue>(calls as ToolCall[], {
+        emit: async (type, metadata, parentId) => {
+          const agentEvent = event(
             runId,
-            "tool_end",
+            type,
             provider,
             model,
-            { toolCallId: call.id, toolName: call.function.name, result, ...(checkpointId ? { checkpointId } : {}) },
-            toolStart.id,
+            { ...metadata, turn: turns, turnId },
+            parentId,
             durableSession?.sessionId
-          )
-        );
+          );
+          await recordEvent(agentEvent);
+          return agentEvent;
+        },
+        execute: async (call: ToolCall, _metadata: Required<Pick<ToolRuntimeMetadata, "readOnly" | "supportsParallel">> & ToolRuntimeMetadata) => {
+          if (config.abortSignal?.aborted) {
+            finishReason = "cancelled";
+            lastError = "Run cancelled before tool execution.";
+            await recordEvent(event(runId, "run_abort", provider, model, { turn: turns, turnId, toolName: call.function.name }, undefined, durableSession?.sessionId));
+            return {
+              result: { ok: false, content: "Tool call cancelled before execution.", metadata: { cancelled: true } },
+              value: {}
+            };
+          }
+          toolCalls += 1;
+          if (toolCallCountsAsCommand(call)) {
+            commandsExecuted += 1;
+          }
+
+          let result: ToolResult;
+          const pendingCheckpoint = await durableSession?.checkpoints.beforeTool(call) ?? null;
+          try {
+            result = await registry.execute(call, context);
+          } catch (error) {
+            result = {
+              ok: false,
+              content: error instanceof Error ? error.message : String(error)
+            };
+          }
+          const checkpoint = await durableSession?.checkpoints.afterTool(pendingCheckpoint, result) ?? null;
+          return {
+            result,
+            value: { ...(checkpoint?.id ? { checkpointId: checkpoint.id } : {}) },
+            eventMetadata: { ...(checkpoint?.id ? { checkpointId: checkpoint.id } : {}) }
+          };
+        }
+      });
+
+      for (const execution of executions as Array<ToolRuntimeExecution<ToolExecutionValue>>) {
+        const call = execution.call;
+        const result = execution.result;
         if (isSubagentRunSummary(result.metadata?.subagentRun)) {
           subagentRuns.push(result.metadata.subagentRun);
         }
@@ -687,8 +730,8 @@ export async function runAgent(config: AgentRunConfig): Promise<AgentRunResult> 
             "failure_analysis",
             provider,
             model,
-            { turn: turns, toolName: call.function.name, analysis: failureAnalysis },
-            toolStart.id,
+            { turn: turns, turnId, toolName: call.function.name, analysis: failureAnalysis },
+            undefined,
             durableSession?.sessionId
           ));
         }
@@ -703,7 +746,7 @@ export async function runAgent(config: AgentRunConfig): Promise<AgentRunResult> 
         if (config.abortSignal?.aborted) {
           finishReason = "cancelled";
           lastError = "Run cancelled during tool execution.";
-          await recordEvent(event(runId, "run_abort", provider, model, { turn: turns, toolName: call.function.name }, undefined, durableSession?.sessionId));
+          await recordEvent(event(runId, "run_abort", provider, model, { turn: turns, turnId, toolName: call.function.name }, undefined, durableSession?.sessionId));
           break;
         }
       }
@@ -757,7 +800,9 @@ export async function runAgent(config: AgentRunConfig): Promise<AgentRunResult> 
     selectedSkills: selectedSkills.map((skill) => ({ name: skill.name, source: skill.source })),
     contextCompactions,
     failureAnalyses: workflow.failureAnalyses,
-    subagentRuns
+    subagentRuns,
+    toolRuntime: toolRuntime.summary(),
+    contextBudget: lastContextBudget
   };
 
   await recordEvent(event(runId, "run_end", provider, model, { result }, undefined, durableSession?.sessionId));

--- a/packages/agent-core/src/context/token-budget.ts
+++ b/packages/agent-core/src/context/token-budget.ts
@@ -1,0 +1,39 @@
+import type { AgentMessage, ToolDefinition } from "agent-ai";
+import type { ContextBudgetSummary } from "../types.js";
+
+function textOfMessage(message: AgentMessage): string {
+  const record = message as AgentMessage & Record<string, unknown>;
+  const parts = [
+    message.role,
+    message.content,
+    typeof record.reasoningContent === "string" ? record.reasoningContent : "",
+    typeof record.name === "string" ? record.name : "",
+    typeof record.toolCallId === "string" ? record.toolCallId : "",
+    Array.isArray(record.toolCalls) ? JSON.stringify(record.toolCalls) : ""
+  ];
+  return parts.filter((part): part is string => typeof part === "string" && part.length > 0).join("\n");
+}
+
+function estimateTokens(chars: number): number {
+  return Math.max(1, Math.ceil(chars / 4));
+}
+
+export function summarizeContextBudget(options: {
+  messages: AgentMessage[];
+  tools: ToolDefinition[];
+  maxMessageHistoryChars?: number;
+  repoMapChars?: number;
+  skillsChars?: number;
+}): ContextBudgetSummary {
+  const messageChars = options.messages.reduce((total, message) => total + textOfMessage(message).length, 0);
+  const toolChars = options.tools.reduce((total, tool) => total + JSON.stringify(tool).length, 0);
+  const estimatedChars = messageChars + toolChars + (options.repoMapChars ?? 0) + (options.skillsChars ?? 0);
+  return {
+    estimated_tokens: estimateTokens(estimatedChars),
+    message_count: options.messages.length,
+    tool_count: options.tools.length,
+    ...(options.maxMessageHistoryChars ? { max_message_history_chars: options.maxMessageHistoryChars } : {}),
+    ...(typeof options.repoMapChars === "number" ? { repo_map_chars: options.repoMapChars } : {}),
+    ...(typeof options.skillsChars === "number" ? { skills_chars: options.skillsChars } : {})
+  };
+}

--- a/packages/agent-core/src/harness/runner.ts
+++ b/packages/agent-core/src/harness/runner.ts
@@ -337,7 +337,9 @@ function finalResultForHarness(options: {
     validationPlan: options.validationPlan ?? options.finalAttempt.validationPlan,
     codeIndex: options.finalAttempt.codeIndex,
     subagentRuns: options.finalAttempt.subagentRuns,
-    reviewFindings: options.reviewFindings ?? options.finalAttempt.reviewFindings
+    reviewFindings: options.reviewFindings ?? options.finalAttempt.reviewFindings,
+    toolRuntime: options.finalAttempt.toolRuntime,
+    contextBudget: options.finalAttempt.contextBudget
   };
 }
 
@@ -432,6 +434,9 @@ export async function runAgentHarness(config: AgentHarnessConfig): Promise<Agent
     const attemptDir = path.join(attemptsDir, `attempt-${attempt}`);
     const attemptSummaryPath = path.join(attemptDir, "summary.json");
     const attemptTracePath = path.join(attemptDir, "trace.jsonl");
+    const attemptToolArtifactRootDir = config.toolArtifactRootDir
+      ? path.join(path.resolve(config.toolArtifactRootDir), `attempt-${attempt}`)
+      : path.join(attemptDir, "artifacts");
     await mkdir(attemptDir, { recursive: true });
     activeAttemptForEvents = attempt;
     const precheck = await runPrecheckBeforeAttempt({ config: controllerConfig, attempt });
@@ -451,6 +456,7 @@ export async function runAgentHarness(config: AgentHarnessConfig): Promise<Agent
       instruction: activeInstruction,
       summaryJsonPath: attemptSummaryPath,
       traceJsonlPath: attemptTracePath,
+      toolArtifactRootDir: attemptToolArtifactRootDir,
       durableSession: false
     });
     const attemptCancelled = rawAttemptResult.finishReason === "cancelled" || config.abortSignal?.aborted === true;

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -151,6 +151,8 @@ export type {
   FailureAnalyzerInput
 } from "./workflow/failure-analyzer.js";
 export {
+  classifyShellCommand,
+  evaluateExecPolicy,
   isPathInside,
   isProbablyMutatingCommand,
   permissionDeniedResult,
@@ -158,6 +160,10 @@ export {
   resolveWorkspacePath,
   workspaceRelativePath
 } from "./policy.js";
+export { createPolicyOnlySandboxAdapter, PolicyOnlySandboxAdapter } from "./sandbox.js";
+export { ToolRuntime } from "./tool-runtime.js";
+export type { ToolRuntimeCallbacks, ToolRuntimeExecution } from "./tool-runtime.js";
+export { summarizeContextBudget } from "./context/token-budget.js";
 export { estimateValidationCost, withEstimatedCost } from "./validation/command-cost.js";
 export { discoverProjects } from "./validation/project-discovery.js";
 export { createValidationPlan } from "./validation/validation-planner.js";
@@ -227,8 +233,12 @@ export type {
   CompactionFallbackMode,
   CompactionMode,
   ContextCompactionSummary,
+  ContextBudgetSummary,
   EvidenceKind,
   EvidenceRecord,
+  ExecIntentSummary,
+  ExecPolicyConfig,
+  ExecPolicyRule,
   FailureAnalysisSummary,
   FinalGateStatus,
   HarnessAttemptSummary,
@@ -254,6 +264,10 @@ export type {
   SubagentRunSummary,
   SubagentType,
   SummaryJson,
+  SandboxAdapter,
+  SandboxConfig,
+  SandboxExecDecision,
+  SandboxExecRequest,
   TodoItem,
   TodoStatus,
   TokenTotals,
@@ -262,6 +276,11 @@ export type {
   ToolRegistryFilter,
   ToolRegistryOptions,
   ToolRegistry,
+  ToolRuntimeMetadata,
+  ToolRuntimeSummary,
+  ToolArtifactSummary,
+  ToolApprovalMode,
+  ToolSandboxMode,
   ToolRisk,
   ToolResult,
   WorkflowPhase,

--- a/packages/agent-core/src/mcp.ts
+++ b/packages/agent-core/src/mcp.ts
@@ -388,6 +388,12 @@ function registeredMcpTool(options: {
       }
     },
     risk: mode === "auto" && readOnly ? "read" : "unknown",
+    runtime: {
+      readOnly,
+      supportsParallel: readOnly,
+      approval: mode === "auto" && readOnly ? "auto" : "prompt",
+      sandbox: "bypass"
+    },
     async execute(args: unknown, context: ToolExecutionContext): Promise<ToolResult> {
       if (!(mode === "approve" || (mode === "auto" && readOnly))) {
         const denied = await requestToolPermission(context, {

--- a/packages/agent-core/src/policy.ts
+++ b/packages/agent-core/src/policy.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import type { PermissionRequest, ToolExecutionContext, ToolResult, ToolRisk } from "./types.js";
+import type { ExecIntentSummary, ExecPolicyConfig, PermissionRequest, ToolExecutionContext, ToolResult, ToolRisk } from "./types.js";
 
 export function isPathInside(parentPath: string, candidatePath: string): boolean {
   const parent = path.resolve(parentPath);
@@ -22,15 +22,85 @@ export function resolveWorkspacePath(workspacePath: string, requestedPath: strin
   return candidate;
 }
 
-export function isProbablyMutatingCommand(command: string): boolean {
-  const patterns = [
+function normalizeCommand(command: string): string {
+  return command.replace(/\s+/g, " ").trim();
+}
+
+function commandStartsWith(command: string, prefix: string): boolean {
+  const normalized = normalizeCommand(command).toLowerCase();
+  const normalizedPrefix = normalizeCommand(prefix).toLowerCase();
+  return normalized === normalizedPrefix || normalized.startsWith(`${normalizedPrefix} `);
+}
+
+function ruleLabel(match: string | string[]): string {
+  return Array.isArray(match) ? match.join(" ") : match;
+}
+
+type ExecPolicyRuleEntry = NonNullable<ExecPolicyConfig["rules"]>[number];
+
+function matchRule(command: string, rules: ExecPolicyConfig["rules"] = []): ExecPolicyRuleEntry | undefined {
+  for (const rule of rules) {
+    const candidates = Array.isArray(rule.match) ? rule.match : [rule.match];
+    if (candidates.some((candidate) => commandStartsWith(command, candidate))) {
+      return rule;
+    }
+  }
+  return undefined;
+}
+
+export function classifyShellCommand(command: string): Omit<ExecIntentSummary, "action" | "reason" | "matchedRule"> {
+  const normalized = normalizeCommand(command);
+  const lower = normalized.toLowerCase();
+  const mutatesWorkspace = [
     /\b(rm|mv|cp|mkdir|rmdir|touch|chmod|chown|ln)\b/,
     /\b(npm|pnpm|yarn|bun)\s+(install|add|remove|update|exec|run)\b/,
-    /\b(git)\s+(add|commit|push|checkout|switch|reset|clean|merge|rebase|apply)\b/,
-    /\b(python|python3|node|tsx|ts-node)\b/,
+    /\b(git)\s+(add|commit|push|checkout|switch|reset|clean|merge|rebase|apply|restore)\b/,
     />\s*[^&]|\btee\b|\bsed\s+-i\b/
-  ];
-  return patterns.some((pattern) => pattern.test(command));
+  ].some((pattern) => pattern.test(lower));
+  const changesGitState = /\bgit\s+(add|commit|push|checkout|switch|reset|clean|merge|rebase|apply|restore)\b/.test(lower);
+  const usesNetwork = /\b(curl|wget|ssh|scp|rsync|npm|pnpm|yarn|bun|pip|uv|poetry|cargo|go)\s+/.test(lower) &&
+    !/\b(npm|pnpm|yarn|bun)\s+(test|run\s+(test|lint|build|typecheck))\b/.test(lower);
+  const executesCode = /\b(node|python|python3|py|tsx|ts-node|bun|deno|ruby|perl|php|go|cargo|npm|pnpm|yarn)\b/.test(lower);
+  const risk: ToolRisk = usesNetwork ? "network" : (mutatesWorkspace || executesCode ? "execute" : "read");
+  return {
+    command,
+    risk,
+    mutatesWorkspace,
+    usesNetwork,
+    changesGitState,
+    executesCode
+  };
+}
+
+function defaultActionForCommand(policy: ExecPolicyConfig | undefined, intent: Omit<ExecIntentSummary, "action" | "reason" | "matchedRule">): ExecIntentSummary["action"] {
+  if (policy?.defaultAction) return policy.defaultAction;
+  if (policy?.allowReadOnlyCommands !== false && intent.risk === "read") return "allow";
+  return intent.mutatesWorkspace || intent.usesNetwork || intent.executesCode ? "prompt" : "allow";
+}
+
+function defaultReason(intent: Omit<ExecIntentSummary, "action" | "reason" | "matchedRule">, action: ExecIntentSummary["action"]): string {
+  if (action === "deny") return "Command was denied by execution policy.";
+  if (intent.usesNetwork) return "Command appears to use network access.";
+  if (intent.changesGitState) return "Command appears to change git state.";
+  if (intent.mutatesWorkspace) return "Command appears to modify workspace state.";
+  if (intent.executesCode) return "Command executes code and requires approval in ask mode.";
+  return "Command is classified as read-only.";
+}
+
+export function evaluateExecPolicy(command: string, policy?: ExecPolicyConfig): ExecIntentSummary {
+  const intent = classifyShellCommand(command);
+  const rule = matchRule(command, policy?.rules);
+  const action = rule?.action ?? defaultActionForCommand(policy, intent);
+  return {
+    ...intent,
+    action,
+    ...(rule ? { matchedRule: ruleLabel(rule.match) } : {}),
+    reason: rule?.reason ?? defaultReason(intent, action)
+  };
+}
+
+export function isProbablyMutatingCommand(command: string): boolean {
+  return classifyShellCommand(command).mutatesWorkspace;
 }
 
 export function permissionDeniedResult(toolName: string, risk: ToolRisk): ToolResult {

--- a/packages/agent-core/src/redaction.ts
+++ b/packages/agent-core/src/redaction.ts
@@ -1,4 +1,4 @@
-const SECRET_KEY_PATTERN = /(api[_-]?key|token|secret|password|passwd|authorization|credential)/i;
+const SECRET_KEY_PATTERN = /(api[_-]?key|secret|password|passwd|authorization|credential|(?:^|[_-])token(?:$|[_-])|(?:^|[_-])access[_-]?token(?:$|[_-])|(?:^|[_-])auth[_-]?token(?:$|[_-]))/i;
 const STATIC_PATTERNS: Array<[RegExp, string]> = [
   [/(authorization\s*[:=]\s*bearer\s+)[^\s"',;]+/gi, "$1[REDACTED]"],
   [/((?:api[_-]?key|token|secret|password|passwd|credential)\s*[:=]\s*["']?)[^"'\s,;]+/gi, "$1[REDACTED]"],
@@ -49,4 +49,3 @@ export function redactSecrets<T>(value: T): T {
 
   return visit(value) as T;
 }
-

--- a/packages/agent-core/src/run-controller.ts
+++ b/packages/agent-core/src/run-controller.ts
@@ -50,6 +50,8 @@ export interface RunConfiguredAgentOptions {
   sessionJsonlPath?: string;
   summaryJsonPath?: string;
   maxToolOutputChars?: number;
+  maxParallelToolCalls?: number;
+  toolArtifactRootDir?: string;
   maxMessageHistoryChars?: number;
   messageHistoryRetain?: number;
   compactionSummaryChars?: number;
@@ -164,6 +166,8 @@ function baseRunConfig(
     ...(defined(options.sessionJsonlPath) ? { sessionJsonlPath: options.sessionJsonlPath } : {}),
     ...(defined(options.summaryJsonPath) ? { summaryJsonPath: options.summaryJsonPath } : {}),
     ...(defined(options.maxToolOutputChars) ? { maxToolOutputChars: options.maxToolOutputChars } : {}),
+    ...(defined(options.maxParallelToolCalls) ? { maxParallelToolCalls: options.maxParallelToolCalls } : {}),
+    ...(defined(options.toolArtifactRootDir) ? { toolArtifactRootDir: options.toolArtifactRootDir } : {}),
     maxMessageHistoryChars: resolved.maxMessageHistoryChars,
     ...(defined(options.messageHistoryRetain) ? { messageHistoryRetain: options.messageHistoryRetain } : {}),
     ...(defined(options.compactionSummaryChars) ? { compactionSummaryChars: options.compactionSummaryChars } : {}),

--- a/packages/agent-core/src/run-controller.ts
+++ b/packages/agent-core/src/run-controller.ts
@@ -21,9 +21,12 @@ import type {
   CompactionFallbackMode,
   CompactionMode,
   ContextMode,
+  ExecPolicyConfig,
   McpServerRunSummary,
   PermissionDecider,
   PermissionMode,
+  SandboxAdapter,
+  SandboxConfig,
   ToolRegistry
 } from "./types.js";
 
@@ -85,6 +88,9 @@ export interface RunConfiguredAgentOptions {
   finalEvidenceMode?: AgentFinalEvidenceMode;
   skillsMode?: AgentSkillsMode;
   skillsMaxChars?: number;
+  execPolicy?: ExecPolicyConfig;
+  sandbox?: SandboxConfig;
+  sandboxAdapter?: SandboxAdapter;
   enableMcp?: boolean;
   mcpConfig?: string;
   eventBus?: AgentEventBusLike;
@@ -190,6 +196,9 @@ function baseRunConfig(
     finalEvidenceMode: resolved.finalEvidenceMode,
     ...(defined(options.skillsMode) ? { skillsMode: options.skillsMode } : {}),
     ...(defined(options.skillsMaxChars) ? { skillsMaxChars: options.skillsMaxChars } : {}),
+    ...(defined(options.execPolicy) ? { execPolicy: options.execPolicy } : {}),
+    ...(defined(options.sandbox) ? { sandbox: options.sandbox } : {}),
+    ...(defined(options.sandboxAdapter) ? { sandboxAdapter: options.sandboxAdapter } : {}),
     ...(defined(options.eventBus) ? { eventBus: options.eventBus } : {}),
     ...(defined(options.abortSignal) ? { abortSignal: options.abortSignal } : {})
   };

--- a/packages/agent-core/src/sandbox.ts
+++ b/packages/agent-core/src/sandbox.ts
@@ -1,0 +1,30 @@
+import type { SandboxAdapter, SandboxExecDecision, SandboxExecRequest } from "./types.js";
+
+export class PolicyOnlySandboxAdapter implements SandboxAdapter {
+  async prepareExec(request: SandboxExecRequest): Promise<SandboxExecDecision> {
+    if (request.sandbox?.filesystem === "read_only" && request.policy.mutatesWorkspace) {
+      return {
+        allowed: false,
+        reason: "Sandbox policy is read-only, but the command appears to modify workspace state."
+      };
+    }
+    if (request.sandbox?.network === "restricted" && request.policy.usesNetwork) {
+      return {
+        allowed: false,
+        reason: "Sandbox policy restricts network access, but the command appears to use the network."
+      };
+    }
+    return {
+      allowed: true,
+      metadata: {
+        sandboxMode: request.sandbox?.mode ?? "policy_only",
+        network: request.sandbox?.network ?? "default",
+        filesystem: request.sandbox?.filesystem ?? "workspace_write"
+      }
+    };
+  }
+}
+
+export function createPolicyOnlySandboxAdapter(): SandboxAdapter {
+  return new PolicyOnlySandboxAdapter();
+}

--- a/packages/agent-core/src/subagents/subtask-tool.ts
+++ b/packages/agent-core/src/subagents/subtask-tool.ts
@@ -121,7 +121,7 @@ export function createSubtaskTool(options: SubagentToolOptions): RegisteredTool 
       }
     },
     execute: async (args, context) => await executeSubtaskTool(args, context, options),
-    risk: "read"
+    risk: "read",
+    runtime: { readOnly: true, supportsParallel: false, approval: "auto", sandbox: "bypass" }
   };
 }
-

--- a/packages/agent-core/src/tool-runtime.ts
+++ b/packages/agent-core/src/tool-runtime.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { randomUUID } from "node:crypto";
 import type { ToolCall } from "agent-ai";
 import { truncateMiddle } from "./compaction.js";
+import { isPathInside } from "./policy.js";
 import type {
   AgentEvent,
   RegisteredTool,
@@ -15,12 +16,15 @@ import type {
   ToolRuntimeSummary
 } from "./types.js";
 
+const DEFAULT_PARALLEL_TOOL_LIMIT = 4;
+
 export interface ToolRuntimeExecution<T> {
   call: ToolCall;
   index: number;
   result: ToolResult;
   value: T;
   metadata: Required<Pick<ToolRuntimeMetadata, "readOnly" | "supportsParallel">> & ToolRuntimeMetadata;
+  startEventId?: string;
 }
 
 export interface ToolRuntimeCallbacks<T> {
@@ -59,11 +63,32 @@ function mergeRuntimeMetadata(tool: RegisteredTool | undefined): RuntimeCall["me
 }
 
 function isAbortResult(result: ToolResult): boolean {
-  return result.metadata?.cancelled === true || /cancelled|aborted/i.test(result.content);
+  return result.metadata?.cancelled === true || result.metadata?.aborted === true;
+}
+
+function abortReason(result: ToolResult): string {
+  const reason = result.metadata?.cancelReason ?? result.metadata?.abortReason;
+  return typeof reason === "string" && reason.trim() ? reason : "abort_signal";
+}
+
+function isAbortError(error: unknown, abortSignal?: AbortSignal): boolean {
+  return abortSignal?.aborted === true || (error instanceof Error && error.name === "AbortError");
+}
+
+function parallelToolLimit(value: number | undefined): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return DEFAULT_PARALLEL_TOOL_LIMIT;
+  return Math.max(1, Math.floor(value));
 }
 
 function artifactSafeName(toolName: string): string {
   return toolName.replace(/[^a-zA-Z0-9_.-]+/g, "_").slice(0, 48) || "tool";
+}
+
+function displayArtifactPath(workspacePath: string, artifactPath: string): string {
+  if (isPathInside(workspacePath, artifactPath)) {
+    return path.relative(workspacePath, artifactPath).split(path.sep).join("/");
+  }
+  return path.resolve(artifactPath).split(path.sep).join("/");
 }
 
 export class ToolRuntime {
@@ -117,11 +142,12 @@ export class ToolRuntime {
 
     const executions = new Array<ToolRuntimeExecution<T>>(planned.length);
     let cursor = 0;
+    const parallelLimit = parallelToolLimit(this.context.maxParallelToolCalls);
     while (cursor < planned.length) {
       const first = planned[cursor];
       if (first.metadata.supportsParallel) {
         const batch: RuntimeCall[] = [];
-        while (cursor < planned.length && planned[cursor].metadata.supportsParallel) {
+        while (cursor < planned.length && planned[cursor].metadata.supportsParallel && batch.length < parallelLimit) {
           batch.push(planned[cursor]);
           cursor += 1;
         }
@@ -129,6 +155,7 @@ export class ToolRuntime {
         await callbacks.emit("tool_progress", {
           phase: "parallel_batch_start",
           size: batch.length,
+          concurrencyLimit: parallelLimit,
           toolNames: batch.map((item) => item.call.function.name)
         });
         const batchResults = await Promise.all(batch.map((item) => this.executeOne(item, callbacks)));
@@ -183,9 +210,11 @@ export class ToolRuntime {
       value = executed.value;
       eventMetadata = executed.eventMetadata ?? {};
     } catch (error) {
+      const cancelled = isAbortError(error, this.context.abortSignal);
       result = {
         ok: false,
-        content: error instanceof Error ? error.message : String(error)
+        content: error instanceof Error ? error.message : String(error),
+        ...(cancelled ? { metadata: { cancelled: true, cancelReason: "abort_signal" } } : {})
       };
       value = undefined as T;
     }
@@ -196,7 +225,7 @@ export class ToolRuntime {
         toolCallId: item.call.id,
         toolName: item.call.function.name,
         index: item.index,
-        reason: result.content
+        reason: abortReason(result)
       }, parentId);
     }
     if (result.ok) this.completed += 1;
@@ -217,7 +246,8 @@ export class ToolRuntime {
       index: item.index,
       result,
       value,
-      metadata: item.metadata
+      metadata: item.metadata,
+      ...(parentId ? { startEventId: parentId } : {})
     };
   }
 
@@ -226,7 +256,8 @@ export class ToolRuntime {
     if (result.content.length <= budget) return result;
     const runId = this.context.runId ?? "run";
     const artifactId = randomUUID();
-    const artifactDir = path.join(this.context.workspacePath, ".agent", "artifacts", runId);
+    const artifactRoot = path.resolve(this.context.toolArtifactRootDir ?? path.join(this.context.workspacePath, ".agent", "artifacts"));
+    const artifactDir = path.join(artifactRoot, runId);
     const artifactPath = path.join(artifactDir, `${artifactSafeName(call.function.name)}-${artifactId}.txt`);
     await mkdir(artifactDir, { recursive: true });
     await writeFile(artifactPath, result.content, "utf8");
@@ -235,7 +266,7 @@ export class ToolRuntime {
       id: artifactId,
       tool_call_id: call.id,
       tool_name: call.function.name,
-      path: path.relative(this.context.workspacePath, artifactPath).split(path.sep).join("/"),
+      path: displayArtifactPath(this.context.workspacePath, artifactPath),
       bytes: Buffer.byteLength(result.content, "utf8"),
       original_chars: result.content.length,
       retained_chars: truncated.text.length

--- a/packages/agent-core/src/tool-runtime.ts
+++ b/packages/agent-core/src/tool-runtime.ts
@@ -1,0 +1,255 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+import type { ToolCall } from "agent-ai";
+import { truncateMiddle } from "./compaction.js";
+import type {
+  AgentEvent,
+  RegisteredTool,
+  ToolArtifactSummary,
+  ToolExecutionContext,
+  ToolRegistry,
+  ToolResult,
+  ToolRisk,
+  ToolRuntimeMetadata,
+  ToolRuntimeSummary
+} from "./types.js";
+
+export interface ToolRuntimeExecution<T> {
+  call: ToolCall;
+  index: number;
+  result: ToolResult;
+  value: T;
+  metadata: Required<Pick<ToolRuntimeMetadata, "readOnly" | "supportsParallel">> & ToolRuntimeMetadata;
+}
+
+export interface ToolRuntimeCallbacks<T> {
+  execute(call: ToolCall, metadata: ToolRuntimeExecution<T>["metadata"]): Promise<{ result: ToolResult; value: T; eventMetadata?: Record<string, unknown> }>;
+  emit(type: AgentEvent["type"], metadata: Record<string, unknown>, parentId?: string): Promise<AgentEvent | void>;
+}
+
+interface RuntimeCall {
+  call: ToolCall;
+  index: number;
+  tool?: RegisteredTool;
+  metadata: ToolRuntimeExecution<unknown>["metadata"];
+}
+
+function defaultRuntimeForRisk(risk: ToolRisk | undefined): Required<Pick<ToolRuntimeMetadata, "readOnly" | "supportsParallel">> & ToolRuntimeMetadata {
+  const readOnly = risk === "read";
+  return {
+    readOnly,
+    supportsParallel: readOnly,
+    waitsForCancellation: false,
+    approval: risk === "read" ? "auto" : "prompt",
+    sandbox: "default"
+  };
+}
+
+function mergeRuntimeMetadata(tool: RegisteredTool | undefined): RuntimeCall["metadata"] {
+  const base = defaultRuntimeForRisk(tool?.risk);
+  const runtime = tool?.runtime ?? {};
+  const readOnly = runtime.readOnly ?? base.readOnly;
+  return {
+    ...base,
+    ...runtime,
+    readOnly,
+    supportsParallel: runtime.supportsParallel ?? (readOnly && base.supportsParallel)
+  };
+}
+
+function isAbortResult(result: ToolResult): boolean {
+  return result.metadata?.cancelled === true || /cancelled|aborted/i.test(result.content);
+}
+
+function artifactSafeName(toolName: string): string {
+  return toolName.replace(/[^a-zA-Z0-9_.-]+/g, "_").slice(0, 48) || "tool";
+}
+
+export class ToolRuntime {
+  private readonly artifacts: ToolArtifactSummary[] = [];
+  private queued = 0;
+  private started = 0;
+  private completed = 0;
+  private aborted = 0;
+  private failed = 0;
+  private parallelBatches = 0;
+  private serialBatches = 0;
+
+  constructor(
+    private readonly registry: ToolRegistry,
+    private readonly context: ToolExecutionContext
+  ) {}
+
+  summary(): ToolRuntimeSummary {
+    return {
+      queued: this.queued,
+      started: this.started,
+      completed: this.completed,
+      aborted: this.aborted,
+      failed: this.failed,
+      parallel_batches: this.parallelBatches,
+      serial_batches: this.serialBatches,
+      artifacts: [...this.artifacts]
+    };
+  }
+
+  async executeBatch<T>(calls: ToolCall[], callbacks: ToolRuntimeCallbacks<T>): Promise<ToolRuntimeExecution<T>[]> {
+    const planned = calls.map((call, index): RuntimeCall => {
+      const tool = this.registry.getTool?.(call.function.name);
+      return {
+        call,
+        index,
+        tool,
+        metadata: mergeRuntimeMetadata(tool)
+      };
+    });
+
+    for (const item of planned) {
+      this.queued += 1;
+      await callbacks.emit("tool_queued", {
+        toolCallId: item.call.id,
+        toolName: item.call.function.name,
+        index: item.index,
+        runtime: item.metadata
+      });
+    }
+
+    const executions = new Array<ToolRuntimeExecution<T>>(planned.length);
+    let cursor = 0;
+    while (cursor < planned.length) {
+      const first = planned[cursor];
+      if (first.metadata.supportsParallel) {
+        const batch: RuntimeCall[] = [];
+        while (cursor < planned.length && planned[cursor].metadata.supportsParallel) {
+          batch.push(planned[cursor]);
+          cursor += 1;
+        }
+        this.parallelBatches += 1;
+        await callbacks.emit("tool_progress", {
+          phase: "parallel_batch_start",
+          size: batch.length,
+          toolNames: batch.map((item) => item.call.function.name)
+        });
+        const batchResults = await Promise.all(batch.map((item) => this.executeOne(item, callbacks)));
+        for (const result of batchResults) executions[result.index] = result;
+      } else {
+        this.serialBatches += 1;
+        cursor += 1;
+        executions[first.index] = await this.executeOne(first, callbacks);
+      }
+    }
+    return executions;
+  }
+
+  private async executeOne<T>(item: RuntimeCall, callbacks: ToolRuntimeCallbacks<T>): Promise<ToolRuntimeExecution<T>> {
+    if (this.context.abortSignal?.aborted) {
+      const result: ToolResult = {
+        ok: false,
+        content: "Tool call aborted before execution.",
+        metadata: { cancelled: true }
+      };
+      this.aborted += 1;
+      await callbacks.emit("tool_aborted", {
+        toolCallId: item.call.id,
+        toolName: item.call.function.name,
+        index: item.index,
+        reason: "abort_signal"
+      });
+      return {
+        call: item.call,
+        index: item.index,
+        result,
+        value: undefined as T,
+        metadata: item.metadata
+      };
+    }
+
+    this.started += 1;
+    const started = await callbacks.emit("tool_start", {
+      toolCall: item.call,
+      toolCallId: item.call.id,
+      toolName: item.call.function.name,
+      index: item.index,
+      runtime: item.metadata
+    });
+    const parentId = started?.id;
+    let result: ToolResult;
+    let value: T;
+    let eventMetadata: Record<string, unknown> = {};
+    try {
+      const executed = await callbacks.execute(item.call, item.metadata as ToolRuntimeExecution<T>["metadata"]);
+      result = await this.applyOutputBudget(item.call, executed.result, item.metadata);
+      value = executed.value;
+      eventMetadata = executed.eventMetadata ?? {};
+    } catch (error) {
+      result = {
+        ok: false,
+        content: error instanceof Error ? error.message : String(error)
+      };
+      value = undefined as T;
+    }
+
+    if (isAbortResult(result)) {
+      this.aborted += 1;
+      await callbacks.emit("tool_aborted", {
+        toolCallId: item.call.id,
+        toolName: item.call.function.name,
+        index: item.index,
+        reason: result.content
+      }, parentId);
+    }
+    if (result.ok) this.completed += 1;
+    else this.failed += 1;
+
+    await callbacks.emit("tool_end", {
+      toolCallId: item.call.id,
+      toolName: item.call.function.name,
+      index: item.index,
+      result,
+      runtime: item.metadata,
+      ...eventMetadata,
+      artifact: result.metadata?.toolArtifact
+    }, parentId);
+
+    return {
+      call: item.call,
+      index: item.index,
+      result,
+      value,
+      metadata: item.metadata
+    };
+  }
+
+  private async applyOutputBudget(call: ToolCall, result: ToolResult, metadata: ToolRuntimeMetadata): Promise<ToolResult> {
+    const budget = Math.max(1, Math.floor(metadata.outputBudget ?? this.context.maxToolOutputChars));
+    if (result.content.length <= budget) return result;
+    const runId = this.context.runId ?? "run";
+    const artifactId = randomUUID();
+    const artifactDir = path.join(this.context.workspacePath, ".agent", "artifacts", runId);
+    const artifactPath = path.join(artifactDir, `${artifactSafeName(call.function.name)}-${artifactId}.txt`);
+    await mkdir(artifactDir, { recursive: true });
+    await writeFile(artifactPath, result.content, "utf8");
+    const truncated = truncateMiddle(result.content, budget);
+    const summary: ToolArtifactSummary = {
+      id: artifactId,
+      tool_call_id: call.id,
+      tool_name: call.function.name,
+      path: path.relative(this.context.workspacePath, artifactPath).split(path.sep).join("/"),
+      bytes: Buffer.byteLength(result.content, "utf8"),
+      original_chars: result.content.length,
+      retained_chars: truncated.text.length
+    };
+    this.artifacts.push(summary);
+    this.context.runState.toolArtifacts = [...(this.context.runState.toolArtifacts ?? []), summary];
+    return {
+      ...result,
+      content: `${truncated.text}\n\n[Full output saved to ${summary.path}]`,
+      metadata: {
+        ...result.metadata,
+        truncated: true,
+        toolArtifact: summary
+      }
+    };
+  }
+}

--- a/packages/agent-core/src/tools/bash.ts
+++ b/packages/agent-core/src/tools/bash.ts
@@ -1,5 +1,4 @@
 import type { ToolExecutionContext, ToolResult } from "../types.js";
-import { truncateMiddle } from "../compaction.js";
 import { evaluateExecPolicy, requestToolPermission, resolveWorkspacePath } from "../policy.js";
 import { runBashCommand } from "../command-runner.js";
 import { createPolicyOnlySandboxAdapter } from "../sandbox.js";
@@ -134,16 +133,15 @@ export async function executeBashTool(args: unknown, context: ToolExecutionConte
     result.timedOut,
     result.cancelled
   );
-  const truncated = truncateMiddle(content, context.maxToolOutputChars);
   return {
     ok: !result.timedOut && !result.cancelled && result.exitCode === 0,
-    content: truncated.text,
+    content,
     metadata: {
       exitCode: result.exitCode,
       durationMs: result.durationMs,
       stdoutBytes: result.stdout.byteLength,
       stderrBytes: result.stderr.byteLength,
-      truncated: truncated.truncated,
+      truncated: false,
       settledOn: result.settledOn,
       signal: result.signal,
       timedOut: result.timedOut,

--- a/packages/agent-core/src/tools/bash.ts
+++ b/packages/agent-core/src/tools/bash.ts
@@ -1,7 +1,8 @@
 import type { ToolExecutionContext, ToolResult } from "../types.js";
 import { truncateMiddle } from "../compaction.js";
-import { isProbablyMutatingCommand, requestToolPermission, resolveWorkspacePath } from "../policy.js";
+import { evaluateExecPolicy, requestToolPermission, resolveWorkspacePath } from "../policy.js";
 import { runBashCommand } from "../command-runner.js";
+import { createPolicyOnlySandboxAdapter } from "../sandbox.js";
 
 interface BashArgs {
   command?: unknown;
@@ -53,12 +54,21 @@ export async function executeBashTool(args: unknown, context: ToolExecutionConte
     };
   }
 
-  if (isProbablyMutatingCommand(command)) {
+  const policy = evaluateExecPolicy(command, context.execPolicy);
+  if (policy.action === "deny") {
+    return {
+      ok: false,
+      content: policy.reason,
+      metadata: { execPolicy: policy }
+    };
+  }
+
+  if (policy.action === "prompt") {
     const denied = await requestToolPermission(context, {
       toolName: "bash",
       arguments: args,
-      risk: "execute",
-      reason: `Command appears to mutate files, install packages, change git state, or execute arbitrary code: ${command}`
+      risk: policy.risk,
+      reason: policy.reason
     });
     if (denied) return denied;
   }
@@ -72,10 +82,30 @@ export async function executeBashTool(args: unknown, context: ToolExecutionConte
 
   const timeoutSec = asNumber(parsed.timeoutSec) ?? context.commandTimeoutSec;
   const timeoutMs = Math.max(1, Math.floor(timeoutSec * 1000));
+  const sandboxAdapter = context.sandboxAdapter ?? (
+    context.sandbox?.mode === "disabled" ? undefined : createPolicyOnlySandboxAdapter()
+  );
+  const sandboxDecision = sandboxAdapter
+    ? await sandboxAdapter.prepareExec({
+        toolName: "bash",
+        command,
+        cwd,
+        env: process.env,
+        policy,
+        sandbox: context.sandbox
+      })
+    : { allowed: true };
+  if (!sandboxDecision.allowed) {
+    return {
+      ok: false,
+      content: sandboxDecision.reason ?? "Command was denied by sandbox policy.",
+      metadata: { execPolicy: policy, sandbox: sandboxDecision.metadata ?? { denied: true } }
+    };
+  }
   const result = await runBashCommand({
-    command,
-    cwd,
-    env: process.env,
+    command: sandboxDecision.command ?? command,
+    cwd: sandboxDecision.cwd ?? cwd,
+    env: sandboxDecision.env ?? process.env,
     timeoutMs,
     abortSignal: context.abortSignal
   });
@@ -90,7 +120,9 @@ export async function executeBashTool(args: unknown, context: ToolExecutionConte
         signal: result.signal,
         timedOut: result.timedOut,
         cancelled: result.cancelled,
-        truncated: false
+        truncated: false,
+        execPolicy: policy,
+        sandbox: sandboxDecision.metadata
       }
     };
   }
@@ -115,7 +147,9 @@ export async function executeBashTool(args: unknown, context: ToolExecutionConte
       settledOn: result.settledOn,
       signal: result.signal,
       timedOut: result.timedOut,
-      cancelled: result.cancelled
+      cancelled: result.cancelled,
+      execPolicy: policy,
+      sandbox: sandboxDecision.metadata
     }
   };
 }

--- a/packages/agent-core/src/tools/registry.ts
+++ b/packages/agent-core/src/tools/registry.ts
@@ -32,6 +32,14 @@ import { DEFAULT_SUBAGENTS_ENABLED } from "../defaults.js";
 
 const FILE_MUTATING_TOOLS = new Set(["write", "edit", "apply_patch", "bash", "shell_session", "service"]);
 
+function readonlyRuntime(): RegisteredTool["runtime"] {
+  return { readOnly: true, supportsParallel: true, approval: "auto", sandbox: "bypass" };
+}
+
+function serialRuntime(): RegisteredTool["runtime"] {
+  return { readOnly: false, supportsParallel: false, approval: "prompt", sandbox: "default" };
+}
+
 function resultChangedFiles(result: ToolResult): string[] {
   const metadata = result.metadata ?? {};
   if (metadata.checkOnly === true) return [];
@@ -101,7 +109,8 @@ const bashTool: RegisteredTool = {
     }
   },
   execute: executeBashTool,
-  risk: "execute"
+  risk: "execute",
+  runtime: serialRuntime()
 };
 
 const readTool: RegisteredTool = {
@@ -123,7 +132,8 @@ const readTool: RegisteredTool = {
     }
   },
   execute: executeReadTool,
-  risk: "read"
+  risk: "read",
+  runtime: readonlyRuntime()
 };
 
 const readManyTool: RegisteredTool = {
@@ -161,7 +171,8 @@ const readManyTool: RegisteredTool = {
     }
   },
   execute: executeReadManyTool,
-  risk: "read"
+  risk: "read",
+  runtime: readonlyRuntime()
 };
 
 const writeTool: RegisteredTool = {
@@ -183,7 +194,8 @@ const writeTool: RegisteredTool = {
     }
   },
   execute: executeWriteTool,
-  risk: "write"
+  risk: "write",
+  runtime: serialRuntime()
 };
 
 const editTool: RegisteredTool = {
@@ -206,7 +218,8 @@ const editTool: RegisteredTool = {
     }
   },
   execute: executeEditTool,
-  risk: "write"
+  risk: "write",
+  runtime: serialRuntime()
 };
 
 const serviceTool: RegisteredTool = {
@@ -236,7 +249,8 @@ const serviceTool: RegisteredTool = {
     }
   },
   execute: executeServiceTool,
-  risk: "execute"
+  risk: "execute",
+  runtime: serialRuntime()
 };
 
 const listTool: RegisteredTool = {
@@ -258,7 +272,8 @@ const listTool: RegisteredTool = {
     }
   },
   execute: executeListTool,
-  risk: "read"
+  risk: "read",
+  runtime: readonlyRuntime()
 };
 
 const globTool: RegisteredTool = {
@@ -280,7 +295,8 @@ const globTool: RegisteredTool = {
     }
   },
   execute: executeGlobTool,
-  risk: "read"
+  risk: "read",
+  runtime: readonlyRuntime()
 };
 
 const grepTool: RegisteredTool = {
@@ -305,7 +321,8 @@ const grepTool: RegisteredTool = {
     }
   },
   execute: executeGrepTool,
-  risk: "read"
+  risk: "read",
+  runtime: readonlyRuntime()
 };
 
 const repoQueryTool: RegisteredTool = {
@@ -330,7 +347,8 @@ const repoQueryTool: RegisteredTool = {
     }
   },
   execute: executeRepoQueryTool,
-  risk: "read"
+  risk: "read",
+  runtime: readonlyRuntime()
 };
 
 const symbolSearchTool: RegisteredTool = {
@@ -355,7 +373,8 @@ const symbolSearchTool: RegisteredTool = {
     }
   },
   execute: executeSymbolSearchTool,
-  risk: "read"
+  risk: "read",
+  runtime: readonlyRuntime()
 };
 
 const validateTool: RegisteredTool = {
@@ -379,7 +398,8 @@ const validateTool: RegisteredTool = {
     }
   },
   execute: executeValidateTool,
-  risk: "execute"
+  risk: "execute",
+  runtime: serialRuntime()
 };
 
 function createShellSessionTool(): RegisteredTool & { registryClose: ToolRegistry["close"] } {
@@ -408,6 +428,7 @@ function createShellSessionTool(): RegisteredTool & { registryClose: ToolRegistr
     },
     execute: controller.execute,
     risk: "execute",
+    runtime: serialRuntime(),
     registryClose: controller.close
   };
 }
@@ -429,7 +450,8 @@ const gitStatusTool: RegisteredTool = {
     }
   },
   execute: executeGitStatusTool,
-  risk: "read"
+  risk: "read",
+  runtime: readonlyRuntime()
 };
 
 const gitDiffTool: RegisteredTool = {
@@ -450,7 +472,8 @@ const gitDiffTool: RegisteredTool = {
     }
   },
   execute: executeGitDiffTool,
-  risk: "read"
+  risk: "read",
+  runtime: readonlyRuntime()
 };
 
 const applyPatchTool: RegisteredTool = {
@@ -472,7 +495,8 @@ const applyPatchTool: RegisteredTool = {
     }
   },
   execute: executeApplyPatchTool,
-  risk: "write"
+  risk: "write",
+  runtime: serialRuntime()
 };
 
 const todoTool: RegisteredTool = {
@@ -497,7 +521,8 @@ const todoTool: RegisteredTool = {
     }
   },
   execute: executeTodoTool,
-  risk: "read"
+  risk: "read",
+  runtime: { readOnly: false, supportsParallel: false, approval: "auto", sandbox: "bypass" }
 };
 
 export function createToolRegistryFromTools(
@@ -515,6 +540,9 @@ export function createToolRegistryFromTools(
 
   return {
     definitions: Array.from(toolMap.values(), (tool) => tool.definition),
+    getTool(name: string): RegisteredTool | undefined {
+      return toolMap.get(name);
+    },
     async execute(toolCall: ToolCall, context: ToolExecutionContext): Promise<ToolResult> {
       const tool = toolMap.get(toolCall.function.name);
       if (!tool) {
@@ -603,6 +631,10 @@ export function mergeToolRegistries(registries: ToolRegistry[], options: ToolReg
   }
   return {
     definitions: [...definitionsByName.values()].map((entry) => entry.definition),
+    getTool(name: string): RegisteredTool | undefined {
+      const entry = definitionsByName.get(name);
+      return entry?.registry.getTool?.(name);
+    },
     async execute(toolCall: ToolCall, context: ToolExecutionContext): Promise<ToolResult> {
       const entry = definitionsByName.get(toolCall.function.name);
       if (!entry) return { ok: false, content: `Unknown tool: ${toolCall.function.name}` };
@@ -625,6 +657,9 @@ export function filterToolRegistry(registry: ToolRegistry, filter: ToolRegistryF
   );
   return {
     definitions: registry.definitions.filter((definition) => names.has(definition.function.name)),
+    getTool(name: string): RegisteredTool | undefined {
+      return names.has(name) ? registry.getTool?.(name) : undefined;
+    },
     async execute(toolCall: ToolCall, context: ToolExecutionContext): Promise<ToolResult> {
       if (!names.has(toolCall.function.name)) {
         return { ok: false, content: `Unknown or disabled tool: ${toolCall.function.name}` };

--- a/packages/agent-core/src/types.ts
+++ b/packages/agent-core/src/types.ts
@@ -5,6 +5,70 @@ export type PermissionMode = "ask" | "yolo";
 
 export type ToolRisk = "read" | "write" | "execute" | "network" | "unknown";
 
+export type ToolApprovalMode = "auto" | "prompt" | "deny";
+export type ToolSandboxMode = "default" | "policy_only" | "bypass";
+
+export interface ToolRuntimeMetadata {
+  readOnly?: boolean;
+  supportsParallel?: boolean;
+  waitsForCancellation?: boolean;
+  approval?: ToolApprovalMode;
+  sandbox?: ToolSandboxMode;
+  outputBudget?: number;
+}
+
+export interface ExecPolicyRule {
+  match: string | string[];
+  action: "allow" | "prompt" | "deny";
+  reason?: string;
+}
+
+export interface ExecPolicyConfig {
+  defaultAction?: "allow" | "prompt" | "deny";
+  allowReadOnlyCommands?: boolean;
+  rules?: ExecPolicyRule[];
+}
+
+export interface ExecIntentSummary {
+  command: string;
+  risk: ToolRisk;
+  mutatesWorkspace: boolean;
+  usesNetwork: boolean;
+  changesGitState: boolean;
+  executesCode: boolean;
+  matchedRule?: string;
+  action: "allow" | "prompt" | "deny";
+  reason: string;
+}
+
+export interface SandboxConfig {
+  mode?: "disabled" | "policy_only";
+  network?: "default" | "restricted";
+  filesystem?: "workspace_write" | "read_only";
+}
+
+export interface SandboxExecRequest {
+  toolName: string;
+  command: string;
+  cwd: string;
+  env?: NodeJS.ProcessEnv;
+  policy: ExecIntentSummary;
+  sandbox?: SandboxConfig;
+}
+
+export interface SandboxExecDecision {
+  allowed: boolean;
+  reason?: string;
+  command?: string;
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  metadata?: Record<string, unknown>;
+}
+
+export interface SandboxAdapter {
+  prepareExec(request: SandboxExecRequest): Promise<SandboxExecDecision>;
+}
+
 export interface PermissionRequest {
   toolName: string;
   arguments: unknown;
@@ -192,6 +256,9 @@ export interface ToolExecutionContext {
   model?: string;
   subagentsEnabled?: boolean;
   subagentDepth?: number;
+  execPolicy?: ExecPolicyConfig;
+  sandbox?: SandboxConfig;
+  sandboxAdapter?: SandboxAdapter;
 }
 
 export interface ToolHandler {
@@ -202,11 +269,13 @@ export interface RegisteredTool {
   definition: ToolDefinition;
   execute: ToolHandler;
   risk?: ToolRisk;
+  runtime?: ToolRuntimeMetadata;
 }
 
 export interface ToolRegistry {
   definitions: ToolDefinition[];
   execute(toolCall: ToolCall, context: ToolExecutionContext): Promise<ToolResult>;
+  getTool?(name: string): RegisteredTool | undefined;
   close?(): Promise<void>;
 }
 
@@ -239,6 +308,7 @@ export interface AgentRunState {
   changedFiles: Set<string>;
   contextIndexes?: Map<string, unknown>;
   contextIndexVersion?: number;
+  toolArtifacts?: ToolArtifactSummary[];
 }
 
 export type ContextMode = "off" | "repo-map";
@@ -262,6 +332,36 @@ export interface ContextCompactionSummary {
   fallback_used: boolean;
   duration_ms: number;
   error?: string;
+}
+
+export interface ContextBudgetSummary {
+  estimated_tokens: number;
+  message_count: number;
+  tool_count: number;
+  max_message_history_chars?: number;
+  repo_map_chars?: number;
+  skills_chars?: number;
+}
+
+export interface ToolRuntimeSummary {
+  queued: number;
+  started: number;
+  completed: number;
+  aborted: number;
+  failed: number;
+  parallel_batches: number;
+  serial_batches: number;
+  artifacts: ToolArtifactSummary[];
+}
+
+export interface ToolArtifactSummary {
+  id: string;
+  tool_call_id: string;
+  tool_name: string;
+  path: string;
+  bytes: number;
+  original_chars: number;
+  retained_chars: number;
 }
 
 export interface CodeIndexSummary {
@@ -329,6 +429,9 @@ export interface AgentRunConfig {
   finalEvidenceMode?: AgentFinalEvidenceMode;
   skillsMode?: AgentSkillsMode;
   skillsMaxChars?: number;
+  execPolicy?: ExecPolicyConfig;
+  sandbox?: SandboxConfig;
+  sandboxAdapter?: SandboxAdapter;
   abortSignal?: AbortSignal;
 }
 
@@ -359,11 +462,16 @@ export interface AgentEvent {
     | "tool_call_delta"
     | "model_heartbeat"
     | "run_abort"
+    | "turn_start"
+    | "context_budget"
     | "model_start"
     | "model_end"
     | "assistant_message"
+    | "tool_queued"
     | "tool_start"
+    | "tool_progress"
     | "tool_end"
+    | "tool_aborted"
     | "context_compaction_start"
     | "context_compaction_end"
     | "context_compaction_error"
@@ -425,6 +533,8 @@ export interface AgentRunResult {
   codeIndex?: CodeIndexSummary;
   subagentRuns?: SubagentRunSummary[];
   reviewFindings?: ReviewGateSummary[];
+  toolRuntime?: ToolRuntimeSummary;
+  contextBudget?: ContextBudgetSummary;
 }
 
 export interface WorkspaceManifestEntry {
@@ -537,6 +647,8 @@ export interface SummaryJson {
   code_index?: CodeIndexSummary;
   subagent_runs?: SubagentRunSummary[];
   review_findings?: ReviewGateSummary[];
+  tool_runtime?: ToolRuntimeSummary;
+  context_budget?: ContextBudgetSummary;
 }
 
 export function addUsage(total: TokenTotals, usage: Usage | undefined): void {

--- a/packages/agent-core/src/types.ts
+++ b/packages/agent-core/src/types.ts
@@ -244,6 +244,8 @@ export interface ToolExecutionContext {
   permissionMode: PermissionMode;
   commandTimeoutSec: number;
   maxToolOutputChars: number;
+  maxParallelToolCalls?: number;
+  toolArtifactRootDir?: string;
   permissionDecider?: PermissionDecider;
   runState: AgentRunState;
   alwaysAllowTools: Set<string>;
@@ -393,6 +395,8 @@ export interface AgentRunConfig {
   sessionJsonlPath?: string;
   summaryJsonPath?: string;
   maxToolOutputChars?: number;
+  maxParallelToolCalls?: number;
+  toolArtifactRootDir?: string;
   maxMessageHistoryChars?: number;
   messageHistoryRetain?: number;
   compactionSummaryChars?: number;

--- a/packages/agent-tui/src/components/status-bar.tsx
+++ b/packages/agent-tui/src/components/status-bar.tsx
@@ -75,6 +75,18 @@ function mcpState(result: AgentRunResult | null, enabled?: boolean): string {
   return enabled ? "enabled" : "off";
 }
 
+function observedToolCalls(events: AgentEvent[]): number {
+  const seen = new Set<string>();
+  let anonymous = 0;
+  for (const event of events) {
+    if (event.type !== "tool_queued" && event.type !== "tool_start") continue;
+    const callId = typeof event.metadata?.toolCallId === "string" ? event.metadata.toolCallId : "";
+    if (callId) seen.add(callId);
+    else anonymous += 1;
+  }
+  return seen.size + anonymous;
+}
+
 export function StatusBar(props: StatusBarProps): string {
   const g = glyphs();
   const width = props.width ?? 100;
@@ -82,7 +94,7 @@ export function StatusBar(props: StatusBarProps): string {
   const finish = props.result ? ` ${props.result.finishReason}` : "";
   const turn = props.result?.turns ?? lastTurn(props.events) ?? 0;
   const turnLimit = props.maxTurns ? `/${props.maxTurns}` : "";
-  const toolCalls = props.result?.toolCalls ?? props.events.filter((event) => event.type === "tool_start").length;
+  const toolCalls = props.result?.toolCalls ?? observedToolCalls(props.events);
   const usage = props.result?.usage ?? usageFromEvents(props.events);
   const workspaceBase = path.basename(props.workspacePath) || props.workspacePath;
   const workspace = redactSecretText(props.workspacePath);

--- a/packages/agent-tui/src/components/timeline.tsx
+++ b/packages/agent-tui/src/components/timeline.tsx
@@ -44,16 +44,26 @@ export function formatTimelineEvent(event: AgentEvent): string {
   }
   if (event.type === "model_start") return prefix(g.running, `model turn ${meta.turn ?? "?"} started`);
   if (event.type === "model_end") return prefix(g.ok, joinDetails([`model turn ${meta.turn ?? "?"} ended`, formatUsage(eventUsage(event))]));
+  if (event.type === "context_budget") {
+    const budget = meta.budget as { estimated_tokens?: unknown; message_count?: unknown; tool_count?: unknown } | undefined;
+    return prefix(g.info, joinDetails([`context turn ${meta.turn ?? "?"}`, `${budget?.estimated_tokens ?? "?"} est tokens`, `${budget?.message_count ?? "?"} messages`, `${budget?.tool_count ?? "?"} tools`]));
+  }
   if (event.type === "assistant_message") {
     const toolCalls = Array.isArray(meta.toolCalls) ? meta.toolCalls.length : 0;
     if (toolCalls > 0) return prefix(g.info, `assistant proposed ${toolCalls} tool call${toolCalls === 1 ? "" : "s"}`);
     const content = typeof meta.content === "string" ? oneLine(redactSecretText(meta.content)) : "";
     return prefix(g.info, `assistant ${truncate(content || "(message)", 130)}`);
   }
+  if (event.type === "tool_queued") {
+    return prefix(g.info, `${meta.toolName ?? "tool"} queued`);
+  }
   if (event.type === "tool_start") {
     const toolName = toolNameFromEvent(event);
     const detail = summarizeToolArguments(toolName, toolArgsFromEvent(event));
     return prefix(g.running, joinDetails([`${toolName} started`, detail]));
+  }
+  if (event.type === "tool_aborted") {
+    return prefix(g.fail, joinDetails([`${meta.toolName ?? "tool"} aborted`, truncate(oneLine(redactSecretText(String(meta.reason ?? ""))), 90)]));
   }
   if (event.type === "tool_end") {
     const result = meta.result as { ok?: boolean; content?: string; metadata?: Record<string, unknown> } | undefined;

--- a/packages/agent-tui/src/components/tool-panel.tsx
+++ b/packages/agent-tui/src/components/tool-panel.tsx
@@ -41,10 +41,29 @@ function groupedTools(tools: string[], width: number): string[] {
   return lines;
 }
 
+function terminalToolKey(event: AgentEvent): string {
+  const callId = event.metadata?.toolCallId;
+  if (event.parentId) return `parent:${event.parentId}`;
+  if (typeof callId === "string" && callId.length > 0) return `call:${callId}`;
+  return `event:${event.id}`;
+}
+
+function recentTerminalToolEvents(events: AgentEvent[], limit: number): AgentEvent[] {
+  const byKey = new Map<string, { event: AgentEvent; index: number }>();
+  events.forEach((event, index) => {
+    if (event.type !== "tool_end" && event.type !== "tool_aborted") return;
+    byKey.set(terminalToolKey(event), { event, index });
+  });
+  return [...byKey.values()]
+    .sort((a, b) => a.index - b.index)
+    .map((item) => item.event)
+    .slice(-limit);
+}
+
 export function ToolPanel(events: AgentEvent[], result: AgentRunResult | null, width = 80, height?: number, color = false): string {
   const g = glyphs();
   const innerWidth = Math.max(20, width - 4);
-  const toolEvents = events.filter((event) => event.type === "tool_end" || event.type === "tool_aborted").slice(-8);
+  const toolEvents = recentTerminalToolEvents(events, 8);
   const startsById = new Map(events.filter((event) => event.type === "tool_start").map((event) => [event.id, event]));
   const lines = [
     "Available",

--- a/packages/agent-tui/src/components/tool-panel.tsx
+++ b/packages/agent-tui/src/components/tool-panel.tsx
@@ -44,7 +44,7 @@ function groupedTools(tools: string[], width: number): string[] {
 export function ToolPanel(events: AgentEvent[], result: AgentRunResult | null, width = 80, height?: number, color = false): string {
   const g = glyphs();
   const innerWidth = Math.max(20, width - 4);
-  const toolEvents = events.filter((event) => event.type === "tool_end").slice(-8);
+  const toolEvents = events.filter((event) => event.type === "tool_end" || event.type === "tool_aborted").slice(-8);
   const startsById = new Map(events.filter((event) => event.type === "tool_start").map((event) => [event.id, event]));
   const lines = [
     "Available",
@@ -63,10 +63,12 @@ export function ToolPanel(events: AgentEvent[], result: AgentRunResult | null, w
     const name = typeof meta.toolName === "string" ? meta.toolName : toolNameFromEvent(start ?? event);
     const detail = start ? summarizeToolArguments(name, toolArgsFromEvent(start)) : "";
     const res = meta.result as { ok?: boolean; content?: string; metadata?: Record<string, unknown> } | undefined;
+    const aborted = event.type === "tool_aborted" || res?.metadata?.cancelled === true;
     const marker = res?.ok ? g.ok : g.fail;
     const duration = typeof res?.metadata?.durationMs === "number" ? `${res.metadata.durationMs}ms` : "";
-    const tail = res?.content ? truncate(oneLine(redactSecretText(res.content)), 70) : "";
-    lines.push(truncateToWidth(`${marker} ${name} ${res?.ok ? "ok" : "failed"} ${[duration, detail, tail].filter(Boolean).join(` ${g.separator} `)}`, innerWidth));
+    const tail = res?.content ? truncate(oneLine(redactSecretText(res.content)), 70) : truncate(oneLine(redactSecretText(String(meta.reason ?? ""))), 70);
+    const status = aborted ? "aborted" : (res?.ok ? "ok" : "failed");
+    lines.push(truncateToWidth(`${marker} ${name} ${status} ${[duration, detail, tail].filter(Boolean).join(` ${g.separator} `)}`, innerWidth));
   }
 
   return box({

--- a/packages/agent-tui/src/render/screen.ts
+++ b/packages/agent-tui/src/render/screen.ts
@@ -88,11 +88,13 @@ function usageSummary(options: RenderScreenOptions): string {
   return usage ? formatUsage(usage) : "unknown";
 }
 
-function statusMarker(status: "running" | "ok" | "failed" | undefined, color: boolean): string {
+function statusMarker(status: "queued" | "running" | "ok" | "failed" | "aborted" | undefined, color: boolean): string {
   const g = streamGlyphs();
+  if (status === "queued") return roleColor("dim", g.info, color);
   if (status === "running") return roleColor("warning", g.running, color);
   if (status === "ok") return roleColor("success", g.ok, color);
   if (status === "failed") return roleColor("danger", g.fail, color);
+  if (status === "aborted") return roleColor("warning", g.fail, color);
   return roleColor("dim", g.info, color);
 }
 
@@ -156,12 +158,19 @@ function shouldUseWorkbench(options: RenderScreenOptions, mainHeight: number): b
 }
 
 function runningTools(events: AgentEvent[]): number {
+  const queued = new Set<string>();
   const running = new Set<string>();
   for (const event of events) {
-    if (event.type === "tool_start") running.add(event.id);
-    if (event.type === "tool_end" && event.parentId) running.delete(event.parentId);
+    const callId = typeof event.metadata?.toolCallId === "string" ? event.metadata.toolCallId : "";
+    if (event.type === "tool_queued" && callId) queued.add(callId);
+    if (event.type === "tool_start") {
+      running.add(event.id);
+      if (callId) queued.delete(callId);
+    }
+    if ((event.type === "tool_end" || event.type === "tool_aborted") && event.parentId) running.delete(event.parentId);
+    if ((event.type === "tool_end" || event.type === "tool_aborted") && callId) queued.delete(callId);
   }
-  return running.size;
+  return running.size + queued.size;
 }
 
 function renderBottomStatus(options: RenderScreenOptions): string {

--- a/packages/agent-tui/src/render/transcript.ts
+++ b/packages/agent-tui/src/render/transcript.ts
@@ -4,11 +4,13 @@ import { oneLine } from "../components/formatting.js";
 import { fitStreamLine, muted, roleColor, streamGlyphs } from "./theme.js";
 import { rgb, truncateToWidth, wrapText } from "../ui/theme.js";
 
-function statusMarker(status: "running" | "ok" | "failed" | undefined, color: boolean): string {
+function statusMarker(status: "queued" | "running" | "ok" | "failed" | "aborted" | undefined, color: boolean): string {
   const g = streamGlyphs();
+  if (status === "queued") return muted(g.info, color);
   if (status === "running") return roleColor("warning", g.running, color);
   if (status === "ok") return roleColor("success", g.ok, color);
   if (status === "failed") return roleColor("danger", g.fail, color);
+  if (status === "aborted") return roleColor("warning", g.fail, color);
   return "";
 }
 

--- a/packages/agent-tui/src/view-model.ts
+++ b/packages/agent-tui/src/view-model.ts
@@ -20,7 +20,7 @@ export type TranscriptEntry =
   | { kind: "system"; text: string; timestamp?: string }
   | { kind: "user"; text: string; timestamp?: string }
   | { kind: "assistant"; text: string; toolCalls?: number; timestamp?: string }
-  | { kind: "tool"; name: string; status: "running" | "ok" | "failed"; summary: string; durationMs?: number; timestamp?: string }
+  | { kind: "tool"; name: string; status: "queued" | "running" | "ok" | "failed" | "aborted"; summary: string; durationMs?: number; timestamp?: string }
   | { kind: "approval"; toolName: string; risk: string; summary: string; timestamp?: string }
   | { kind: "diff"; mode: "stat" | "patch"; summary: string; timestamp?: string }
   | { kind: "changes"; files: string[]; timestamp?: string }
@@ -73,10 +73,11 @@ function toolEntry(start: AgentEvent, end: AgentEvent | undefined): TranscriptEn
   const detail = summarizeToolArguments(name, toolArgsFromEvent(start));
   const tail = result?.content ? truncate(oneLine(redactSecretText(result.content)), 90) : "";
   const size = formatBytes(result?.metadata?.sizeBytes);
+  const aborted = end?.type === "tool_aborted" || result?.metadata?.cancelled === true;
   return {
     kind: "tool",
     name,
-    status: end ? resultStatus(result) : "running",
+    status: end ? (aborted ? "aborted" : resultStatus(result)) : (start.type === "tool_queued" ? "queued" : "running"),
     summary: [detail, size, tail].filter(Boolean).join("  "),
     durationMs: toolDuration(result),
     timestamp: eventTime(end ?? start)
@@ -102,10 +103,16 @@ function harnessEntry(start: AgentEvent, end: AgentEvent | undefined): Transcrip
 function entriesFromEvents(events: AgentEvent[]): TranscriptEntry[] {
   const entries: TranscriptEntry[] = [];
   const toolEndsByParent = new Map<string, AgentEvent>();
+  const toolStartsByCallId = new Map<string, AgentEvent>();
+  const toolAbortsByParent = new Map<string, AgentEvent>();
+  const toolAbortsByCallId = new Map<string, AgentEvent>();
   const checkEndsByParent = new Map<string, AgentEvent>();
   let latestAssistantDelta: AgentEvent | null = null;
   for (const event of events) {
     if (event.type === "tool_end" && event.parentId) toolEndsByParent.set(event.parentId, event);
+    if (event.type === "tool_start" && typeof event.metadata?.toolCallId === "string") toolStartsByCallId.set(event.metadata.toolCallId, event);
+    if (event.type === "tool_aborted" && event.parentId) toolAbortsByParent.set(event.parentId, event);
+    if (event.type === "tool_aborted" && typeof event.metadata?.toolCallId === "string") toolAbortsByCallId.set(event.metadata.toolCallId, event);
     if (event.type === "harness_check_end" && event.parentId) checkEndsByParent.set(event.parentId, event);
     if (event.type === "assistant_delta") latestAssistantDelta = event;
   }
@@ -128,8 +135,35 @@ function entriesFromEvents(events: AgentEvent[]): TranscriptEntry[] {
       entries.push({ kind: "assistant", text, toolCalls, timestamp: eventTime(event) });
       continue;
     }
+    if (event.type === "tool_queued") {
+      const callId = typeof meta.toolCallId === "string" ? meta.toolCallId : "";
+      if (callId && toolStartsByCallId.has(callId)) continue;
+      entries.push(toolEntry(event, callId ? toolAbortsByCallId.get(callId) : undefined));
+      continue;
+    }
     if (event.type === "tool_start") {
-      entries.push(toolEntry(event, toolEndsByParent.get(event.id)));
+      entries.push(toolEntry(event, toolAbortsByParent.get(event.id) ?? toolEndsByParent.get(event.id)));
+      continue;
+    }
+    if (event.type === "tool_aborted" && !event.parentId) {
+      const callId = typeof meta.toolCallId === "string" ? meta.toolCallId : "";
+      if (callId && toolStartsByCallId.has(callId)) continue;
+      entries.push({
+        kind: "tool",
+        name: typeof meta.toolName === "string" ? meta.toolName : "tool",
+        status: "aborted",
+        summary: truncate(oneLine(redactSecretText(String(meta.reason ?? ""))), 90),
+        timestamp: eventTime(event)
+      });
+      continue;
+    }
+    if (event.type === "context_budget") {
+      const budget = meta.budget as { estimated_tokens?: unknown; message_count?: unknown; tool_count?: unknown } | undefined;
+      entries.push({
+        kind: "system",
+        text: `context ${budget?.estimated_tokens ?? "?"} est tokens  ${budget?.message_count ?? "?"} messages  ${budget?.tool_count ?? "?"} tools`,
+        timestamp: eventTime(event)
+      });
       continue;
     }
     if (event.type === "harness_check_start") {

--- a/tests/agent-core.exec-policy.test.ts
+++ b/tests/agent-core.exec-policy.test.ts
@@ -1,0 +1,73 @@
+import { mkdtemp } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  classifyShellCommand,
+  createPolicyOnlySandboxAdapter,
+  evaluateExecPolicy,
+  executeBashTool,
+  type ToolExecutionContext
+} from "../packages/agent-core/src/index.js";
+
+async function context(): Promise<ToolExecutionContext> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "sigma-policy-"));
+  return {
+    workspacePath: dir,
+    permissionMode: "ask",
+    commandTimeoutSec: 2,
+    maxToolOutputChars: 1000,
+    runState: { todos: [], nextTodoId: 1, changedFiles: new Set<string>() },
+    alwaysAllowTools: new Set<string>()
+  };
+}
+
+describe("exec policy", () => {
+  it("classifies read-only, workspace-changing, code, network, and git-state commands", () => {
+    expect(classifyShellCommand("git status --short")).toMatchObject({ risk: "read", mutatesWorkspace: false });
+    expect(classifyShellCommand("node script.js")).toMatchObject({ risk: "execute", executesCode: true });
+    expect(classifyShellCommand("git reset --hard")).toMatchObject({ changesGitState: true, mutatesWorkspace: true });
+    expect(classifyShellCommand("curl https://example.com")).toMatchObject({ risk: "network", usesNetwork: true });
+    expect(classifyShellCommand("echo hi > out.txt")).toMatchObject({ mutatesWorkspace: true });
+  });
+
+  it("applies explicit allow, prompt, and deny rules before defaults", () => {
+    expect(evaluateExecPolicy("git status", { rules: [{ match: "git status", action: "allow" }] })).toMatchObject({
+      action: "allow",
+      matchedRule: "git status"
+    });
+    expect(evaluateExecPolicy("node test.js")).toMatchObject({ action: "prompt" });
+    expect(evaluateExecPolicy("rm -rf dist", { rules: [{ match: "rm", action: "deny", reason: "no remove" }] })).toMatchObject({
+      action: "deny",
+      reason: "no remove"
+    });
+  });
+
+  it("records permission and sandbox decisions for bash commands", async () => {
+    const ctx = await context();
+    let decisions = 0;
+    ctx.permissionDecider = {
+      decide: async (request) => {
+        decisions += 1;
+        expect(request.reason).toContain("executes code");
+        return "allow";
+      }
+    };
+    ctx.sandbox = { mode: "policy_only", filesystem: "workspace_write", network: "default" };
+    ctx.sandboxAdapter = createPolicyOnlySandboxAdapter();
+    const result = await executeBashTool({ command: "node -e \"console.log(42)\"" }, ctx);
+    expect(result.ok).toBe(true);
+    expect(result.metadata?.execPolicy).toMatchObject({ action: "prompt", executesCode: true });
+    expect(result.metadata?.sandbox).toMatchObject({ sandboxMode: "policy_only" });
+    expect(decisions).toBe(1);
+  });
+
+  it("blocks network-like commands when policy-only sandbox restricts network", async () => {
+    const ctx = await context();
+    ctx.permissionMode = "yolo";
+    ctx.sandbox = { mode: "policy_only", network: "restricted" };
+    const result = await executeBashTool({ command: "curl https://example.com" }, ctx);
+    expect(result.ok).toBe(false);
+    expect(result.content).toContain("network");
+  });
+});

--- a/tests/agent-core.harness.test.ts
+++ b/tests/agent-core.harness.test.ts
@@ -372,6 +372,37 @@ describe("agent-core harness", () => {
     await expect(stat(path.join(attemptsDir, "attempt-2", "summary.json"))).resolves.toBeTruthy();
   });
 
+  it("stores large tool output artifacts under attempt directories", async () => {
+    const dir = await tempWorkspace();
+    const runDir = await mkdtemp(path.join(os.tmpdir(), "sigma-harness-artifacts-"));
+    const attemptsDir = path.join(runDir, "attempts");
+    const summaryPath = path.join(runDir, "summary.json");
+    const payload = "HARNESS_FULL_OUTPUT_".repeat(80);
+    const model = new SequenceModel([
+      bashResponse(`printf '${payload}'`),
+      finalResponse("done")
+    ]);
+
+    const result = await runAgentHarness({
+      instruction: "capture large output",
+      workspacePath: dir,
+      modelClient: model,
+      validationMode: "off",
+      finalEvidenceMode: "off",
+      reviewAntiGaming: false,
+      permissionMode: "yolo",
+      maxToolOutputChars: 80,
+      summaryJsonPath: summaryPath,
+      attemptsDir
+    });
+
+    const artifact = result.toolRuntime?.artifacts[0];
+    expect(result.status).toBe("completed");
+    expect(artifact?.path).toContain(attemptsDir.split(path.sep).join("/"));
+    await expect(readFile(artifact?.path ?? "", "utf8")).resolves.toContain(payload);
+    await expect(stat(path.join(dir, ".agent", "artifacts"))).rejects.toThrow();
+  });
+
   it("returns a failed result when validation retry limit is exhausted", async () => {
     const dir = await tempWorkspace();
     const model = new SequenceModel([writeResponse("bad.js", "function nope(\n"), finalResponse()]);

--- a/tests/agent-core.loop.test.ts
+++ b/tests/agent-core.loop.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile } from "node:fs/promises";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
@@ -423,6 +423,39 @@ describe("agent loop", () => {
     expect(result.usage).toMatchObject({ inputTokens: 1, outputTokens: 2, totalTokens: 3 });
     expect(events).toEqual(expect.arrayContaining(["assistant_delta", "reasoning_delta", "assistant_message"]));
     expect(model.requests[0].abortSignal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("dispatches tool calls through the runtime and records context budget", async () => {
+    const dir = await tempWorkspace();
+    await writeFile(path.join(dir, "a.txt"), "alpha", "utf8");
+    await writeFile(path.join(dir, "b.txt"), "bravo", "utf8");
+    const events: string[] = [];
+    const bus = new AgentEventBus();
+    bus.on((event) => events.push(event.type));
+    const model = new FakeModel([
+      {
+        message: {
+          role: "assistant",
+          toolCalls: [
+            { id: "read-a", type: "function", function: { name: "read", arguments: { path: "a.txt" } } },
+            { id: "read-b", type: "function", function: { name: "read", arguments: { path: "b.txt" } } }
+          ]
+        }
+      },
+      { message: { role: "assistant", content: "done" } }
+    ]);
+
+    const result = await runAgent({
+      instruction: "read files",
+      workspacePath: dir,
+      modelClient: model,
+      eventBus: bus
+    });
+
+    expect(result.status).toBe("completed");
+    expect(result.toolRuntime).toMatchObject({ queued: 2, completed: 2, parallel_batches: 1 });
+    expect(result.contextBudget?.message_count).toBeGreaterThan(0);
+    expect(events).toEqual(expect.arrayContaining(["turn_start", "context_budget", "tool_queued", "tool_start", "tool_end"]));
   });
 
   it("cancels before a model request", async () => {

--- a/tests/agent-core.loop.test.ts
+++ b/tests/agent-core.loop.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import type { ModelClient, ModelRequest, ModelResponse } from "../packages/agent-ai/src/index.js";
-import { AgentEventBus, runAgent } from "../packages/agent-core/src/index.js";
+import { AgentEventBus, runAgent, type AgentEvent } from "../packages/agent-core/src/index.js";
 
 class FakeModel implements ModelClient {
   readonly provider = "deepseek" as const;
@@ -159,7 +159,11 @@ describe("agent loop", () => {
     const summaryPath = path.join(dir, "summary.json");
     const eventBus = new AgentEventBus();
     const events: string[] = [];
-    eventBus.on((event) => events.push(event.type));
+    const agentEvents: AgentEvent[] = [];
+    eventBus.on((event) => {
+      events.push(event.type);
+      agentEvents.push(event);
+    });
     const model = new FakeModel([
       {
         message: {
@@ -187,6 +191,9 @@ describe("agent loop", () => {
 
     expect(result.status).toBe("completed");
     expect(events).toContain("failure_analysis");
+    const toolStart = agentEvents.find((event) => event.type === "tool_start");
+    const failureAnalysis = agentEvents.find((event) => event.type === "failure_analysis");
+    expect(failureAnalysis?.parentId).toBe(toolStart?.id);
     expect(result.failureAnalyses?.[0]).toMatchObject({ category: "segmentation_fault", confidence: expect.any(Number) });
     expect(result.workflow?.failure_patterns).toEqual([
       expect.objectContaining({ category: "segmentation_fault", count: 1, last_exit_code: 139 })
@@ -456,6 +463,41 @@ describe("agent loop", () => {
     expect(result.toolRuntime).toMatchObject({ queued: 2, completed: 2, parallel_batches: 1 });
     expect(result.contextBudget?.message_count).toBeGreaterThan(0);
     expect(events).toEqual(expect.arrayContaining(["turn_start", "context_budget", "tool_queued", "tool_start", "tool_end"]));
+  });
+
+  it("stores complete bash output artifacts through the runtime", async () => {
+    const dir = await tempWorkspace();
+    const payload = "SIGMA_FULL_OUTPUT_".repeat(80);
+    const model = new FakeModel([
+      {
+        message: {
+          role: "assistant",
+          toolCalls: [
+            {
+              id: "large-bash",
+              type: "function",
+              function: { name: "bash", arguments: { command: `printf '${payload}'` } }
+            }
+          ]
+        }
+      },
+      { message: { role: "assistant", content: "done" } }
+    ]);
+
+    const result = await runAgent({
+      instruction: "capture large output",
+      workspacePath: dir,
+      modelClient: model,
+      permissionMode: "yolo",
+      maxToolOutputChars: 80
+    });
+
+    const artifact = result.toolRuntime?.artifacts[0];
+    expect(artifact).toBeTruthy();
+    const artifactPath = path.isAbsolute(artifact?.path ?? "") ? artifact?.path ?? "" : path.join(dir, artifact?.path ?? "");
+    const artifactText = await readFile(artifactPath, "utf8");
+    expect(artifactText).toContain(payload);
+    expect(result.status).toBe("completed");
   });
 
   it("cancels before a model request", async () => {

--- a/tests/agent-core.redaction.test.ts
+++ b/tests/agent-core.redaction.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import type { ModelClient, ModelRequest, ModelResponse } from "../packages/agent-ai/src/index.js";
-import { runAgent } from "../packages/agent-core/src/index.js";
+import { redactSecrets, runAgent } from "../packages/agent-core/src/index.js";
 
 class SecretModel implements ModelClient {
   readonly provider = "deepseek" as const;
@@ -17,6 +17,21 @@ class SecretModel implements ModelClient {
 }
 
 describe("secret redaction", () => {
+  it("keeps token usage counters while redacting real token fields", () => {
+    const redacted = redactSecrets({
+      input_tokens: 12,
+      output_tokens: 5,
+      token: "sigma-secret-value-abcdef",
+      nested: { auth_token: "sigma-secret-value-ghijkl" }
+    });
+    expect(redacted).toMatchObject({
+      input_tokens: 12,
+      output_tokens: 5,
+      token: "[REDACTED]",
+      nested: { auth_token: "[REDACTED]" }
+    });
+  });
+
   it("redacts env-shaped secrets from summaries and traces", async () => {
     const dir = await mkdtemp(path.join(os.tmpdir(), "sigma-redaction-"));
     const secret = "sigma-secret-value-123456";
@@ -43,4 +58,3 @@ describe("secret redaction", () => {
     }
   });
 });
-

--- a/tests/agent-core.tool-runtime.test.ts
+++ b/tests/agent-core.tool-runtime.test.ts
@@ -98,4 +98,111 @@ describe("ToolRuntime", () => {
     expect(artifact?.path).toMatch(/\.agent\/artifacts\/runtime-test\/big_read-/);
     await expect(readFile(path.join(ctx.workspacePath, artifact?.path ?? ""), "utf8")).resolves.toBe("x".repeat(200));
   });
+
+  it("honors the default parallel tool limit for read-only batches", async () => {
+    const ctx = await context();
+    const tools = Array.from({ length: 6 }, (_, index): RegisteredTool => ({
+      definition: {
+        type: "function",
+        function: {
+          name: `read_${index}`,
+          description: "runtime test tool",
+          parameters: { type: "object", additionalProperties: false }
+        }
+      },
+      risk: "read",
+      runtime: { readOnly: true, supportsParallel: true },
+      execute: async () => {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await sleep(40);
+        active -= 1;
+        return { ok: true, content: `read_${index}` };
+      }
+    }));
+    let active = 0;
+    let maxActive = 0;
+    const registry = createToolRegistryFromTools(tools);
+    const runtime = new ToolRuntime(registry, ctx);
+
+    await runtime.executeBatch(tools.map((registered, index) => call(String(index), registered.definition.function.name)), {
+      emit: async () => {},
+      execute: async (toolCall) => ({ result: await registry.execute(toolCall, ctx), value: {} })
+    });
+
+    expect(maxActive).toBeLessThanOrEqual(4);
+    expect(runtime.summary()).toMatchObject({ parallel_batches: 2, completed: 6 });
+  });
+
+  it("uses structured cancellation metadata instead of matching output text", async () => {
+    const ctx = await context();
+    const registry = createToolRegistryFromTools([
+      {
+        definition: {
+          type: "function",
+          function: {
+            name: "text_abort",
+            description: "returns abort-looking text",
+            parameters: { type: "object", additionalProperties: false }
+          }
+        },
+        risk: "read",
+        runtime: { readOnly: true, supportsParallel: true },
+        execute: async () => ({ ok: false, content: "operation aborted by upstream" })
+      },
+      {
+        definition: {
+          type: "function",
+          function: {
+            name: "structured_abort",
+            description: "returns cancellation metadata",
+            parameters: { type: "object", additionalProperties: false }
+          }
+        },
+        risk: "read",
+        runtime: { readOnly: true, supportsParallel: true },
+        execute: async () => ({ ok: false, content: "stopped", metadata: { cancelled: true, cancelReason: "test_cancelled" } })
+      }
+    ]);
+    const runtime = new ToolRuntime(registry, ctx);
+    const aborted: AgentEvent[] = [];
+
+    await runtime.executeBatch([call("text", "text_abort"), call("structured", "structured_abort")], {
+      emit: async (type, metadata, parentId) => {
+        const event = {
+          id: `${type}-${aborted.length}`,
+          timestamp: new Date().toISOString(),
+          type,
+          runId: "runtime-test",
+          metadata,
+          parentId
+        } as AgentEvent;
+        if (type === "tool_aborted") aborted.push(event);
+        return event;
+      },
+      execute: async (toolCall) => ({ result: await registry.execute(toolCall, ctx), value: {} })
+    });
+
+    expect(aborted).toHaveLength(1);
+    expect(aborted[0].metadata).toMatchObject({ toolCallId: "structured", reason: "test_cancelled" });
+  });
+
+  it("can write large-output artifacts outside the workspace", async () => {
+    const ctx = await context(40);
+    const artifactRoot = await mkdtemp(path.join(os.tmpdir(), "sigma-runtime-artifacts-"));
+    ctx.toolArtifactRootDir = artifactRoot;
+    const registry = createToolRegistryFromTools([
+      tool("big_external", { readOnly: true, output: "z".repeat(200) })
+    ]);
+    const runtime = new ToolRuntime(registry, ctx);
+    const [result] = await runtime.executeBatch([call("external-1", "big_external")], {
+      emit: async () => {},
+      execute: async (toolCall) => ({ result: await registry.execute(toolCall, ctx), value: {} })
+    });
+    const artifact = result.result.metadata?.toolArtifact as { path?: string } | undefined;
+
+    expect(artifact?.path).toContain(artifactRoot.split(path.sep).join("/"));
+    expect(artifact?.path).not.toContain(".agent/artifacts");
+    await expect(readFile(artifact?.path ?? "", "utf8")).resolves.toBe("z".repeat(200));
+  });
 });

--- a/tests/agent-core.tool-runtime.test.ts
+++ b/tests/agent-core.tool-runtime.test.ts
@@ -1,0 +1,101 @@
+import { mkdtemp, readFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import type { ToolCall } from "../packages/agent-ai/src/index.js";
+import {
+  createToolRegistryFromTools,
+  ToolRuntime,
+  type AgentEvent,
+  type RegisteredTool,
+  type ToolExecutionContext
+} from "../packages/agent-core/src/index.js";
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function call(id: string, name: string): ToolCall {
+  return { id, type: "function", function: { name, arguments: {} } };
+}
+
+async function context(maxToolOutputChars = 1000): Promise<ToolExecutionContext> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "sigma-runtime-"));
+  return {
+    workspacePath: dir,
+    permissionMode: "ask",
+    commandTimeoutSec: 2,
+    maxToolOutputChars,
+    runId: "runtime-test",
+    runState: { todos: [], nextTodoId: 1, changedFiles: new Set<string>() },
+    alwaysAllowTools: new Set<string>()
+  };
+}
+
+function tool(name: string, options: { delayMs?: number; readOnly?: boolean; output?: string }): RegisteredTool {
+  return {
+    definition: {
+      type: "function",
+      function: {
+        name,
+        description: "runtime test tool",
+        parameters: { type: "object", additionalProperties: false }
+      }
+    },
+    risk: options.readOnly ? "read" : "write",
+    runtime: {
+      readOnly: options.readOnly,
+      supportsParallel: options.readOnly
+    },
+    execute: async () => {
+      if (options.delayMs) await sleep(options.delayMs);
+      return { ok: true, content: options.output ?? name };
+    }
+  };
+}
+
+describe("ToolRuntime", () => {
+  it("runs consecutive parallel-safe tools together and serial tools as barriers", async () => {
+    const ctx = await context();
+    const registry = createToolRegistryFromTools([
+      tool("read_a", { delayMs: 80, readOnly: true }),
+      tool("read_b", { delayMs: 80, readOnly: true }),
+      tool("write_a", { delayMs: 40, readOnly: false }),
+      tool("read_c", { delayMs: 20, readOnly: true })
+    ]);
+    const runtime = new ToolRuntime(registry, ctx);
+    const events: AgentEvent["type"][] = [];
+    const startedAt = Date.now();
+    const results = await runtime.executeBatch(
+      [call("1", "read_a"), call("2", "read_b"), call("3", "write_a"), call("4", "read_c")],
+      {
+        emit: async (type) => {
+          events.push(type);
+        },
+        execute: async (toolCall) => ({ result: await registry.execute(toolCall, ctx), value: {} })
+      }
+    );
+    const durationMs = Date.now() - startedAt;
+    expect(results.map((result) => result.result.content)).toEqual(["read_a", "read_b", "write_a", "read_c"]);
+    expect(durationMs).toBeLessThan(180);
+    expect(runtime.summary()).toMatchObject({ queued: 4, started: 4, completed: 4, parallel_batches: 2, serial_batches: 1 });
+    expect(events).toContain("tool_queued");
+    expect(events).toContain("tool_progress");
+  });
+
+  it("stores oversized tool output as an artifact and returns a bounded response", async () => {
+    const ctx = await context(40);
+    const registry = createToolRegistryFromTools([
+      tool("big_read", { readOnly: true, output: "x".repeat(200) })
+    ]);
+    const runtime = new ToolRuntime(registry, ctx);
+    const [result] = await runtime.executeBatch([call("big-1", "big_read")], {
+      emit: async () => {},
+      execute: async (toolCall) => ({ result: await registry.execute(toolCall, ctx), value: {} })
+    });
+    const artifact = result.result.metadata?.toolArtifact as { path?: string } | undefined;
+    expect(result.result.content).toContain("Full output saved");
+    expect(artifact?.path).toMatch(/\.agent\/artifacts\/runtime-test\/big_read-/);
+    await expect(readFile(path.join(ctx.workspacePath, artifact?.path ?? ""), "utf8")).resolves.toBe("x".repeat(200));
+  });
+});

--- a/tests/agent-core.tools.test.ts
+++ b/tests/agent-core.tools.test.ts
@@ -86,12 +86,12 @@ describe("agent-core tools", () => {
     expect(Date.now() - startedAt).toBeLessThan(3000);
   });
 
-  it("truncates large bash output with head and tail", async () => {
+  it("returns complete large bash output for runtime budgeting", async () => {
     const { context } = await workspace();
     context.maxToolOutputChars = 80;
     const result = await executeBashTool({ command: "printf 'abcdef%.0s' {1..80}" }, context);
-    expect(result.metadata?.truncated).toBe(true);
-    expect(result.content).toContain("[truncated]");
+    expect(result.metadata?.truncated).toBe(false);
+    expect(result.content).toContain("abcdef".repeat(80));
   });
 
   it("reads a relative file", async () => {

--- a/tests/agent-tui.render.test.ts
+++ b/tests/agent-tui.render.test.ts
@@ -383,6 +383,41 @@ describe("agent-tui stream rendering", () => {
     }));
   });
 
+  it("renders queued, aborted, and context budget events", () => {
+    const queued = event("tool_queued", { toolCallId: "call-1", toolName: "read" });
+    const aborted = event("tool_aborted", { toolCallId: "call-2", toolName: "bash", reason: "abort signal" });
+    const contextBudget = event("context_budget", {
+      budget: { estimated_tokens: 123, message_count: 4, tool_count: 12 }
+    });
+    const entries = buildTranscript({
+      workspacePath: "/tmp/sigma",
+      events: [queued, aborted, contextBudget],
+      result: null
+    });
+    expect(entries).toContainEqual(expect.objectContaining({ kind: "tool", name: "read", status: "queued" }));
+    expect(entries).toContainEqual(expect.objectContaining({ kind: "tool", name: "bash", status: "aborted" }));
+    expect(entries.some((entry) => entry.kind === "system" && entry.text.includes("123 est tokens"))).toBe(true);
+
+    const rendered = renderScreen({
+      workspacePath: "/tmp/sigma",
+      provider: "deepseek",
+      permissionMode: "ask",
+      mode: "build",
+      running: true,
+      result: null,
+      events: [queued, aborted, contextBudget],
+      message: null,
+      composer: createComposerState(),
+      entries,
+      width: 96,
+      height: 18,
+      color: false
+    });
+    expect(rendered).toContain("read");
+    expect(rendered).toContain("context 123 est tokens");
+    expect(assertWithinWidth(rendered, 96)).toBe(true);
+  });
+
   it("redacts approval details and truncates diff output with color disabled", () => {
     const request: PermissionRequest = {
       toolName: "bash",

--- a/tests/agent-tui.render.test.ts
+++ b/tests/agent-tui.render.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import type { AgentEvent, AgentRunResult, PermissionRequest } from "../packages/agent-core/src/index.js";
 import { approvalPromptLines } from "../packages/agent-tui/src/components/approval-prompt.js";
 import { renderDiffLines } from "../packages/agent-tui/src/components/diff-panel.js";
+import { ToolPanel } from "../packages/agent-tui/src/components/tool-panel.js";
 import { createComposerState } from "../packages/agent-tui/src/composer-state.js";
 import { mergeDisabledToolsForMode, PLAN_DISABLED_TOOLS } from "../packages/agent-tui/src/mode.js";
 import { renderScreen } from "../packages/agent-tui/src/render/screen.js";
@@ -416,6 +417,24 @@ describe("agent-tui stream rendering", () => {
     expect(rendered).toContain("read");
     expect(rendered).toContain("context 123 est tokens");
     expect(assertWithinWidth(rendered, 96)).toBe(true);
+  });
+
+  it("dedupes terminal tool events in the tool panel", () => {
+    const start = event("tool_start", {
+      toolCall: { id: "call-1", function: { name: "bash", arguments: { command: "sleep 5" } } },
+      toolCallId: "call-1",
+      toolName: "bash"
+    });
+    const aborted = event("tool_aborted", { toolCallId: "call-1", toolName: "bash", reason: "abort_signal" }, start.id);
+    const end = event("tool_end", {
+      toolCallId: "call-1",
+      toolName: "bash",
+      result: { ok: false, content: "Tool call cancelled.", metadata: { cancelled: true } }
+    }, start.id);
+
+    const rendered = ToolPanel([start, aborted, end], null, 96, undefined, false);
+
+    expect(rendered.match(/bash aborted/g)).toHaveLength(1);
   });
 
   it("redacts approval details and truncates diff output with color disabled", () => {


### PR DESCRIPTION
## Summary

Adds the first v1 runtime foundations for Sigma Agent:

- Introduces a core `ToolRuntime` that queues tools, runs parallel-safe read tools together, preserves serial barriers for mutating/executing tools, emits lifecycle events, and stores oversized outputs as artifacts.
- Adds execution-policy classification plus a policy-only sandbox adapter for bash command intent checks.
- Adds turn/context-budget events and summary fields for runtime and context visibility.
- Updates CLI/TUI rendering for queued, aborted, and context-budget events.
- Keeps benchmark-boundary constraints intact and adds regression coverage for redaction counters.

## Validation

- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm test:harbor`

## Notes

This keeps the v1 sandbox intentionally policy-only. The adapter interface is in place for a future OS-backed implementation.