### PR TITLE
Add sandbox runtime and Windows helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,7 +478,9 @@ Tool calls are dispatched through the core tool runtime. Read-only tools that de
 
 Each turn also emits `turn_start` and `context_budget`. The budget is an estimate of current model-visible messages, tool definitions, repo map, and selected skills. Oversized runtime tool output can be saved under `.agent/artifacts/<run-id>/`, with the model receiving a bounded preview plus an artifact reference.
 
-Shell execution now passes through an execution policy classifier before `bash` starts. The classifier records whether a command appears read-only, workspace-changing, git-state-changing, network-using, or code-executing. Policy rules can allow, prompt, or deny command prefixes; the default remains conservative in `ask` and permissive in `yolo`. A policy-only sandbox adapter is included for filesystem/network intent checks, with the interface left open for stronger OS-backed adapters later.
+Shell execution now passes through an execution policy classifier before `bash` starts. The classifier records whether a command appears read-only, workspace-changing, git-state-changing, network-using, or code-executing. Policy rules can allow, prompt, or deny command prefixes; the default remains conservative in `ask` and permissive in `yolo`. Sandbox-aware execution is used for bash, service, shell sessions, and harness precheck/validation commands. On Linux, the bubblewrap backend mounts only required system paths plus the workspace/read roots, overlays configured write roots, and protects `denyRead`/`denyWrite` paths where the OS can enforce them. On Windows, the native helper uses a restricted token and restores any temporary ACL changes before returning.
+
+If an OS sandbox backend is unavailable and `sandbox.required=false`, Sigma may fall back to policy-only checks. Tool metadata, harness results, stream UI, and `agent doctor` include a clear warning when this happens. Use `--sandbox-required` (or `AGENT_SANDBOX_REQUIRED=true`) for fail-closed automation, including benchmark or harness runs where policy-only fallback is not acceptable.
 
 The core loop exposes these default tools:
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "smoke:local": "pnpm build && node scripts/smoke-local.mjs",
     "smoke:local:fake": "pnpm build && node scripts/smoke-local.mjs --provider fake",
     "smoke:harbor": "node scripts/run-bash.mjs scripts/smoke-harbor.sh",
+    "verify:sandbox": "node scripts/verify-sandbox.mjs",
     "bench:tb:smoke": "node scripts/bench-terminal-bench.mjs --mode smoke",
     "bench:tb:k": "node scripts/bench-terminal-bench.mjs --mode k",
     "bench:tb:task": "node scripts/bench-terminal-bench.mjs --mode task",

--- a/packages/agent-cli/src/commands/doctor.ts
+++ b/packages/agent-cli/src/commands/doctor.ts
@@ -1,6 +1,6 @@
 import { access } from "node:fs/promises";
 import { createModelClient } from "agent-ai";
-import { redactSecrets } from "agent-core";
+import { createDefaultSandboxAdapter, normalizeSandboxConfig, redactSecrets } from "agent-core";
 import { loadCliConfig, parseArgs } from "../config.js";
 import { maskSecret } from "../output.js";
 
@@ -41,6 +41,10 @@ export async function runDoctorCommand(argv: string[]): Promise<number> {
     provider: config.provider,
     model: config.model ?? null,
     providerKeys: providerKeyStatusJson(config.provider),
+    sandbox: {
+      effective: normalizeSandboxConfig(config.workspace, config.sandbox),
+      availability: await createDefaultSandboxAdapter().checkAvailability?.(config.sandbox, config.workspace)
+    },
     apiCheck: {
       requested: flags["check-api"] === true,
       status: "skipped" as "skipped" | "ok" | "failed",
@@ -52,6 +56,13 @@ export async function runDoctorCommand(argv: string[]): Promise<number> {
   lines.push(`provider=${config.provider}`);
   lines.push(`model=${config.model ?? "(provider default)"}`);
   lines.push(providerKeyStatus(config.provider));
+  const sandboxAvailability = report.sandbox.availability;
+  lines.push(
+    `sandbox=${report.sandbox.effective.mode}/${report.sandbox.effective.backend}` +
+      ` network=${report.sandbox.effective.network.mode}` +
+      ` available=${sandboxAvailability?.available ?? false}` +
+      `${sandboxAvailability?.reason ? ` reason=${sandboxAvailability.reason}` : ""}`
+  );
 
   try {
     await access(config.workspace);

--- a/packages/agent-cli/src/commands/doctor.ts
+++ b/packages/agent-cli/src/commands/doctor.ts
@@ -4,6 +4,11 @@ import { createDefaultSandboxAdapter, normalizeSandboxConfig, redactSecrets } fr
 import { loadCliConfig, parseArgs } from "../config.js";
 import { maskSecret } from "../output.js";
 
+function fallbackWarning(availability: { available: boolean; backend: string; reason?: string } | undefined, required: boolean): string | null {
+  if (!availability || availability.available || required) return null;
+  return `OS sandbox backend '${availability.backend}' is unavailable; commands will use policy-only checks because sandbox.required=false. Use --sandbox-required to fail closed.`;
+}
+
 function providerKeyStatus(provider: string): string {
   if (provider === "deepseek") {
     return `DEEPSEEK_API_KEY=${maskSecret(process.env.DEEPSEEK_API_KEY)}`;
@@ -43,7 +48,8 @@ export async function runDoctorCommand(argv: string[]): Promise<number> {
     providerKeys: providerKeyStatusJson(config.provider),
     sandbox: {
       effective: normalizeSandboxConfig(config.workspace, config.sandbox),
-      availability: await createDefaultSandboxAdapter().checkAvailability?.(config.sandbox, config.workspace)
+      availability: await createDefaultSandboxAdapter().checkAvailability?.(config.sandbox, config.workspace),
+      fallbackWarning: null as string | null
     },
     apiCheck: {
       requested: flags["check-api"] === true,
@@ -51,6 +57,7 @@ export async function runDoctorCommand(argv: string[]): Promise<number> {
       message: null as string | null
     }
   };
+  report.sandbox.fallbackWarning = fallbackWarning(report.sandbox.availability, report.sandbox.effective.required);
 
   lines.push(`node=${process.version}`);
   lines.push(`provider=${config.provider}`);
@@ -61,7 +68,8 @@ export async function runDoctorCommand(argv: string[]): Promise<number> {
     `sandbox=${report.sandbox.effective.mode}/${report.sandbox.effective.backend}` +
       ` network=${report.sandbox.effective.network.mode}` +
       ` available=${sandboxAvailability?.available ?? false}` +
-      `${sandboxAvailability?.reason ? ` reason=${sandboxAvailability.reason}` : ""}`
+      `${sandboxAvailability?.reason ? ` reason=${sandboxAvailability.reason}` : ""}` +
+      `${report.sandbox.fallbackWarning ? ` warning=${report.sandbox.fallbackWarning}` : ""}`
   );
 
   try {

--- a/packages/agent-cli/src/commands/run.ts
+++ b/packages/agent-cli/src/commands/run.ts
@@ -90,6 +90,15 @@ Core flags:
   --max-turns <number>
   --max-wall-time-sec <number>
   --command-timeout-sec <number>
+  --sandbox <read-only|workspace-write|danger-full-access|policy-only|external>
+  --sandbox-backend <auto|bubblewrap|seatbelt|windows|external|policy-only>
+  --sandbox-required
+  --sandbox-network <default|restricted|disabled>
+  --sandbox-add-read <comma-separated-paths>
+  --sandbox-add-write <comma-separated-paths>
+  --sandbox-deny-read <comma-separated-paths>
+  --sandbox-deny-write <comma-separated-paths>
+  --sandbox-external-command <command>
 
 Run-controller flags:
   --validation-mode <off|auto>
@@ -186,6 +195,7 @@ async function runNonInteractiveCommand(
       maxWallTimeSec: cliConfig.maxWallTimeSec,
       commandTimeoutSec: cliConfig.commandTimeoutSec,
       permissionMode: cliConfig.permissionMode,
+      sandbox: cliConfig.sandbox,
       traceJsonlPath: cliConfig.traceJsonl,
       sessionJsonlPath: cliConfig.sessionJsonl,
       summaryJsonPath: cliConfig.summaryJson,

--- a/packages/agent-cli/src/config.ts
+++ b/packages/agent-cli/src/config.ts
@@ -10,14 +10,19 @@ import type {
   CompactionFallbackMode,
   CompactionMode,
   ContextMode,
-  PermissionMode
+  PermissionMode,
+  SandboxBackend,
+  SandboxConfig,
+  SandboxMode,
+  SandboxNetworkMode
 } from "agent-core";
 import {
   DEFAULT_COMPACTION_MODE,
   DEFAULT_FINAL_EVIDENCE_MODE,
   DEFAULT_MAX_MESSAGE_HISTORY_CHARS,
   DEFAULT_SUBAGENTS_ENABLED,
-  DEFAULT_VALIDATION_MODE
+  DEFAULT_VALIDATION_MODE,
+  createDefaultSandboxConfig
 } from "agent-core";
 
 export interface ParsedArgs {
@@ -72,6 +77,7 @@ export interface CliConfig {
   subagentMaxTurns?: number;
   subagentMaxOutputChars?: number;
   reviewAntiGaming: boolean;
+  sandbox: SandboxConfig;
   enableMcp: boolean;
   mcpConfig?: string;
   noStreamUi: boolean;
@@ -112,6 +118,7 @@ const BOOLEAN_FLAGS = new Set([
   "no-subagents",
   "quiet",
   "review-anti-gaming",
+  "sandbox-required",
   "stream-ui"
 ]);
 
@@ -226,6 +233,31 @@ function flattenConfig(parsed: unknown): ConfigValues {
   addSection("review", {
     anti_gaming: "review_anti_gaming"
   });
+  addSection("sandbox", {
+    mode: "sandbox_mode",
+    backend: "sandbox_backend",
+    required: "sandbox_required",
+    external_command: "sandbox_external_command",
+    external_args: "sandbox_external_args"
+  });
+  const sandbox = parsed.sandbox;
+  if (isRecord(sandbox)) {
+    const network = sandbox.network;
+    if (isRecord(network)) {
+      if (network.mode !== undefined) result.sandbox_network_mode = network.mode;
+      if (network.allowed_hosts !== undefined) result.sandbox_network_allowed_hosts = network.allowed_hosts;
+      if (network.denied_hosts !== undefined) result.sandbox_network_denied_hosts = network.denied_hosts;
+      if (network.allow_localhost !== undefined) result.sandbox_network_allow_localhost = network.allow_localhost;
+    }
+    const filesystem = sandbox.filesystem;
+    if (isRecord(filesystem)) {
+      if (filesystem.read_roots !== undefined) result.sandbox_read_roots = filesystem.read_roots;
+      if (filesystem.write_roots !== undefined) result.sandbox_write_roots = filesystem.write_roots;
+      if (filesystem.deny_read !== undefined) result.sandbox_deny_read = filesystem.deny_read;
+      if (filesystem.deny_write !== undefined) result.sandbox_deny_write = filesystem.deny_write;
+      if (filesystem.temp_root !== undefined) result.sandbox_temp_root = filesystem.temp_root;
+    }
+  }
   addSection("mcp", {
     enabled: "enable_mcp",
     config: "mcp_config"
@@ -287,6 +319,43 @@ function optionalProviderValue(value: unknown): ProviderName | undefined {
 function permissionModeValue(value: unknown): PermissionMode {
   if (value === "ask" || value === "yolo") return value;
   throw new Error(`Unsupported permission mode '${String(value)}'. Use ask or yolo.`);
+}
+
+function sandboxModeValue(value: unknown): SandboxMode {
+  if (
+    value === "read-only" ||
+    value === "workspace-write" ||
+    value === "danger-full-access" ||
+    value === "policy-only" ||
+    value === "policy_only" ||
+    value === "external" ||
+    value === "disabled"
+  ) {
+    return value;
+  }
+  if (value === "read_only") return "read-only";
+  if (value === "workspace_write") return "workspace-write";
+  throw new Error(`Unsupported sandbox mode '${String(value)}'. Use read-only, workspace-write, danger-full-access, policy-only, external, or disabled.`);
+}
+
+function sandboxBackendValue(value: unknown): SandboxBackend {
+  if (
+    value === "auto" ||
+    value === "bubblewrap" ||
+    value === "seatbelt" ||
+    value === "windows" ||
+    value === "external" ||
+    value === "policy-only" ||
+    value === "policy_only"
+  ) {
+    return value;
+  }
+  throw new Error(`Unsupported sandbox backend '${String(value)}'. Use auto, bubblewrap, seatbelt, windows, external, or policy-only.`);
+}
+
+function sandboxNetworkModeValue(value: unknown): SandboxNetworkMode {
+  if (value === "default" || value === "restricted" || value === "disabled") return value;
+  throw new Error(`Unsupported sandbox network mode '${String(value)}'. Use default, restricted, or disabled.`);
 }
 
 function validationModeValue(value: unknown): AgentHarnessValidationMode {
@@ -358,6 +427,100 @@ function optionalNumberValue(value: unknown): number | undefined {
   return Number.isFinite(parsed) ? parsed : undefined;
 }
 
+function optionalStringList(value: unknown): string[] | undefined {
+  const list = stringListValue(value);
+  return list.length > 0 ? list : undefined;
+}
+
+function sandboxConfigFromValues(
+  flags: Record<string, string | boolean>,
+  config: ConfigValues
+): SandboxConfig {
+  const defaults = createDefaultSandboxConfig();
+  const modeValue =
+    stringValue(flags.sandbox) ??
+    process.env.AGENT_SANDBOX ??
+    stringValue(config.sandbox_mode);
+  const backendValue =
+    stringValue(flags["sandbox-backend"]) ??
+    process.env.AGENT_SANDBOX_BACKEND ??
+    stringValue(config.sandbox_backend);
+  const networkModeValue =
+    stringValue(flags["sandbox-network"]) ??
+    process.env.AGENT_SANDBOX_NETWORK ??
+    stringValue(config.sandbox_network_mode);
+  const externalCommand =
+    stringValue(flags["sandbox-external-command"]) ??
+    process.env.AGENT_SANDBOX_EXTERNAL_COMMAND ??
+    stringValue(config.sandbox_external_command);
+
+  const sandbox: SandboxConfig = {
+    mode: modeValue ? sandboxModeValue(modeValue) : defaults.mode,
+    backend: backendValue ? sandboxBackendValue(backendValue) : defaults.backend,
+    required: boolValue(
+      flags["sandbox-required"] ?? process.env.AGENT_SANDBOX_REQUIRED ?? config.sandbox_required,
+      defaults.required ?? false
+    ),
+    network: {
+      mode: networkModeValue ? sandboxNetworkModeValue(networkModeValue) : "restricted",
+      allowedHosts: optionalStringList(
+        flags["sandbox-allowed-hosts"] ??
+          process.env.AGENT_SANDBOX_ALLOWED_HOSTS ??
+          config.sandbox_network_allowed_hosts
+      ),
+      deniedHosts: optionalStringList(
+        flags["sandbox-denied-hosts"] ??
+          process.env.AGENT_SANDBOX_DENIED_HOSTS ??
+          config.sandbox_network_denied_hosts
+      ),
+      allowLocalhost: boolValue(
+        flags["sandbox-allow-localhost"] ??
+          process.env.AGENT_SANDBOX_ALLOW_LOCALHOST ??
+          config.sandbox_network_allow_localhost,
+        true
+      )
+    },
+    filesystem: {
+      readRoots: optionalStringList(
+        flags["sandbox-add-read"] ??
+          process.env.AGENT_SANDBOX_ADD_READ ??
+          config.sandbox_read_roots
+      ),
+      writeRoots: optionalStringList(
+        flags["sandbox-add-write"] ??
+          process.env.AGENT_SANDBOX_ADD_WRITE ??
+          config.sandbox_write_roots
+      ),
+      denyRead: optionalStringList(
+        flags["sandbox-deny-read"] ??
+          process.env.AGENT_SANDBOX_DENY_READ ??
+          config.sandbox_deny_read
+      ),
+      denyWrite: optionalStringList(
+        flags["sandbox-deny-write"] ??
+          process.env.AGENT_SANDBOX_DENY_WRITE ??
+          config.sandbox_deny_write
+      ),
+      tempRoot:
+        stringValue(flags["sandbox-temp-root"]) ??
+        process.env.AGENT_SANDBOX_TEMP_ROOT ??
+        stringValue(config.sandbox_temp_root)
+    },
+    external: externalCommand
+      ? {
+          command: externalCommand,
+          args: optionalStringList(
+            flags["sandbox-external-args"] ??
+              process.env.AGENT_SANDBOX_EXTERNAL_ARGS ??
+              config.sandbox_external_args
+          ) ?? []
+        }
+      : defaults.external
+  };
+
+  return sandbox;
+}
+
 export function loadCliConfig(flags: Record<string, string | boolean>): CliConfig {
   const homeConfig = loadTomlConfig(path.join(os.homedir(), ".agent", "config.toml"));
   const preliminaryWorkspace =
@@ -416,6 +579,7 @@ export function loadCliConfig(flags: Record<string, string | boolean>): CliConfi
       stringValue(config.validation_mode) ??
       DEFAULTS.validationMode
   );
+  const sandbox = sandboxConfigFromValues(flags, config);
 
   return {
     workspace,
@@ -438,6 +602,7 @@ export function loadCliConfig(flags: Record<string, string | boolean>): CliConfi
         stringValue(config.permission_mode) ??
         DEFAULTS.permissionMode
     ),
+    sandbox,
     traceJsonl,
     summaryJson,
     sessionJsonl,

--- a/packages/agent-cli/src/index.ts
+++ b/packages/agent-cli/src/index.ts
@@ -39,6 +39,9 @@ Common run flags:
   --workspace <path>
   --provider <deepseek|glm>
   --permission-mode <ask|yolo>
+  --sandbox <read-only|workspace-write|danger-full-access|policy-only|external>
+  --sandbox-required
+  --sandbox-network <default|restricted|disabled>
   --output-format <text|json|stream-json>
   --json
   --quiet
@@ -81,6 +84,16 @@ function completionScript(shell: string): string {
     "--provider",
     "--model",
     "--permission-mode",
+    "--sandbox",
+    "--sandbox-backend",
+    "--sandbox-required",
+    "--sandbox-network",
+    "--sandbox-add-read",
+    "--sandbox-add-write",
+    "--sandbox-deny-read",
+    "--sandbox-deny-write",
+    "--sandbox-external-command",
+    "--sandbox-external-args",
     "--max-turns",
     "--max-wall-time-sec",
     "--command-timeout-sec",
@@ -164,6 +177,7 @@ function tuiOptionsFromCliConfig(config: CliConfig): TuiAppOptions {
     maxTurns: config.maxTurns,
     maxWallTimeSec: config.maxWallTimeSec,
     commandTimeoutSec: config.commandTimeoutSec,
+    sandbox: config.sandbox,
     validationMode: config.validationMode,
     validationCommands: config.validationCommands,
     validationRetryLimit: config.validationRetryLimit,

--- a/packages/agent-cli/src/stream-ui.ts
+++ b/packages/agent-cli/src/stream-ui.ts
@@ -51,6 +51,15 @@ function usageSummary(value: unknown): string {
   return `input=${input} output=${output} total=${total}`;
 }
 
+function sandboxWarning(metadata: Record<string, unknown> | undefined): string {
+  const sandbox = metadata?.sandbox;
+  if (!sandbox || typeof sandbox !== "object") return "";
+  const warning = (sandbox as Record<string, unknown>).warning;
+  return typeof warning === "string" && warning
+    ? ` sandbox_warning=${truncateMiddle(redactSecretText(warning.replace(/\s+/g, " ")), 140).text}`
+    : "";
+}
+
 export function formatAgentEvent(event: AgentEvent): string | null {
   switch (event.type) {
     case "run_start":
@@ -76,10 +85,11 @@ export function formatAgentEvent(event: AgentEvent): string | null {
     case "tool_end": {
       const result = event.metadata?.result as { ok?: unknown; content?: unknown; metadata?: Record<string, unknown> } | undefined;
       const duration = typeof result?.metadata?.durationMs === "number" ? ` duration_ms=${result.metadata.durationMs}` : "";
+      const warning = sandboxWarning(result?.metadata);
       const tail = typeof result?.content === "string" && result.content.trim()
         ? ` ${truncateMiddle(redactSecretText(result.content.replace(/\s+/g, " ").trim()), 120).text}`
         : "";
-      return `[sigma] tool_end ${toolNameFromEvent(event)} ${result?.ok === true ? "ok" : "failed"}${duration}${tail}`;
+      return `[sigma] tool_end ${toolNameFromEvent(event)} ${result?.ok === true ? "ok" : "failed"}${duration}${warning}${tail}`;
     }
     case "context_compaction_start":
       return `[sigma] context_compaction_start strategy=${String(event.metadata?.strategy ?? "?")} compacted_messages=${String(event.metadata?.compacted_message_count ?? "?")}`;
@@ -116,7 +126,7 @@ export function formatAgentEvent(event: AgentEvent): string | null {
     case "harness_check_start":
       return `[sigma] ${String(event.metadata?.kind ?? "check")}_start attempt=${String(event.metadata?.attempt ?? "?")} command=${truncateMiddle(redactSecretText(String(event.metadata?.command ?? "")).replace(/\s+/g, " "), 160).text}`;
     case "harness_check_end":
-      return `[sigma] ${String(event.metadata?.kind ?? "check")}_end attempt=${String(event.metadata?.attempt ?? "?")} exit=${String(event.metadata?.exitCode ?? "?")} duration_ms=${String(event.metadata?.durationMs ?? "?")}`;
+      return `[sigma] ${String(event.metadata?.kind ?? "check")}_end attempt=${String(event.metadata?.attempt ?? "?")} exit=${String(event.metadata?.exitCode ?? "?")} duration_ms=${String(event.metadata?.durationMs ?? "?")}${sandboxWarning(event.metadata)}`;
     case "usage":
       return `[sigma] usage turn=${String(event.metadata?.turn ?? "?")} ${usageSummary(event.metadata?.usage)}`;
     case "run_end": {

--- a/packages/agent-core/helpers/windows-sandbox-runner.ps1
+++ b/packages/agent-core/helpers/windows-sandbox-runner.ps1
@@ -1,0 +1,466 @@
+param(
+  [string]$Request,
+  [switch]$Probe
+)
+
+$ErrorActionPreference = "Stop"
+
+$source = @"
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Security.AccessControl;
+using System.Security.Principal;
+using System.Text;
+
+namespace Sigma.WindowsSandbox {
+  public static class NativeRunner {
+    const UInt32 TOKEN_DUPLICATE = 0x0002;
+    const UInt32 TOKEN_ASSIGN_PRIMARY = 0x0001;
+    const UInt32 TOKEN_QUERY = 0x0008;
+    const UInt32 TOKEN_ADJUST_PRIVILEGES = 0x0020;
+    const UInt32 TOKEN_ADJUST_DEFAULT = 0x0080;
+    const UInt32 TOKEN_ADJUST_SESSIONID = 0x0100;
+    const UInt32 DISABLE_MAX_PRIVILEGE = 0x1;
+    const UInt32 LUA_TOKEN = 0x4;
+    const UInt32 WRITE_RESTRICTED = 0x8;
+    const UInt32 STARTF_USESTDHANDLES = 0x00000100;
+    const UInt32 CREATE_NO_WINDOW = 0x08000000;
+    const UInt32 INFINITE = 0xffffffff;
+    const UInt32 GENERIC_ALL = 0x10000000;
+    const UInt32 ERROR_SUCCESS = 0;
+    const UInt32 GRANT_ACCESS = 1;
+    const UInt32 SE_PRIVILEGE_ENABLED = 0x00000002;
+    const UInt32 SE_GROUP_LOGON_ID = 0xC0000000;
+    const Int32 STD_INPUT_HANDLE = -10;
+    const Int32 STD_OUTPUT_HANDLE = -11;
+    const Int32 STD_ERROR_HANDLE = -12;
+    const Int32 TokenGroups = 2;
+    const Int32 TokenDefaultDacl = 6;
+    const Int32 TRUSTEE_IS_SID = 0;
+    const Int32 TRUSTEE_IS_UNKNOWN = 0;
+
+    [StructLayout(LayoutKind.Sequential)]
+    struct SID_AND_ATTRIBUTES {
+      public IntPtr Sid;
+      public UInt32 Attributes;
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    struct STARTUPINFO {
+      public UInt32 cb;
+      public string lpReserved;
+      public string lpDesktop;
+      public string lpTitle;
+      public UInt32 dwX;
+      public UInt32 dwY;
+      public UInt32 dwXSize;
+      public UInt32 dwYSize;
+      public UInt32 dwXCountChars;
+      public UInt32 dwYCountChars;
+      public UInt32 dwFillAttribute;
+      public UInt32 dwFlags;
+      public UInt16 wShowWindow;
+      public UInt16 cbReserved2;
+      public IntPtr lpReserved2;
+      public IntPtr hStdInput;
+      public IntPtr hStdOutput;
+      public IntPtr hStdError;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    struct PROCESS_INFORMATION {
+      public IntPtr hProcess;
+      public IntPtr hThread;
+      public UInt32 dwProcessId;
+      public UInt32 dwThreadId;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    struct LUID {
+      public UInt32 LowPart;
+      public Int32 HighPart;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    struct LUID_AND_ATTRIBUTES {
+      public LUID Luid;
+      public UInt32 Attributes;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    struct TOKEN_PRIVILEGES_ONE {
+      public UInt32 PrivilegeCount;
+      public LUID_AND_ATTRIBUTES Privilege;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    struct TRUSTEE {
+      public IntPtr pMultipleTrustee;
+      public Int32 MultipleTrusteeOperation;
+      public Int32 TrusteeForm;
+      public Int32 TrusteeType;
+      public IntPtr ptstrName;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    struct EXPLICIT_ACCESS {
+      public UInt32 grfAccessPermissions;
+      public UInt32 grfAccessMode;
+      public UInt32 grfInheritance;
+      public TRUSTEE Trustee;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    struct TOKEN_DEFAULT_DACL {
+      public IntPtr DefaultDacl;
+    }
+
+    [DllImport("kernel32.dll")]
+    static extern IntPtr GetCurrentProcess();
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    static extern IntPtr GetStdHandle(Int32 nStdHandle);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    static extern bool CloseHandle(IntPtr hObject);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    static extern UInt32 WaitForSingleObject(IntPtr hHandle, UInt32 dwMilliseconds);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    static extern bool GetExitCodeProcess(IntPtr hProcess, out UInt32 lpExitCode);
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    static extern bool OpenProcessToken(IntPtr ProcessHandle, UInt32 DesiredAccess, out IntPtr TokenHandle);
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    static extern bool GetTokenInformation(
+      IntPtr TokenHandle,
+      Int32 TokenInformationClass,
+      IntPtr TokenInformation,
+      Int32 TokenInformationLength,
+      out Int32 ReturnLength);
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    static extern bool CreateRestrictedToken(
+      IntPtr ExistingTokenHandle,
+      UInt32 Flags,
+      UInt32 DisableSidCount,
+      IntPtr SidsToDisable,
+      UInt32 DeletePrivilegeCount,
+      IntPtr PrivilegesToDelete,
+      UInt32 RestrictedSidCount,
+      SID_AND_ATTRIBUTES[] SidsToRestrict,
+      out IntPtr NewTokenHandle);
+
+    [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    static extern bool LookupPrivilegeValue(string lpSystemName, string lpName, out LUID lpLuid);
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    static extern bool AdjustTokenPrivileges(
+      IntPtr TokenHandle,
+      bool DisableAllPrivileges,
+      ref TOKEN_PRIVILEGES_ONE NewState,
+      UInt32 BufferLength,
+      IntPtr PreviousState,
+      IntPtr ReturnLength);
+
+    [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode, EntryPoint = "SetEntriesInAclW")]
+    static extern UInt32 SetEntriesInAcl(
+      UInt32 cCountOfExplicitEntries,
+      EXPLICIT_ACCESS[] pListOfExplicitEntries,
+      IntPtr OldAcl,
+      out IntPtr NewAcl);
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    static extern bool SetTokenInformation(
+      IntPtr TokenHandle,
+      Int32 TokenInformationClass,
+      ref TOKEN_DEFAULT_DACL TokenInformation,
+      UInt32 TokenInformationLength);
+
+    [DllImport("kernel32.dll")]
+    static extern IntPtr LocalFree(IntPtr hMem);
+
+    [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    static extern bool CreateProcessAsUser(
+      IntPtr hToken,
+      string lpApplicationName,
+      StringBuilder lpCommandLine,
+      IntPtr lpProcessAttributes,
+      IntPtr lpThreadAttributes,
+      bool bInheritHandles,
+      UInt32 dwCreationFlags,
+      IntPtr lpEnvironment,
+      string lpCurrentDirectory,
+      ref STARTUPINFO lpStartupInfo,
+      out PROCESS_INFORMATION lpProcessInformation);
+
+    [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    static extern bool CreateProcessWithTokenW(
+      IntPtr hToken,
+      UInt32 dwLogonFlags,
+      string lpApplicationName,
+      StringBuilder lpCommandLine,
+      UInt32 dwCreationFlags,
+      IntPtr lpEnvironment,
+      string lpCurrentDirectory,
+      ref STARTUPINFO lpStartupInfo,
+      out PROCESS_INFORMATION lpProcessInformation);
+
+    public static int Probe() {
+      SecurityIdentifier sid = new SecurityIdentifier("S-1-5-21-1111111111-2222222222-3333333333-4444");
+      IntPtr ptr = SidToPtr(sid);
+      IntPtr logonPtr = SidToPtr(GetLogonSid());
+      IntPtr everyonePtr = SidToPtr(new SecurityIdentifier(WellKnownSidType.WorldSid, null));
+      try {
+        IntPtr token = CreateRestrictedWriteToken(new [] { ptr, logonPtr, everyonePtr });
+        CloseHandle(token);
+        return 0;
+      } finally {
+        Marshal.FreeHGlobal(ptr);
+        Marshal.FreeHGlobal(logonPtr);
+        Marshal.FreeHGlobal(everyonePtr);
+      }
+    }
+
+    public static int Run(string program, string[] args, string commandLine, string cwd, string capabilitySid, string[] writeRoots, string[] denyWrite) {
+      if (String.IsNullOrWhiteSpace(program)) throw new ArgumentException("missing program");
+      if (String.IsNullOrWhiteSpace(cwd)) cwd = Directory.GetCurrentDirectory();
+      SecurityIdentifier cap = new SecurityIdentifier(capabilitySid);
+
+      foreach (string root in writeRoots ?? new string[0]) {
+        if (!String.IsNullOrWhiteSpace(root) && Directory.Exists(root)) AddRule(root, cap, AccessControlType.Allow, true);
+        else if (!String.IsNullOrWhiteSpace(root) && File.Exists(root)) AddRule(root, cap, AccessControlType.Allow, false);
+      }
+      foreach (string target in denyWrite ?? new string[0]) {
+        if (!String.IsNullOrWhiteSpace(target) && Directory.Exists(target)) AddRule(target, cap, AccessControlType.Deny, true);
+        else if (!String.IsNullOrWhiteSpace(target) && File.Exists(target)) AddRule(target, cap, AccessControlType.Deny, false);
+      }
+
+      IntPtr sidPtr = SidToPtr(cap);
+      IntPtr logonPtr = SidToPtr(GetLogonSid());
+      IntPtr everyonePtr = SidToPtr(new SecurityIdentifier(WellKnownSidType.WorldSid, null));
+      IntPtr restricted = IntPtr.Zero;
+      try {
+        restricted = CreateRestrictedWriteToken(new [] { sidPtr, logonPtr, everyonePtr });
+        return SpawnAndWait(restricted, program, args ?? new string[0], commandLine, cwd);
+      } finally {
+        if (restricted != IntPtr.Zero) CloseHandle(restricted);
+        Marshal.FreeHGlobal(sidPtr);
+        Marshal.FreeHGlobal(logonPtr);
+        Marshal.FreeHGlobal(everyonePtr);
+      }
+    }
+
+    static IntPtr CreateRestrictedWriteToken(IntPtr[] restrictingSids) {
+      IntPtr baseToken;
+      UInt32 access = TOKEN_DUPLICATE | TOKEN_ASSIGN_PRIMARY | TOKEN_QUERY | TOKEN_ADJUST_DEFAULT | TOKEN_ADJUST_SESSIONID | TOKEN_ADJUST_PRIVILEGES;
+      if (!OpenProcessToken(GetCurrentProcess(), access, out baseToken)) ThrowLast("OpenProcessToken");
+      try {
+        SID_AND_ATTRIBUTES[] entries = new SID_AND_ATTRIBUTES[restrictingSids.Length];
+        for (int i = 0; i < restrictingSids.Length; i++) {
+          entries[i].Sid = restrictingSids[i];
+          entries[i].Attributes = 0;
+        }
+        IntPtr restricted;
+        if (!CreateRestrictedToken(baseToken, DISABLE_MAX_PRIVILEGE | LUA_TOKEN | WRITE_RESTRICTED, 0, IntPtr.Zero, 0, IntPtr.Zero, (UInt32)entries.Length, entries, out restricted)) {
+          ThrowLast("CreateRestrictedToken");
+        }
+        SetDefaultDacl(restricted, restrictingSids);
+        EnableSinglePrivilege(restricted, "SeChangeNotifyPrivilege");
+        return restricted;
+      } finally {
+        CloseHandle(baseToken);
+      }
+    }
+
+    static void SetDefaultDacl(IntPtr token, IntPtr[] sids) {
+      EXPLICIT_ACCESS[] entries = new EXPLICIT_ACCESS[sids.Length];
+      for (int i = 0; i < sids.Length; i++) {
+        entries[i].grfAccessPermissions = GENERIC_ALL;
+        entries[i].grfAccessMode = GRANT_ACCESS;
+        entries[i].grfInheritance = 0;
+        entries[i].Trustee = new TRUSTEE();
+        entries[i].Trustee.pMultipleTrustee = IntPtr.Zero;
+        entries[i].Trustee.MultipleTrusteeOperation = 0;
+        entries[i].Trustee.TrusteeForm = TRUSTEE_IS_SID;
+        entries[i].Trustee.TrusteeType = TRUSTEE_IS_UNKNOWN;
+        entries[i].Trustee.ptstrName = sids[i];
+      }
+      IntPtr acl;
+      UInt32 result = SetEntriesInAcl((UInt32)entries.Length, entries, IntPtr.Zero, out acl);
+      if (result != ERROR_SUCCESS) throw new InvalidOperationException("SetEntriesInAcl failed: " + result.ToString());
+      try {
+        TOKEN_DEFAULT_DACL info = new TOKEN_DEFAULT_DACL();
+        info.DefaultDacl = acl;
+        if (!SetTokenInformation(token, TokenDefaultDacl, ref info, (UInt32)Marshal.SizeOf(typeof(TOKEN_DEFAULT_DACL)))) {
+          ThrowLast("SetTokenInformation(TokenDefaultDacl)");
+        }
+      } finally {
+        if (acl != IntPtr.Zero) LocalFree(acl);
+      }
+    }
+
+    static void EnableSinglePrivilege(IntPtr token, string name) {
+      LUID luid;
+      if (!LookupPrivilegeValue(null, name, out luid)) ThrowLast("LookupPrivilegeValue");
+      TOKEN_PRIVILEGES_ONE privileges = new TOKEN_PRIVILEGES_ONE();
+      privileges.PrivilegeCount = 1;
+      privileges.Privilege = new LUID_AND_ATTRIBUTES();
+      privileges.Privilege.Luid = luid;
+      privileges.Privilege.Attributes = SE_PRIVILEGE_ENABLED;
+      if (!AdjustTokenPrivileges(token, false, ref privileges, 0, IntPtr.Zero, IntPtr.Zero)) ThrowLast("AdjustTokenPrivileges");
+    }
+
+    static SecurityIdentifier GetLogonSid() {
+      IntPtr token;
+      if (!OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, out token)) ThrowLast("OpenProcessToken(TokenGroups)");
+      try {
+        Int32 needed = 0;
+        GetTokenInformation(token, TokenGroups, IntPtr.Zero, 0, out needed);
+        if (needed <= 0) ThrowLast("GetTokenInformation(TokenGroups size)");
+        IntPtr buffer = Marshal.AllocHGlobal(needed);
+        try {
+          if (!GetTokenInformation(token, TokenGroups, buffer, needed, out needed)) ThrowLast("GetTokenInformation(TokenGroups)");
+          Int32 groupCount = Marshal.ReadInt32(buffer);
+          IntPtr entry = IntPtr.Add(buffer, IntPtr.Size);
+          Int32 entrySize = Marshal.SizeOf(typeof(SID_AND_ATTRIBUTES));
+          for (Int32 i = 0; i < groupCount; i++) {
+            SID_AND_ATTRIBUTES item = (SID_AND_ATTRIBUTES)Marshal.PtrToStructure(IntPtr.Add(entry, i * entrySize), typeof(SID_AND_ATTRIBUTES));
+            if ((item.Attributes & SE_GROUP_LOGON_ID) == SE_GROUP_LOGON_ID) {
+              return new SecurityIdentifier(item.Sid);
+            }
+          }
+        } finally {
+          Marshal.FreeHGlobal(buffer);
+        }
+      } finally {
+        CloseHandle(token);
+      }
+      throw new InvalidOperationException("Current token does not include a logon SID.");
+    }
+
+    static int SpawnAndWait(IntPtr token, string program, string[] args, string commandLine, string cwd) {
+      STARTUPINFO si = new STARTUPINFO();
+      si.cb = (UInt32)Marshal.SizeOf(typeof(STARTUPINFO));
+      si.lpDesktop = "winsta0\\default";
+      si.dwFlags = STARTF_USESTDHANDLES;
+      si.hStdInput = GetStdHandle(STD_INPUT_HANDLE);
+      si.hStdOutput = GetStdHandle(STD_OUTPUT_HANDLE);
+      si.hStdError = GetStdHandle(STD_ERROR_HANDLE);
+      PROCESS_INFORMATION pi;
+      StringBuilder cmdline = new StringBuilder(String.IsNullOrWhiteSpace(commandLine) ? BuildCommandLine(program, args) : commandLine);
+      bool ok = CreateProcessAsUser(token, null, cmdline, IntPtr.Zero, IntPtr.Zero, true, CREATE_NO_WINDOW, IntPtr.Zero, cwd, ref si, out pi);
+      if (!ok) {
+        cmdline = new StringBuilder(String.IsNullOrWhiteSpace(commandLine) ? BuildCommandLine(program, args) : commandLine);
+        ok = CreateProcessWithTokenW(token, 0, null, cmdline, CREATE_NO_WINDOW, IntPtr.Zero, cwd, ref si, out pi);
+      }
+      if (!ok) ThrowLast("CreateProcessAsUser/CreateProcessWithTokenW");
+      try {
+        WaitForSingleObject(pi.hProcess, INFINITE);
+        UInt32 exitCode;
+        if (!GetExitCodeProcess(pi.hProcess, out exitCode)) ThrowLast("GetExitCodeProcess");
+        return unchecked((int)exitCode);
+      } finally {
+        CloseHandle(pi.hThread);
+        CloseHandle(pi.hProcess);
+      }
+    }
+
+    static void AddRule(string path, SecurityIdentifier sid, AccessControlType type, bool directory) {
+      FileSystemRights rights = FileSystemRights.Modify | FileSystemRights.Synchronize;
+      if (directory) {
+        DirectoryInfo info = new DirectoryInfo(path);
+        DirectorySecurity security = info.GetAccessControl();
+        FileSystemAccessRule rule = new FileSystemAccessRule(sid, rights, InheritanceFlags.ContainerInherit | InheritanceFlags.ObjectInherit, PropagationFlags.None, type);
+        security.SetAccessRule(rule);
+        info.SetAccessControl(security);
+      } else {
+        FileInfo info = new FileInfo(path);
+        FileSecurity security = info.GetAccessControl();
+        FileSystemAccessRule rule = new FileSystemAccessRule(sid, rights, AccessControlType.Allow);
+        if (type == AccessControlType.Deny) rule = new FileSystemAccessRule(sid, rights, AccessControlType.Deny);
+        security.SetAccessRule(rule);
+        info.SetAccessControl(security);
+      }
+    }
+
+    static IntPtr SidToPtr(SecurityIdentifier sid) {
+      byte[] bytes = new byte[sid.BinaryLength];
+      sid.GetBinaryForm(bytes, 0);
+      IntPtr ptr = Marshal.AllocHGlobal(bytes.Length);
+      Marshal.Copy(bytes, 0, ptr, bytes.Length);
+      return ptr;
+    }
+
+    static string BuildCommandLine(string program, string[] args) {
+      StringBuilder builder = new StringBuilder();
+      AppendQuoted(builder, program);
+      foreach (string arg in args) {
+        builder.Append(' ');
+        AppendQuoted(builder, arg ?? "");
+      }
+      return builder.ToString();
+    }
+
+    static void AppendQuoted(StringBuilder builder, string value) {
+      builder.Append('"');
+      int slashCount = 0;
+      foreach (char ch in value) {
+        if (ch == '\\') {
+          slashCount++;
+          continue;
+        }
+        if (ch == '"') {
+          builder.Append('\\', slashCount * 2 + 1);
+          builder.Append('"');
+          slashCount = 0;
+          continue;
+        }
+        builder.Append('\\', slashCount);
+        slashCount = 0;
+        builder.Append(ch);
+      }
+      builder.Append('\\', slashCount * 2);
+      builder.Append('"');
+    }
+
+    static void ThrowLast(string operation) {
+      int error = Marshal.GetLastWin32Error();
+      System.ComponentModel.Win32Exception ex = new System.ComponentModel.Win32Exception(error);
+      throw new System.ComponentModel.Win32Exception(error, operation + " failed: " + ex.Message + " (" + error.ToString() + ")");
+    }
+  }
+}
+"@
+
+Add-Type -TypeDefinition $source
+
+if ($Probe) {
+  exit [Sigma.WindowsSandbox.NativeRunner]::Probe()
+}
+
+if (-not $Request) {
+  throw "Missing -Request"
+}
+
+$jsonText = [System.IO.File]::ReadAllText($Request, [System.Text.Encoding]::UTF8)
+$json = $jsonText | ConvertFrom-Json
+Remove-Item -LiteralPath $Request -Force -ErrorAction SilentlyContinue
+
+function ToStringArray($value) {
+  if ($null -eq $value) { return [string[]]@() }
+  return [string[]]@($value)
+}
+
+exit [Sigma.WindowsSandbox.NativeRunner]::Run(
+  [string]$json.program,
+  (ToStringArray $json.args),
+  [string]$json.commandLine,
+  [string]$json.cwd,
+  [string]$json.capabilitySid,
+  (ToStringArray $json.writeRoots),
+  (ToStringArray $json.denyWrite)
+)

--- a/packages/agent-core/helpers/windows-sandbox-runner.ps1
+++ b/packages/agent-core/helpers/windows-sandbox-runner.ps1
@@ -7,6 +7,7 @@ $ErrorActionPreference = "Stop"
 
 $source = @"
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Security.AccessControl;
@@ -225,32 +226,49 @@ namespace Sigma.WindowsSandbox {
       }
     }
 
-    public static int Run(string program, string[] args, string commandLine, string cwd, string capabilitySid, string[] writeRoots, string[] denyWrite) {
+    class AclBackup {
+      public string Path;
+      public bool Directory;
+      public string Sddl;
+    }
+
+    public static int Run(string program, string[] args, string commandLine, string cwd, string capabilitySid, string[] writeRoots, string[] denyWrite, string[] denyRead) {
       if (String.IsNullOrWhiteSpace(program)) throw new ArgumentException("missing program");
       if (String.IsNullOrWhiteSpace(cwd)) cwd = Directory.GetCurrentDirectory();
       SecurityIdentifier cap = new SecurityIdentifier(capabilitySid);
 
-      foreach (string root in writeRoots ?? new string[0]) {
-        if (!String.IsNullOrWhiteSpace(root) && Directory.Exists(root)) AddRule(root, cap, AccessControlType.Allow, true);
-        else if (!String.IsNullOrWhiteSpace(root) && File.Exists(root)) AddRule(root, cap, AccessControlType.Allow, false);
-      }
-      foreach (string target in denyWrite ?? new string[0]) {
-        if (!String.IsNullOrWhiteSpace(target) && Directory.Exists(target)) AddRule(target, cap, AccessControlType.Deny, true);
-        else if (!String.IsNullOrWhiteSpace(target) && File.Exists(target)) AddRule(target, cap, AccessControlType.Deny, false);
-      }
-
       IntPtr sidPtr = SidToPtr(cap);
-      IntPtr logonPtr = SidToPtr(GetLogonSid());
-      IntPtr everyonePtr = SidToPtr(new SecurityIdentifier(WellKnownSidType.WorldSid, null));
+      IntPtr logonPtr = IntPtr.Zero;
+      IntPtr everyonePtr = IntPtr.Zero;
       IntPtr restricted = IntPtr.Zero;
+      List<AclBackup> aclBackups = new List<AclBackup>();
       try {
+        foreach (string root in writeRoots ?? new string[0]) {
+          AddRuleIfExists(aclBackups, root, cap, FileSystemRights.Modify | FileSystemRights.Synchronize, AccessControlType.Allow);
+        }
+        foreach (string target in denyWrite ?? new string[0]) {
+          AddRuleIfExists(aclBackups, target, cap, FileSystemRights.Modify | FileSystemRights.Synchronize, AccessControlType.Deny);
+        }
+        foreach (string target in denyRead ?? new string[0]) {
+          AddRuleIfExists(aclBackups, target, cap, FileSystemRights.ReadAndExecute | FileSystemRights.Synchronize, AccessControlType.Deny);
+        }
+
+        logonPtr = SidToPtr(GetLogonSid());
+        everyonePtr = SidToPtr(new SecurityIdentifier(WellKnownSidType.WorldSid, null));
         restricted = CreateRestrictedWriteToken(new [] { sidPtr, logonPtr, everyonePtr });
         return SpawnAndWait(restricted, program, args ?? new string[0], commandLine, cwd);
       } finally {
         if (restricted != IntPtr.Zero) CloseHandle(restricted);
-        Marshal.FreeHGlobal(sidPtr);
-        Marshal.FreeHGlobal(logonPtr);
-        Marshal.FreeHGlobal(everyonePtr);
+        Exception restoreError = null;
+        try {
+          RestoreAclBackups(aclBackups);
+        } catch (Exception ex) {
+          restoreError = ex;
+        }
+        if (sidPtr != IntPtr.Zero) Marshal.FreeHGlobal(sidPtr);
+        if (logonPtr != IntPtr.Zero) Marshal.FreeHGlobal(logonPtr);
+        if (everyonePtr != IntPtr.Zero) Marshal.FreeHGlobal(everyonePtr);
+        if (restoreError != null) throw restoreError;
       }
     }
 
@@ -369,8 +387,63 @@ namespace Sigma.WindowsSandbox {
       }
     }
 
-    static void AddRule(string path, SecurityIdentifier sid, AccessControlType type, bool directory) {
-      FileSystemRights rights = FileSystemRights.Modify | FileSystemRights.Synchronize;
+    static void AddRuleIfExists(List<AclBackup> backups, string path, SecurityIdentifier sid, FileSystemRights rights, AccessControlType type) {
+      if (String.IsNullOrWhiteSpace(path)) return;
+      if (Directory.Exists(path)) {
+        BackupAcl(backups, path, true);
+        AddRule(path, sid, rights, type, true);
+      } else if (File.Exists(path)) {
+        BackupAcl(backups, path, false);
+        AddRule(path, sid, rights, type, false);
+      }
+    }
+
+    static string AclBackupKey(string path, bool directory) {
+      return (directory ? "D:" : "F:") + System.IO.Path.GetFullPath(path).ToUpperInvariant();
+    }
+
+    static void BackupAcl(List<AclBackup> backups, string path, bool directory) {
+      string key = AclBackupKey(path, directory);
+      foreach (AclBackup existing in backups) {
+        if (AclBackupKey(existing.Path, existing.Directory) == key) return;
+      }
+      if (directory) {
+        DirectoryInfo info = new DirectoryInfo(path);
+        backups.Add(new AclBackup {
+          Path = path,
+          Directory = true,
+          Sddl = info.GetAccessControl(AccessControlSections.Access).GetSecurityDescriptorSddlForm(AccessControlSections.Access)
+        });
+      } else {
+        FileInfo info = new FileInfo(path);
+        backups.Add(new AclBackup {
+          Path = path,
+          Directory = false,
+          Sddl = info.GetAccessControl(AccessControlSections.Access).GetSecurityDescriptorSddlForm(AccessControlSections.Access)
+        });
+      }
+    }
+
+    static void RestoreAclBackups(List<AclBackup> backups) {
+      for (int i = backups.Count - 1; i >= 0; i--) {
+        AclBackup backup = backups[i];
+        if (backup.Directory) {
+          if (!Directory.Exists(backup.Path)) continue;
+          DirectoryInfo info = new DirectoryInfo(backup.Path);
+          DirectorySecurity security = new DirectorySecurity();
+          security.SetSecurityDescriptorSddlForm(backup.Sddl, AccessControlSections.Access);
+          info.SetAccessControl(security);
+        } else {
+          if (!File.Exists(backup.Path)) continue;
+          FileInfo info = new FileInfo(backup.Path);
+          FileSecurity security = new FileSecurity();
+          security.SetSecurityDescriptorSddlForm(backup.Sddl, AccessControlSections.Access);
+          info.SetAccessControl(security);
+        }
+      }
+    }
+
+    static void AddRule(string path, SecurityIdentifier sid, FileSystemRights rights, AccessControlType type, bool directory) {
       if (directory) {
         DirectoryInfo info = new DirectoryInfo(path);
         DirectorySecurity security = info.GetAccessControl();
@@ -380,8 +453,7 @@ namespace Sigma.WindowsSandbox {
       } else {
         FileInfo info = new FileInfo(path);
         FileSecurity security = info.GetAccessControl();
-        FileSystemAccessRule rule = new FileSystemAccessRule(sid, rights, AccessControlType.Allow);
-        if (type == AccessControlType.Deny) rule = new FileSystemAccessRule(sid, rights, AccessControlType.Deny);
+        FileSystemAccessRule rule = new FileSystemAccessRule(sid, rights, type);
         security.SetAccessRule(rule);
         info.SetAccessControl(security);
       }
@@ -462,5 +534,6 @@ exit [Sigma.WindowsSandbox.NativeRunner]::Run(
   [string]$json.cwd,
   [string]$json.capabilitySid,
   (ToStringArray $json.writeRoots),
-  (ToStringArray $json.denyWrite)
+  (ToStringArray $json.denyWrite),
+  (ToStringArray $json.denyRead)
 )

--- a/packages/agent-core/src/agent.ts
+++ b/packages/agent-core/src/agent.ts
@@ -28,6 +28,7 @@ import {
   workflowFailureNudge
 } from "./controller/workflow-state.js";
 import { redactSecrets } from "./redaction.js";
+import { createDefaultSandboxConfig } from "./sandbox.js";
 import { ToolRuntime, type ToolRuntimeExecution } from "./tool-runtime.js";
 import type {
   AgentEvent,
@@ -341,7 +342,7 @@ export async function runAgent(config: AgentRunConfig): Promise<AgentRunResult> 
     subagentsEnabled,
     subagentDepth: 0,
     execPolicy: config.execPolicy,
-    sandbox: config.sandbox,
+    sandbox: config.sandbox ?? createDefaultSandboxConfig(),
     sandboxAdapter: config.sandboxAdapter,
     ...(config.abortSignal ? { abortSignal: config.abortSignal } : {})
   };

--- a/packages/agent-core/src/exec-runtime.ts
+++ b/packages/agent-core/src/exec-runtime.ts
@@ -33,6 +33,7 @@ interface ProcessSpec {
   cwd: string;
   env?: NodeJS.ProcessEnv;
   metadata?: Record<string, unknown>;
+  cleanup?: () => Promise<void> | void;
 }
 
 function specFromDecision(originalCommand: string, decision: SandboxExecDecision, fallbackArgs?: string[]): ProcessSpec {
@@ -42,7 +43,8 @@ function specFromDecision(originalCommand: string, decision: SandboxExecDecision
       args: decision.args,
       cwd: decision.cwd ?? process.cwd(),
       env: decision.env,
-      metadata: decision.metadata
+      metadata: decision.metadata,
+      cleanup: decision.cleanup
     };
   }
   if (decision.command) {
@@ -51,7 +53,8 @@ function specFromDecision(originalCommand: string, decision: SandboxExecDecision
       args: ["-lc", decision.command],
       cwd: decision.cwd ?? process.cwd(),
       env: decision.env,
-      metadata: decision.metadata
+      metadata: decision.metadata,
+      cleanup: decision.cleanup
     };
   }
   return {
@@ -59,8 +62,31 @@ function specFromDecision(originalCommand: string, decision: SandboxExecDecision
     args: fallbackArgs ?? ["-lc", originalCommand],
     cwd: decision.cwd ?? process.cwd(),
     env: decision.env,
-    metadata: decision.metadata
+    metadata: decision.metadata,
+    cleanup: decision.cleanup
   };
+}
+
+async function runCleanup(cleanup: (() => Promise<void> | void) | undefined): Promise<void> {
+  if (!cleanup) return;
+  try {
+    await cleanup();
+  } catch {
+    // Cleanup is best-effort; command results should still describe the child.
+  }
+}
+
+function attachCleanup(child: ChildProcess, cleanup: (() => Promise<void> | void) | undefined): void {
+  if (!cleanup) return;
+  let cleaned = false;
+  const once = () => {
+    if (cleaned) return;
+    cleaned = true;
+    void runCleanup(cleanup);
+  };
+  child.once("close", once);
+  child.once("exit", once);
+  child.once("error", once);
 }
 
 async function prepareSandboxedProcess(options: PrepareOptions, fallbackArgs?: string[]): Promise<ProcessSpec | SandboxExecDecision> {
@@ -108,6 +134,8 @@ export async function runSandboxedBashCommand(
     detachedProcessGroup: options.detachedProcessGroup,
     windowsHide: true,
     abortSignal: options.abortSignal
+  }).finally(async () => {
+    await runCleanup(spec.cleanup);
   });
   return { result, sandbox: spec.metadata };
 }
@@ -139,6 +167,7 @@ export async function spawnSandboxedBashCommand(options: {
     stdio: options.stdio,
     windowsHide: true
   });
+  attachCleanup(child, spec.cleanup);
   return { child, sandbox: spec.metadata };
 }
 
@@ -165,5 +194,6 @@ export async function spawnSandboxedInteractiveShell(options: {
     detached: process.platform !== "win32",
     windowsHide: true
   }) as ChildProcessWithoutNullStreams;
+  attachCleanup(child, spec.cleanup);
   return { child, sandbox: spec.metadata };
 }

--- a/packages/agent-core/src/exec-runtime.ts
+++ b/packages/agent-core/src/exec-runtime.ts
@@ -1,0 +1,169 @@
+import { spawn, type ChildProcess, type ChildProcessWithoutNullStreams, type StdioOptions } from "node:child_process";
+import { bashExecutable, runCommand, type CommandResult, type RunCommandOptions } from "./command-runner.js";
+import { createDefaultSandboxAdapter } from "./sandbox.js";
+import type { ExecIntentSummary, SandboxExecDecision, ToolExecutionContext } from "./types.js";
+
+export interface SandboxedRunResult {
+  result: CommandResult;
+  sandbox: Record<string, unknown> | undefined;
+}
+
+export interface SandboxedSpawnResult {
+  child: ChildProcess;
+  sandbox: Record<string, unknown> | undefined;
+}
+
+export interface SandboxedInteractiveShellResult {
+  child: ChildProcessWithoutNullStreams;
+  sandbox: Record<string, unknown> | undefined;
+}
+
+interface PrepareOptions {
+  toolName: string;
+  command: string;
+  cwd: string;
+  env?: NodeJS.ProcessEnv;
+  policy: ExecIntentSummary;
+  context: ToolExecutionContext;
+}
+
+interface ProcessSpec {
+  command: string;
+  args: string[];
+  cwd: string;
+  env?: NodeJS.ProcessEnv;
+  metadata?: Record<string, unknown>;
+}
+
+function specFromDecision(originalCommand: string, decision: SandboxExecDecision, fallbackArgs?: string[]): ProcessSpec {
+  if (decision.args) {
+    return {
+      command: decision.command ?? bashExecutable(),
+      args: decision.args,
+      cwd: decision.cwd ?? process.cwd(),
+      env: decision.env,
+      metadata: decision.metadata
+    };
+  }
+  if (decision.command) {
+    return {
+      command: bashExecutable(),
+      args: ["-lc", decision.command],
+      cwd: decision.cwd ?? process.cwd(),
+      env: decision.env,
+      metadata: decision.metadata
+    };
+  }
+  return {
+    command: bashExecutable(),
+    args: fallbackArgs ?? ["-lc", originalCommand],
+    cwd: decision.cwd ?? process.cwd(),
+    env: decision.env,
+    metadata: decision.metadata
+  };
+}
+
+async function prepareSandboxedProcess(options: PrepareOptions, fallbackArgs?: string[]): Promise<ProcessSpec | SandboxExecDecision> {
+  const adapter = options.context.sandboxAdapter ?? createDefaultSandboxAdapter();
+  const decision = await adapter.prepareExec({
+    toolName: options.toolName,
+    command: options.command,
+    cwd: options.cwd,
+    workspacePath: options.context.workspacePath,
+    env: options.env ?? process.env,
+    policy: options.policy,
+    sandbox: options.context.sandbox ?? { mode: "disabled" }
+  });
+  if (!decision.allowed) return decision;
+  return specFromDecision(options.command, decision, fallbackArgs);
+}
+
+export async function runSandboxedBashCommand(
+  options: Omit<RunCommandOptions, "command" | "args"> & {
+    command: string;
+    policy: ExecIntentSummary;
+    toolName: string;
+    context: ToolExecutionContext;
+  }
+): Promise<SandboxedRunResult | SandboxExecDecision> {
+  const prepared = await prepareSandboxedProcess({
+    toolName: options.toolName,
+    command: options.command,
+    cwd: options.cwd,
+    env: options.env,
+    policy: options.policy,
+    context: options.context
+  });
+  if ("allowed" in prepared) return prepared;
+  const spec = prepared as ProcessSpec;
+  const result = await runCommand({
+    command: spec.command,
+    args: spec.args,
+    cwd: spec.cwd,
+    env: spec.env ?? process.env,
+    timeoutMs: options.timeoutMs,
+    drainMs: options.drainMs,
+    killSettleMs: options.killSettleMs,
+    termToKillMs: options.termToKillMs,
+    detachedProcessGroup: options.detachedProcessGroup,
+    windowsHide: true,
+    abortSignal: options.abortSignal
+  });
+  return { result, sandbox: spec.metadata };
+}
+
+export async function spawnSandboxedBashCommand(options: {
+  toolName: string;
+  command: string;
+  cwd: string;
+  env?: NodeJS.ProcessEnv;
+  policy: ExecIntentSummary;
+  context: ToolExecutionContext;
+  detached?: boolean;
+  stdio?: StdioOptions;
+}): Promise<SandboxedSpawnResult | SandboxExecDecision> {
+  const prepared = await prepareSandboxedProcess({
+    toolName: options.toolName,
+    command: options.command,
+    cwd: options.cwd,
+    env: options.env,
+    policy: options.policy,
+    context: options.context
+  });
+  if ("allowed" in prepared) return prepared;
+  const spec = prepared as ProcessSpec;
+  const child = spawn(spec.command, spec.args, {
+    cwd: spec.cwd,
+    env: spec.env ?? process.env,
+    detached: options.detached,
+    stdio: options.stdio,
+    windowsHide: true
+  });
+  return { child, sandbox: spec.metadata };
+}
+
+export async function spawnSandboxedInteractiveShell(options: {
+  toolName: string;
+  cwd: string;
+  env?: NodeJS.ProcessEnv;
+  policy: ExecIntentSummary;
+  context: ToolExecutionContext;
+}): Promise<SandboxedInteractiveShellResult | SandboxExecDecision> {
+  const prepared = await prepareSandboxedProcess({
+    toolName: options.toolName,
+    command: "bash --noprofile --norc",
+    cwd: options.cwd,
+    env: options.env,
+    policy: options.policy,
+    context: options.context
+  }, ["--noprofile", "--norc"]);
+  if ("allowed" in prepared) return prepared;
+  const spec = prepared as ProcessSpec;
+  const child = spawn(spec.command, spec.args, {
+    cwd: spec.cwd,
+    env: spec.env ?? process.env,
+    detached: process.platform !== "win32",
+    windowsHide: true
+  }) as ChildProcessWithoutNullStreams;
+  return { child, sandbox: spec.metadata };
+}

--- a/packages/agent-core/src/harness/runner.ts
+++ b/packages/agent-core/src/harness/runner.ts
@@ -221,10 +221,14 @@ async function runChecks(options: {
         kind: "validation",
         source: spec.source,
         command: spec.command,
-        workspacePath: spec.cwd ?? workspacePath,
+        workspacePath,
+        cwd: spec.cwd ?? workspacePath,
         attempt: options.attempt,
         timeoutSec: validationTimeoutSec,
         relatedFiles: spec.relatedFiles,
+        execPolicy: options.config.execPolicy,
+        sandbox: options.config.sandbox,
+        sandboxAdapter: options.config.sandboxAdapter,
         abortSignal: options.config.abortSignal
       });
       emitHarnessEvent(options.config, "harness_check_end", {
@@ -233,7 +237,8 @@ async function runChecks(options: {
         attempt: options.attempt,
         exitCode: result.exit_code,
         durationMs: result.duration_ms,
-        cwd: spec.cwd ?? workspacePath
+        cwd: spec.cwd ?? workspacePath,
+        sandbox: result.sandbox
       });
       results.push(result);
     }
@@ -266,9 +271,13 @@ async function runPrecheckBeforeAttempt(options: {
     source: "precheck",
     command,
     workspacePath: path.resolve(options.config.workspacePath),
+    cwd: path.resolve(options.config.workspacePath),
     attempt: options.attempt,
     timeoutSec: options.config.precheckTimeoutSec ?? DEFAULT_PRECHECK_TIMEOUT_SEC,
     relatedFiles: [],
+    execPolicy: options.config.execPolicy,
+    sandbox: options.config.sandbox,
+    sandboxAdapter: options.config.sandboxAdapter,
     abortSignal: options.config.abortSignal
   });
   emitHarnessEvent(options.config, "harness_check_end", {
@@ -276,7 +285,8 @@ async function runPrecheckBeforeAttempt(options: {
     source: "precheck",
     attempt: options.attempt,
     exitCode: result.exit_code,
-    durationMs: result.duration_ms
+    durationMs: result.duration_ms,
+    sandbox: result.sandbox
   });
   return result;
 }

--- a/packages/agent-core/src/harness/validation.ts
+++ b/packages/agent-core/src/harness/validation.ts
@@ -1,5 +1,8 @@
-import type { HarnessCommandResult } from "../types.js";
-import { runBashCommand } from "../command-runner.js";
+import path from "node:path";
+import { runSandboxedBashCommand } from "../exec-runtime.js";
+import { createDefaultSandboxConfig } from "../sandbox.js";
+import { evaluateExecPolicy } from "../policy.js";
+import type { ExecPolicyConfig, HarnessCommandResult, SandboxAdapter, SandboxConfig, ToolExecutionContext } from "../types.js";
 
 export interface ValidationCommandSpec {
   source: string;
@@ -17,19 +20,76 @@ export async function runHarnessCommand(options: {
   source: string;
   command: string;
   workspacePath: string;
+  cwd?: string;
   attempt: number;
   timeoutSec: number;
   relatedFiles?: string[];
+  execPolicy?: ExecPolicyConfig;
+  sandbox?: SandboxConfig;
+  sandboxAdapter?: SandboxAdapter;
   abortSignal?: AbortSignal;
 }): Promise<HarnessCommandResult> {
   const startedAt = Date.now();
-  const result = await runBashCommand({
+  const workspacePath = path.resolve(options.workspacePath);
+  const cwd = path.resolve(options.cwd ?? options.workspacePath);
+  const label = options.kind === "validation" ? "validation" : "precheck";
+  const policy = evaluateExecPolicy(options.command, options.execPolicy ?? { defaultAction: "allow" });
+  if (policy.action === "deny") {
+    return {
+      kind: options.kind,
+      source: options.source,
+      command: options.command,
+      attempt: options.attempt,
+      exit_code: 126,
+      stdout_tail: "",
+      stderr_tail: policy.reason,
+      related_files: options.relatedFiles ?? [],
+      timeout_sec: options.timeoutSec,
+      duration_ms: Date.now() - startedAt,
+      message: `${label} command denied by execution policy`
+    };
+  }
+
+  const context: ToolExecutionContext = {
+    workspacePath,
+    permissionMode: "yolo",
+    commandTimeoutSec: options.timeoutSec,
+    maxToolOutputChars: 4000,
+    runState: { todos: [], nextTodoId: 1, changedFiles: new Set<string>() },
+    alwaysAllowTools: new Set<string>(),
+    execPolicy: options.execPolicy,
+    sandbox: options.sandbox ?? createDefaultSandboxConfig(),
+    sandboxAdapter: options.sandboxAdapter,
+    ...(options.abortSignal ? { abortSignal: options.abortSignal } : {})
+  };
+
+  const execution = await runSandboxedBashCommand({
+    toolName: `harness.${options.kind}`,
     command: options.command,
-    cwd: options.workspacePath,
+    cwd,
     env: process.env,
     timeoutMs: Math.max(1, Math.floor(options.timeoutSec * 1000)),
-    abortSignal: options.abortSignal
+    abortSignal: options.abortSignal,
+    policy,
+    context
   });
+  if ("allowed" in execution) {
+    return {
+      kind: options.kind,
+      source: options.source,
+      command: options.command,
+      attempt: options.attempt,
+      exit_code: 126,
+      stdout_tail: "",
+      stderr_tail: execution.reason ?? "Command was denied by sandbox policy.",
+      related_files: options.relatedFiles ?? [],
+      timeout_sec: options.timeoutSec,
+      duration_ms: Date.now() - startedAt,
+      sandbox: execution.metadata,
+      message: `${label} command denied by sandbox policy`
+    };
+  }
+  const { result, sandbox } = execution;
 
   if (result.error) {
     return {
@@ -47,6 +107,7 @@ export async function runHarnessCommand(options: {
       signal: result.signal ?? undefined,
       timed_out: result.timedOut || undefined,
       cancelled: result.cancelled || undefined,
+      sandbox,
       message: `${options.kind} command failed: ${result.error.message}`
     };
   }
@@ -54,7 +115,6 @@ export async function runHarnessCommand(options: {
   const code = result.cancelled ? 130 : result.timedOut ? 124 : result.exitCode ?? 1;
   const stdoutTail = tailText(result.stdout.toString("utf8"));
   const stderrTail = tailText(result.stderr.toString("utf8"));
-  const label = options.kind === "validation" ? "validation" : "precheck";
   return {
     kind: options.kind,
     source: options.source,
@@ -70,6 +130,7 @@ export async function runHarnessCommand(options: {
     signal: result.signal ?? undefined,
     timed_out: result.timedOut || undefined,
     cancelled: result.cancelled || undefined,
+    sandbox,
     message: result.cancelled ? `${label} command cancelled` : code === 0 ? `${label} command passed` : `${label} command failed with exit code ${code}`
   };
 }

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -160,7 +160,17 @@ export {
   resolveWorkspacePath,
   workspaceRelativePath
 } from "./policy.js";
-export { createPolicyOnlySandboxAdapter, PolicyOnlySandboxAdapter } from "./sandbox.js";
+export {
+  createDefaultSandboxAdapter,
+  createDefaultSandboxConfig,
+  createPolicyOnlySandboxAdapter,
+  DefaultSandboxAdapter,
+  formatSandboxShellCommand,
+  normalizeSandboxConfig,
+  PolicyOnlySandboxAdapter,
+  sandboxMetadata
+} from "./sandbox.js";
+export type { EffectiveSandboxConfig } from "./sandbox.js";
 export { ToolRuntime } from "./tool-runtime.js";
 export type { ToolRuntimeCallbacks, ToolRuntimeExecution } from "./tool-runtime.js";
 export { summarizeContextBudget } from "./context/token-budget.js";
@@ -265,9 +275,17 @@ export type {
   SubagentType,
   SummaryJson,
   SandboxAdapter,
+  SandboxAvailability,
+  SandboxBackend,
   SandboxConfig,
   SandboxExecDecision,
   SandboxExecRequest,
+  SandboxExternalConfig,
+  SandboxFilesystemConfig,
+  SandboxFilesystemMode,
+  SandboxMode,
+  SandboxNetworkConfig,
+  SandboxNetworkMode,
   TodoItem,
   TodoStatus,
   TokenTotals,

--- a/packages/agent-core/src/sandbox.ts
+++ b/packages/agent-core/src/sandbox.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
-import { existsSync } from "node:fs";
-import { mkdir, writeFile } from "node:fs/promises";
+import { existsSync, statSync } from "node:fs";
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -45,6 +45,36 @@ const DEFAULT_PROTECTED_WRITE_PATHS = [
   ".agent/skills"
 ];
 
+const DEFAULT_BUBBLEWRAP_SYSTEM_READ_PATHS = [
+  "/usr",
+  "/bin",
+  "/sbin",
+  "/lib",
+  "/lib64",
+  "/etc/alternatives",
+  "/etc/ca-certificates",
+  "/etc/ssl",
+  "/etc/pki",
+  "/etc/ld.so.cache",
+  "/etc/nsswitch.conf",
+  "/etc/passwd",
+  "/etc/group",
+  "/etc/hosts",
+  "/etc/resolv.conf",
+  "/etc/localtime",
+  "/var/lib/ca-certificates"
+];
+
+interface PathOverlay {
+  source: string;
+  target: string;
+}
+
+interface PreparedPaths {
+  cleanup?: () => Promise<void>;
+  metadata: Record<string, unknown>;
+}
+
 function normalizeMode(value: SandboxMode | undefined): EffectiveSandboxMode {
   if (value === "policy_only") return "policy-only";
   if (value === undefined) return "workspace-write";
@@ -83,6 +113,22 @@ function resolvePathList(workspacePath: string, values: string[] | undefined): s
   return [...new Set((values ?? []).map((item) => resolveSandboxPath(workspacePath, item)))];
 }
 
+function uniquePathList(values: string[]): string[] {
+  return [...new Set(values.map((item) => path.resolve(item)))];
+}
+
+function isPathInsidePath(parentPath: string, candidatePath: string): boolean {
+  const parent = path.resolve(parentPath);
+  const candidate = path.resolve(candidatePath);
+  const normalizedParent = process.platform === "win32" ? parent.toLowerCase() : parent;
+  const normalizedCandidate = process.platform === "win32" ? candidate.toLowerCase() : candidate;
+  return normalizedCandidate === normalizedParent || normalizedCandidate.startsWith(`${normalizedParent}${path.sep}`);
+}
+
+function isPathInsideAny(parentPaths: string[], candidatePath: string): boolean {
+  return parentPaths.some((root) => existsSync(root) && isPathInsidePath(root, candidatePath));
+}
+
 function filesystemMode(value: SandboxConfig["filesystem"] | undefined): "read-only" | "workspace-write" | undefined {
   if (value === "read_only") return "read-only";
   if (value === "workspace_write") return "workspace-write";
@@ -109,10 +155,14 @@ export function normalizeSandboxConfig(workspacePath: string, sandbox?: SandboxC
   const backend = normalizeBackend(base.backend, mode, base.mode);
   const fsConfig = configObject(base.filesystem);
   const workspace = path.resolve(workspacePath);
+  const configuredWriteRoots = resolvePathList(workspace, fsConfig.writeRoots);
   const writeRoots = mode === "workspace-write"
     ? resolvePathList(workspace, fsConfig.writeRoots && fsConfig.writeRoots.length > 0 ? fsConfig.writeRoots : ["."])
-    : resolvePathList(workspace, fsConfig.writeRoots);
-  const readRoots = resolvePathList(workspace, fsConfig.readRoots);
+    : mode === "external"
+      ? configuredWriteRoots
+      : [];
+  const workspaceReadRoots = mode === "workspace-write" || mode === "read-only" ? [workspace] : [];
+  const readRoots = uniquePathList([...workspaceReadRoots, ...resolvePathList(workspace, fsConfig.readRoots)]);
   const denyRead = resolvePathList(workspace, fsConfig.denyRead);
   const denyWrite = resolvePathList(workspace, [
     ...DEFAULT_PROTECTED_WRITE_PATHS,
@@ -293,38 +343,153 @@ function addReadOnlyOverlays(args: string[], paths: string[]): void {
   }
 }
 
-function buildBubblewrapArgs(effective: EffectiveSandboxConfig, cwd: string, command: string[]): string[] {
+function pathType(target: string): "directory" | "file" {
+  try {
+    return statSync(target).isDirectory() ? "directory" : "file";
+  } catch {
+    return missingDenyWritePathType(target);
+  }
+}
+
+function missingDenyWritePathType(target: string): "directory" | "file" {
+  const normalized = path.resolve(target).split(path.sep).join("/");
+  if (normalized.endsWith("/.agent/skills")) return "directory";
+  if (target.endsWith(path.sep) || target.endsWith("/") || target.endsWith("\\")) return "directory";
+  return path.extname(target) ? "file" : "directory";
+}
+
+async function createParentDirs(target: string): Promise<string[]> {
+  const parent = path.dirname(path.resolve(target));
+  const created: string[] = [];
+  let cursor = parent;
+  while (!existsSync(cursor)) {
+    created.push(cursor);
+    const next = path.dirname(cursor);
+    if (next === cursor) break;
+    cursor = next;
+  }
+  await mkdir(parent, { recursive: true });
+  return created;
+}
+
+async function prepareMissingDenyWritePaths(effective: EffectiveSandboxConfig): Promise<PreparedPaths> {
+  const createdTargets: Array<{ path: string; type: "directory" | "file" }> = [];
+  const createdDirs: string[] = [];
+  const roots = uniquePathList(effective.filesystem.writeRoots);
+  for (const target of effective.filesystem.denyWrite) {
+    if (existsSync(target) || !isPathInsideAny(roots, target)) continue;
+    const type = missingDenyWritePathType(target);
+    createdDirs.push(...await createParentDirs(target));
+    if (type === "directory") {
+      await mkdir(target, { recursive: true });
+    } else {
+      await writeFile(target, "", { flag: "wx" }).catch(async (error: unknown) => {
+        if (error && typeof error === "object" && "code" in error && (error as { code?: string }).code === "EEXIST") return;
+        throw error;
+      });
+      await chmod(target, 0o444).catch(() => {});
+    }
+    createdTargets.push({ path: target, type });
+  }
+  const uniqueCreatedDirs = [...new Set(createdDirs)];
+  return {
+    metadata: {
+      protectedPlaceholders: createdTargets.map((item) => item.path)
+    },
+    cleanup: async () => {
+      for (const item of [...createdTargets].reverse()) {
+        await rm(item.path, { recursive: item.type === "directory", force: true }).catch(() => {});
+      }
+      for (const dir of uniqueCreatedDirs) {
+        await rm(dir, { recursive: false, force: false }).catch(() => {});
+      }
+    }
+  };
+}
+
+async function prepareDenyReadOverlays(effective: EffectiveSandboxConfig): Promise<PreparedPaths & { overlays: PathOverlay[] }> {
+  const existing = effective.filesystem.denyRead.filter((target) => existsSync(target));
+  if (existing.length === 0) return { overlays: [], metadata: { denyReadOverlays: [] } };
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "sigma-bwrap-deny-read-"));
+  const overlays: PathOverlay[] = [];
+  let index = 0;
+  for (const target of existing) {
+    const type = pathType(target);
+    const source = path.join(tempDir, `${index}-${type}`);
+    index += 1;
+    if (type === "directory") {
+      await mkdir(source, { recursive: true });
+    } else {
+      await writeFile(source, "", "utf8");
+    }
+    await chmod(source, 0).catch(() => {});
+    overlays.push({ source, target });
+  }
+  return {
+    overlays,
+    metadata: {
+      denyReadOverlays: overlays.map((item) => item.target)
+    },
+    cleanup: async () => {
+      await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    }
+  };
+}
+
+function combineCleanups(...cleanups: Array<(() => Promise<void> | void) | undefined>): (() => Promise<void>) | undefined {
+  const filtered = cleanups.filter((cleanup): cleanup is () => Promise<void> | void => Boolean(cleanup));
+  if (filtered.length === 0) return undefined;
+  return async () => {
+    for (const cleanup of filtered) {
+      try {
+        await cleanup();
+      } catch {
+        // Keep later cleanup steps running even if one path was already removed.
+      }
+    }
+  };
+}
+
+function buildBubblewrapArgs(effective: EffectiveSandboxConfig, cwd: string, command: string[], denyReadOverlays: PathOverlay[]): string[] {
   const args = [
-    "--die-with-parent",
-    "--ro-bind", "/", "/",
-    "--proc", "/proc",
-    "--dev", "/dev",
-    "--tmpfs", "/tmp",
-    "--setenv", "TMPDIR", "/tmp"
+    "--die-with-parent"
   ];
+  addReadOnlyOverlays(args, DEFAULT_BUBBLEWRAP_SYSTEM_READ_PATHS);
+  args.push("--proc", "/proc", "--dev", "/dev", "--tmpfs", "/tmp", "--setenv", "TMPDIR", "/tmp");
   if (effective.network.mode === "restricted" || effective.network.mode === "disabled") {
     args.push("--unshare-net");
-  }
-  for (const root of effective.filesystem.writeRoots) {
-    if (existsSync(root)) args.push("--bind", root, root);
   }
   for (const root of effective.filesystem.readRoots) {
     if (existsSync(root)) args.push("--ro-bind", root, root);
   }
+  for (const root of effective.filesystem.writeRoots) {
+    if (existsSync(root)) args.push("--bind", root, root);
+  }
   addReadOnlyOverlays(args, effective.filesystem.denyWrite);
+  for (const overlay of denyReadOverlays) {
+    args.push("--ro-bind", overlay.source, overlay.target);
+  }
   args.push("--chdir", cwd, ...command);
   return args;
 }
 
-function prepareBubblewrapExec(request: SandboxExecRequest, effective: EffectiveSandboxConfig): SandboxExecDecision {
-  const args = buildBubblewrapArgs(effective, request.cwd, ["/usr/bin/env", "bash", "-lc", request.command]);
+async function prepareBubblewrapExec(request: SandboxExecRequest, effective: EffectiveSandboxConfig): Promise<SandboxExecDecision> {
+  const writePlaceholders = await prepareMissingDenyWritePaths(effective);
+  const denyRead = await prepareDenyReadOverlays(effective);
+  const args = buildBubblewrapArgs(effective, request.cwd, ["/usr/bin/env", "bash", "-lc", request.command], denyRead.overlays);
   return {
     allowed: true,
     command: "bwrap",
     args,
     cwd: request.cwd,
     env: request.env,
-    metadata: sandboxMetadata(effective, { enforcement: "bubblewrap", transformed: true })
+    metadata: sandboxMetadata(effective, {
+      enforcement: "bubblewrap",
+      transformed: true,
+      ...writePlaceholders.metadata,
+      ...denyRead.metadata
+    }),
+    cleanup: combineCleanups(denyRead.cleanup, writePlaceholders.cleanup)
   };
 }
 
@@ -376,6 +541,7 @@ async function prepareWindowsExec(request: SandboxExecRequest, effective: Effect
   const requestDir = path.join(os.tmpdir(), "sigma-windows-sandbox");
   const tempRootBase = effective.filesystem.tempRoot ?? path.join(os.tmpdir(), "sigma-windows-sandbox-tmp");
   const tempRoot = path.join(tempRootBase, randomUUID());
+  const writePlaceholders = await prepareMissingDenyWritePaths(effective);
   await mkdir(requestDir, { recursive: true });
   await mkdir(tempRoot, { recursive: true });
   const requestPath = path.join(requestDir, `${randomUUID()}.json`);
@@ -396,12 +562,13 @@ async function prepareWindowsExec(request: SandboxExecRequest, effective: Effect
       program: shell,
       args: request.toolName === "shell_session" ? ["/q"] : [],
       commandLine: request.toolName === "shell_session"
-        ? windowsArgQuote(shell)
+        ? `${windowsArgQuote(shell)} /q`
         : `${windowsArgQuote(shell)} /d /s /c ${windowsArgQuote(request.command)}`,
       cwd: request.cwd,
       capabilitySid,
       writeRoots: allowedWriteRoots,
-      denyWrite: effective.filesystem.denyWrite
+      denyWrite: effective.filesystem.denyWrite,
+      denyRead: effective.filesystem.denyRead
     })}\n`,
     "utf8"
   );
@@ -411,7 +578,20 @@ async function prepareWindowsExec(request: SandboxExecRequest, effective: Effect
     args: ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", helper, "-Request", requestPath],
     cwd: request.cwd,
     env,
-    metadata: sandboxMetadata(effective, { enforcement: "windows-restricted-token", transformed: true, capabilitySid, tempRoot, shell: "cmd.exe" })
+    metadata: sandboxMetadata(effective, {
+      enforcement: "windows-restricted-token",
+      transformed: true,
+      capabilitySid,
+      tempRoot,
+      shell: "cmd.exe",
+      ...writePlaceholders.metadata
+    }),
+    cleanup: combineCleanups(
+      writePlaceholders.cleanup,
+      async () => {
+        await rm(tempRoot, { recursive: true, force: true }).catch(() => {});
+      }
+    )
   };
 }
 
@@ -420,16 +600,26 @@ function unavailableDecision(
   effective: EffectiveSandboxConfig,
   availability: SandboxAvailability
 ): SandboxExecDecision {
+  const unavailableReason = availability.reason ?? `Sandbox backend ${availability.backend} is unavailable.`;
   if (effective.required) {
     return {
       allowed: false,
-      reason: availability.reason ?? `Sandbox backend ${availability.backend} is unavailable.`,
-      metadata: sandboxMetadata(effective, { backendAvailable: false, reason: availability.reason })
+      reason: unavailableReason,
+      metadata: sandboxMetadata(effective, {
+        backendAvailable: false,
+        osSandbox: false,
+        fallbackAllowed: false,
+        reason: unavailableReason
+      })
     };
   }
+  const warning = `OS sandbox backend '${availability.backend}' is unavailable; running with policy-only checks because sandbox.required=false. Filesystem and network isolation are not enforced by the OS.`;
   const fallback = policyOnlyDecision(request, { ...effective, backend: "policy-only" }, {
     fallbackFrom: availability.backend,
-    fallbackReason: availability.reason
+    fallbackReason: unavailableReason,
+    fallbackAllowed: true,
+    osSandbox: false,
+    warning
   });
   return {
     ...fallback,
@@ -476,7 +666,7 @@ export class DefaultSandboxAdapter implements SandboxAdapter {
     const availability = backendAvailability(backend, effective);
     if (!availability.available) return unavailableDecision(request, effective, availability);
     if (backend === "policy-only") return policyOnlyDecision(request, effective);
-    if (backend === "bubblewrap") return prepareBubblewrapExec(request, { ...effective, backend });
+    if (backend === "bubblewrap") return await prepareBubblewrapExec(request, { ...effective, backend });
     if (backend === "windows") return await prepareWindowsExec(request, { ...effective, backend });
     if (backend === "external") return prepareExternalExec(request, { ...effective, backend });
 

--- a/packages/agent-core/src/sandbox.ts
+++ b/packages/agent-core/src/sandbox.ts
@@ -204,9 +204,37 @@ export function sandboxMetadata(effective: EffectiveSandboxConfig, extra: Record
   };
 }
 
-function commandExists(command: string, args: string[] = ["--version"]): boolean {
+interface CommandProbeResult {
+  ok: boolean;
+  status?: number | null;
+  signal?: NodeJS.Signals | null;
+  error?: string;
+}
+
+interface SandboxProbeResult {
+  available: boolean;
+  reason?: string;
+}
+
+function commandProbe(command: string, args: string[] = ["--version"]): CommandProbeResult {
   const result = spawnSync(command, args, { stdio: "ignore", windowsHide: true });
-  return !result.error && result.status === 0;
+  return {
+    ok: !result.error && result.status === 0,
+    status: result.status,
+    signal: result.signal,
+    ...(result.error ? { error: result.error.message } : {})
+  };
+}
+
+function commandExists(command: string, args: string[] = ["--version"]): boolean {
+  return commandProbe(command, args).ok;
+}
+
+function probeFailureDetail(result: CommandProbeResult): string {
+  if (result.error) return result.error;
+  if (result.status !== undefined && result.status !== null) return `exit status ${result.status}`;
+  if (result.signal) return `signal ${result.signal}`;
+  return "unknown failure";
 }
 
 function windowsSandboxHelperPath(): string {
@@ -217,12 +245,44 @@ function windowsCommandShellPath(): string {
   return process.env.ComSpec || path.join(process.env.SystemRoot || "C:\\Windows", "System32", "cmd.exe");
 }
 
-function bubblewrapAvailable(): boolean {
-  return process.platform === "linux" && commandExists("bwrap");
+function bubblewrapAvailabilityProbe(): SandboxProbeResult {
+  if (process.platform !== "linux") {
+    return { available: false, reason: "bubblewrap backend is only available on Linux." };
+  }
+  const bwrap = commandProbe("bwrap");
+  if (!bwrap.ok) {
+    return {
+      available: false,
+      reason: `bubblewrap command probe failed (${probeFailureDetail(bwrap)}). Install bubblewrap (bwrap) and make sure it is on PATH.`
+    };
+  }
+
+  const unshare = commandProbe("unshare", ["-Ur", "true"]);
+  if (unshare.ok) return { available: true };
+
+  const minimalBwrap = commandProbe("bwrap", ["--ro-bind", "/", "/", "true"]);
+  if (minimalBwrap.ok) return { available: true };
+
+  return {
+    available: false,
+    reason: `bubblewrap is installed, but Linux user namespaces are unavailable or the minimal bubblewrap probe failed (unshare -Ur true: ${probeFailureDetail(unshare)}; bwrap probe: ${probeFailureDetail(minimalBwrap)}). Enable unprivileged user namespaces or fix the bwrap installation.`
+  };
 }
 
-function seatbeltAvailable(): boolean {
-  return process.platform === "darwin" && existsSync("/usr/bin/sandbox-exec");
+function seatbeltAvailabilityProbe(): SandboxProbeResult {
+  if (process.platform !== "darwin") {
+    return { available: false, reason: "macOS seatbelt backend is only available on macOS." };
+  }
+  if (existsSync("/usr/bin/sandbox-exec")) {
+    return {
+      available: false,
+      reason: "macOS seatbelt backend is detected but command execution is not implemented yet."
+    };
+  }
+  return {
+    available: false,
+    reason: "macOS seatbelt backend command execution is not implemented yet, and /usr/bin/sandbox-exec was not found."
+  };
 }
 
 function windowsSandboxAvailable(effective: EffectiveSandboxConfig): SandboxAvailability {
@@ -261,14 +321,14 @@ function backendAvailability(backend: EffectiveSandboxBackend, effective: Effect
       : { available: false, backend, mode: effective.mode, reason: "External sandbox backend requires external.command." };
   }
   if (backend === "bubblewrap") {
-    return bubblewrapAvailable()
+    const probe = bubblewrapAvailabilityProbe();
+    return probe.available
       ? { available: true, backend, mode: effective.mode, metadata: sandboxMetadata(effective) }
-      : { available: false, backend, mode: effective.mode, reason: "bubblewrap backend is unavailable. Install bwrap and enable user namespaces." };
+      : { available: false, backend, mode: effective.mode, reason: probe.reason };
   }
   if (backend === "seatbelt") {
-    return seatbeltAvailable()
-      ? { available: true, backend, mode: effective.mode, metadata: sandboxMetadata(effective) }
-      : { available: false, backend, mode: effective.mode, reason: "macOS seatbelt backend is unavailable." };
+    const probe = seatbeltAvailabilityProbe();
+    return { available: false, backend, mode: effective.mode, reason: probe.reason };
   }
   if (backend === "windows") {
     return windowsSandboxAvailable(effective);

--- a/packages/agent-core/src/sandbox.ts
+++ b/packages/agent-core/src/sandbox.ts
@@ -1,30 +1,504 @@
-import type { SandboxAdapter, SandboxExecDecision, SandboxExecRequest } from "./types.js";
+import { spawnSync } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
+import { existsSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type {
+  SandboxAdapter,
+  SandboxAvailability,
+  SandboxBackend,
+  SandboxConfig,
+  SandboxExecDecision,
+  SandboxExecRequest,
+  SandboxFilesystemConfig,
+  SandboxMode,
+  SandboxNetworkConfig,
+  SandboxNetworkMode
+} from "./types.js";
+
+type EffectiveSandboxMode = "disabled" | "read-only" | "workspace-write" | "danger-full-access" | "policy-only" | "external";
+type EffectiveSandboxBackend = "auto" | "bubblewrap" | "seatbelt" | "windows" | "external" | "policy-only";
+
+export interface EffectiveSandboxConfig {
+  mode: EffectiveSandboxMode;
+  backend: EffectiveSandboxBackend;
+  required: boolean;
+  network: Required<Pick<SandboxNetworkConfig, "mode" | "allowLocalhost">> & Omit<SandboxNetworkConfig, "mode" | "allowLocalhost">;
+  filesystem: {
+    readRoots: string[];
+    writeRoots: string[];
+    denyRead: string[];
+    denyWrite: string[];
+    tempRoot?: string;
+  };
+  external?: {
+    command?: string;
+    args: string[];
+  };
+}
+
+const DEFAULT_PROTECTED_WRITE_PATHS = [
+  ".agent/config.toml",
+  ".agent/mcp.json",
+  ".agent/skills"
+];
+
+function normalizeMode(value: SandboxMode | undefined): EffectiveSandboxMode {
+  if (value === "policy_only") return "policy-only";
+  if (value === undefined) return "workspace-write";
+  return value;
+}
+
+function normalizeBackend(value: SandboxBackend | undefined, mode: EffectiveSandboxMode, rawMode?: SandboxMode): EffectiveSandboxBackend {
+  if (value === "policy_only") return "policy-only";
+  if (value) return value;
+  if (rawMode === "policy_only" || rawMode === "policy-only") return "policy-only";
+  if (mode === "policy-only") return "policy-only";
+  if (mode === "external") return "external";
+  return "auto";
+}
+
+function normalizeNetwork(value: SandboxConfig["network"] | undefined): EffectiveSandboxConfig["network"] {
+  if (typeof value === "string") {
+    return { mode: value, allowLocalhost: true };
+  }
+  return {
+    ...(value ?? {}),
+    mode: value?.mode ?? "restricted",
+    allowLocalhost: value?.allowLocalhost ?? true
+  };
+}
+
+function configObject(value: SandboxConfig["filesystem"] | undefined): SandboxFilesystemConfig {
+  return typeof value === "object" && value !== null ? value : {};
+}
+
+function resolveSandboxPath(workspacePath: string, input: string): string {
+  return path.resolve(path.isAbsolute(input) ? input : path.join(workspacePath, input));
+}
+
+function resolvePathList(workspacePath: string, values: string[] | undefined): string[] {
+  return [...new Set((values ?? []).map((item) => resolveSandboxPath(workspacePath, item)))];
+}
+
+function filesystemMode(value: SandboxConfig["filesystem"] | undefined): "read-only" | "workspace-write" | undefined {
+  if (value === "read_only") return "read-only";
+  if (value === "workspace_write") return "workspace-write";
+  return undefined;
+}
+
+export function createDefaultSandboxConfig(): SandboxConfig {
+  return {
+    mode: "workspace-write",
+    backend: "auto",
+    required: false,
+    network: { mode: "restricted", allowLocalhost: true },
+    filesystem: {
+      writeRoots: ["."],
+      denyWrite: DEFAULT_PROTECTED_WRITE_PATHS
+    }
+  };
+}
+
+export function normalizeSandboxConfig(workspacePath: string, sandbox?: SandboxConfig): EffectiveSandboxConfig {
+  const base = sandbox ?? createDefaultSandboxConfig();
+  const legacyFilesystemMode = filesystemMode(base.filesystem);
+  const mode = legacyFilesystemMode ?? normalizeMode(base.mode);
+  const backend = normalizeBackend(base.backend, mode, base.mode);
+  const fsConfig = configObject(base.filesystem);
+  const workspace = path.resolve(workspacePath);
+  const writeRoots = mode === "workspace-write"
+    ? resolvePathList(workspace, fsConfig.writeRoots && fsConfig.writeRoots.length > 0 ? fsConfig.writeRoots : ["."])
+    : resolvePathList(workspace, fsConfig.writeRoots);
+  const readRoots = resolvePathList(workspace, fsConfig.readRoots);
+  const denyRead = resolvePathList(workspace, fsConfig.denyRead);
+  const denyWrite = resolvePathList(workspace, [
+    ...DEFAULT_PROTECTED_WRITE_PATHS,
+    ...(fsConfig.denyWrite ?? [])
+  ]);
+  const tempRoot = fsConfig.tempRoot ? resolveSandboxPath(workspace, fsConfig.tempRoot) : undefined;
+
+  return {
+    mode,
+    backend,
+    required: base.required ?? false,
+    network: normalizeNetwork(base.network),
+    filesystem: {
+      readRoots,
+      writeRoots,
+      denyRead,
+      denyWrite,
+      ...(tempRoot ? { tempRoot } : {})
+    },
+    ...(base.external
+      ? { external: { command: base.external.command, args: base.external.args ?? [] } }
+      : {})
+  };
+}
+
+export function sandboxMetadata(effective: EffectiveSandboxConfig, extra: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    mode: effective.mode,
+    backend: effective.backend,
+    required: effective.required,
+    network: effective.network.mode,
+    allowLocalhost: effective.network.allowLocalhost,
+    readRoots: effective.filesystem.readRoots,
+    writeRoots: effective.filesystem.writeRoots,
+    denyRead: effective.filesystem.denyRead,
+    denyWrite: effective.filesystem.denyWrite,
+    ...(effective.filesystem.tempRoot ? { tempRoot: effective.filesystem.tempRoot } : {}),
+    ...extra
+  };
+}
+
+function commandExists(command: string, args: string[] = ["--version"]): boolean {
+  const result = spawnSync(command, args, { stdio: "ignore", windowsHide: true });
+  return !result.error && result.status === 0;
+}
+
+function windowsSandboxHelperPath(): string {
+  return path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "helpers", "windows-sandbox-runner.ps1");
+}
+
+function windowsCommandShellPath(): string {
+  return process.env.ComSpec || path.join(process.env.SystemRoot || "C:\\Windows", "System32", "cmd.exe");
+}
+
+function bubblewrapAvailable(): boolean {
+  return process.platform === "linux" && commandExists("bwrap");
+}
+
+function seatbeltAvailable(): boolean {
+  return process.platform === "darwin" && existsSync("/usr/bin/sandbox-exec");
+}
+
+function windowsSandboxAvailable(effective: EffectiveSandboxConfig): SandboxAvailability {
+  if (process.platform !== "win32") {
+    return { available: false, backend: "windows", mode: effective.mode, reason: "Windows sandbox backend is only available on Windows." };
+  }
+  if (effective.network.mode === "restricted" || effective.network.mode === "disabled") {
+    return {
+      available: false,
+      backend: "windows",
+      mode: effective.mode,
+      reason: "Windows native sandbox v1 does not implement WFP network isolation; use network=default or WSL/bubblewrap for restricted network."
+    };
+  }
+  const helper = windowsSandboxHelperPath();
+  if (!existsSync(helper)) {
+    return { available: false, backend: "windows", mode: effective.mode, reason: `Windows sandbox helper not found: ${helper}` };
+  }
+  if (!commandExists("powershell.exe", ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", helper, "-Probe"])) {
+    return { available: false, backend: "windows", mode: effective.mode, reason: "Windows sandbox helper probe failed." };
+  }
+  return { available: true, backend: "windows", mode: effective.mode, metadata: sandboxMetadata(effective) };
+}
+
+function backendAvailability(backend: EffectiveSandboxBackend, effective: EffectiveSandboxConfig): SandboxAvailability {
+  if (effective.mode === "disabled" || effective.mode === "danger-full-access") {
+    return { available: true, backend: "none", mode: effective.mode, metadata: sandboxMetadata(effective) };
+  }
+  if (backend === "policy-only") {
+    return { available: true, backend, mode: effective.mode, metadata: sandboxMetadata(effective) };
+  }
+  if (backend === "external") {
+    const command = effective.external?.command;
+    return command
+      ? { available: true, backend, mode: effective.mode, metadata: sandboxMetadata(effective) }
+      : { available: false, backend, mode: effective.mode, reason: "External sandbox backend requires external.command." };
+  }
+  if (backend === "bubblewrap") {
+    return bubblewrapAvailable()
+      ? { available: true, backend, mode: effective.mode, metadata: sandboxMetadata(effective) }
+      : { available: false, backend, mode: effective.mode, reason: "bubblewrap backend is unavailable. Install bwrap and enable user namespaces." };
+  }
+  if (backend === "seatbelt") {
+    return seatbeltAvailable()
+      ? { available: true, backend, mode: effective.mode, metadata: sandboxMetadata(effective) }
+      : { available: false, backend, mode: effective.mode, reason: "macOS seatbelt backend is unavailable." };
+  }
+  if (backend === "windows") {
+    return windowsSandboxAvailable(effective);
+  }
+  return { available: false, backend, mode: effective.mode, reason: `Unsupported sandbox backend: ${backend}` };
+}
+
+function selectAutoBackend(): EffectiveSandboxBackend {
+  if (process.platform === "linux") return "bubblewrap";
+  if (process.platform === "darwin") return "seatbelt";
+  if (process.platform === "win32") return "windows";
+  return "policy-only";
+}
+
+function policyOnlyDecision(request: SandboxExecRequest, effective: EffectiveSandboxConfig, extra: Record<string, unknown> = {}): SandboxExecDecision {
+  if (effective.mode === "read-only" && request.policy.mutatesWorkspace) {
+    return {
+      allowed: false,
+      reason: "Sandbox policy is read-only, but the command appears to modify workspace state.",
+      metadata: sandboxMetadata(effective, { enforcement: "policy-only", ...extra })
+    };
+  }
+  if ((effective.network.mode === "restricted" || effective.network.mode === "disabled") && request.policy.usesNetwork) {
+    return {
+      allowed: false,
+      reason: "Sandbox policy restricts network access, but the command appears to use the network.",
+      metadata: sandboxMetadata(effective, { enforcement: "policy-only", ...extra })
+    };
+  }
+  return {
+    allowed: true,
+    cwd: request.cwd,
+    env: request.env,
+    metadata: sandboxMetadata(effective, { enforcement: "policy-only", ...extra })
+  };
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function windowsArgQuote(value: string): string {
+  let result = "\"";
+  let slashCount = 0;
+  for (const char of value) {
+    if (char === "\\") {
+      slashCount += 1;
+      continue;
+    }
+    if (char === "\"") {
+      result += "\\".repeat(slashCount * 2 + 1);
+      result += "\"";
+      slashCount = 0;
+      continue;
+    }
+    result += "\\".repeat(slashCount);
+    slashCount = 0;
+    result += char;
+  }
+  result += "\\".repeat(slashCount * 2);
+  result += "\"";
+  return result;
+}
+
+function existingPaths(paths: string[]): string[] {
+  return paths.filter((item) => existsSync(item));
+}
+
+function addReadOnlyOverlays(args: string[], paths: string[]): void {
+  for (const item of existingPaths(paths)) {
+    args.push("--ro-bind", item, item);
+  }
+}
+
+function buildBubblewrapArgs(effective: EffectiveSandboxConfig, cwd: string, command: string[]): string[] {
+  const args = [
+    "--die-with-parent",
+    "--ro-bind", "/", "/",
+    "--proc", "/proc",
+    "--dev", "/dev",
+    "--tmpfs", "/tmp",
+    "--setenv", "TMPDIR", "/tmp"
+  ];
+  if (effective.network.mode === "restricted" || effective.network.mode === "disabled") {
+    args.push("--unshare-net");
+  }
+  for (const root of effective.filesystem.writeRoots) {
+    if (existsSync(root)) args.push("--bind", root, root);
+  }
+  for (const root of effective.filesystem.readRoots) {
+    if (existsSync(root)) args.push("--ro-bind", root, root);
+  }
+  addReadOnlyOverlays(args, effective.filesystem.denyWrite);
+  args.push("--chdir", cwd, ...command);
+  return args;
+}
+
+function prepareBubblewrapExec(request: SandboxExecRequest, effective: EffectiveSandboxConfig): SandboxExecDecision {
+  const args = buildBubblewrapArgs(effective, request.cwd, ["/usr/bin/env", "bash", "-lc", request.command]);
+  return {
+    allowed: true,
+    command: "bwrap",
+    args,
+    cwd: request.cwd,
+    env: request.env,
+    metadata: sandboxMetadata(effective, { enforcement: "bubblewrap", transformed: true })
+  };
+}
+
+function prepareExternalExec(request: SandboxExecRequest, effective: EffectiveSandboxConfig): SandboxExecDecision {
+  const command = effective.external?.command;
+  if (!command) {
+    return {
+      allowed: false,
+      reason: "External sandbox backend requires external.command.",
+      metadata: sandboxMetadata(effective, { enforcement: "external" })
+    };
+  }
+  return {
+    allowed: true,
+    command,
+    args: [
+      ...(effective.external?.args ?? []),
+      "--cwd",
+      request.cwd,
+      "--",
+      "/usr/bin/env",
+      "bash",
+      "-lc",
+      request.command
+    ],
+    cwd: request.cwd,
+    env: request.env,
+    metadata: sandboxMetadata(effective, { enforcement: "external", transformed: true })
+  };
+}
+
+function capabilitySidForSandbox(workspacePath: string, effective: EffectiveSandboxConfig): string {
+  const hash = createHash("sha256")
+    .update("sigma-windows-sandbox-v1\0")
+    .update(path.resolve(workspacePath).toLowerCase())
+    .update("\0")
+    .update(effective.mode)
+    .digest();
+  const parts: string[] = [];
+  for (let offset = 0; offset < 16; offset += 4) {
+    parts.push(String(hash.readUInt32LE(offset)));
+  }
+  return `S-1-5-21-${parts.join("-")}`;
+}
+
+async function prepareWindowsExec(request: SandboxExecRequest, effective: EffectiveSandboxConfig): Promise<SandboxExecDecision> {
+  const helper = windowsSandboxHelperPath();
+  const shell = windowsCommandShellPath();
+  const requestDir = path.join(os.tmpdir(), "sigma-windows-sandbox");
+  const tempRootBase = effective.filesystem.tempRoot ?? path.join(os.tmpdir(), "sigma-windows-sandbox-tmp");
+  const tempRoot = path.join(tempRootBase, randomUUID());
+  await mkdir(requestDir, { recursive: true });
+  await mkdir(tempRoot, { recursive: true });
+  const requestPath = path.join(requestDir, `${randomUUID()}.json`);
+  const capabilitySid = capabilitySidForSandbox(request.workspacePath ?? request.cwd, effective);
+  const allowedWriteRoots = [
+    ...(effective.mode === "workspace-write" ? effective.filesystem.writeRoots : []),
+    tempRoot
+  ];
+  const env = {
+    ...(request.env ?? process.env),
+    TEMP: tempRoot,
+    TMP: tempRoot,
+    TMPDIR: tempRoot
+  };
+  await writeFile(
+    requestPath,
+    `${JSON.stringify({
+      program: shell,
+      args: request.toolName === "shell_session" ? ["/q"] : [],
+      commandLine: request.toolName === "shell_session"
+        ? windowsArgQuote(shell)
+        : `${windowsArgQuote(shell)} /d /s /c ${windowsArgQuote(request.command)}`,
+      cwd: request.cwd,
+      capabilitySid,
+      writeRoots: allowedWriteRoots,
+      denyWrite: effective.filesystem.denyWrite
+    })}\n`,
+    "utf8"
+  );
+  return {
+    allowed: true,
+    command: "powershell.exe",
+    args: ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", helper, "-Request", requestPath],
+    cwd: request.cwd,
+    env,
+    metadata: sandboxMetadata(effective, { enforcement: "windows-restricted-token", transformed: true, capabilitySid, tempRoot, shell: "cmd.exe" })
+  };
+}
+
+function unavailableDecision(
+  request: SandboxExecRequest,
+  effective: EffectiveSandboxConfig,
+  availability: SandboxAvailability
+): SandboxExecDecision {
+  if (effective.required) {
+    return {
+      allowed: false,
+      reason: availability.reason ?? `Sandbox backend ${availability.backend} is unavailable.`,
+      metadata: sandboxMetadata(effective, { backendAvailable: false, reason: availability.reason })
+    };
+  }
+  const fallback = policyOnlyDecision(request, { ...effective, backend: "policy-only" }, {
+    fallbackFrom: availability.backend,
+    fallbackReason: availability.reason
+  });
+  return {
+    ...fallback,
+    metadata: {
+      ...(fallback.metadata ?? {}),
+      backendAvailable: false
+    }
+  };
+}
 
 export class PolicyOnlySandboxAdapter implements SandboxAdapter {
+  async checkAvailability(sandbox: SandboxConfig | undefined, workspacePath: string): Promise<SandboxAvailability> {
+    const effective = normalizeSandboxConfig(workspacePath, sandbox);
+    return { available: true, backend: "policy-only", mode: effective.mode, metadata: sandboxMetadata(effective) };
+  }
+
   async prepareExec(request: SandboxExecRequest): Promise<SandboxExecDecision> {
-    if (request.sandbox?.filesystem === "read_only" && request.policy.mutatesWorkspace) {
+    return policyOnlyDecision(request, normalizeSandboxConfig(request.workspacePath ?? request.cwd, request.sandbox));
+  }
+}
+
+export class DefaultSandboxAdapter implements SandboxAdapter {
+  async checkAvailability(sandbox: SandboxConfig | undefined, workspacePath: string): Promise<SandboxAvailability> {
+    const effective = normalizeSandboxConfig(workspacePath, sandbox);
+    const backend = effective.backend === "auto" ? selectAutoBackend() : effective.backend;
+    return backendAvailability(backend, effective);
+  }
+
+  async prepareExec(request: SandboxExecRequest): Promise<SandboxExecDecision> {
+    const effective = normalizeSandboxConfig(request.workspacePath ?? request.cwd, request.sandbox);
+    if (effective.mode === "disabled" || effective.mode === "danger-full-access") {
       return {
-        allowed: false,
-        reason: "Sandbox policy is read-only, but the command appears to modify workspace state."
+        allowed: true,
+        cwd: request.cwd,
+        env: request.env,
+        metadata: sandboxMetadata(effective, { enforcement: "none" })
       };
     }
-    if (request.sandbox?.network === "restricted" && request.policy.usesNetwork) {
-      return {
-        allowed: false,
-        reason: "Sandbox policy restricts network access, but the command appears to use the network."
-      };
+    if (effective.mode === "policy-only") {
+      return policyOnlyDecision(request, effective);
     }
-    return {
-      allowed: true,
-      metadata: {
-        sandboxMode: request.sandbox?.mode ?? "policy_only",
-        network: request.sandbox?.network ?? "default",
-        filesystem: request.sandbox?.filesystem ?? "workspace_write"
-      }
-    };
+
+    const backend = effective.backend === "auto" ? selectAutoBackend() : effective.backend;
+    const availability = backendAvailability(backend, effective);
+    if (!availability.available) return unavailableDecision(request, effective, availability);
+    if (backend === "policy-only") return policyOnlyDecision(request, effective);
+    if (backend === "bubblewrap") return prepareBubblewrapExec(request, { ...effective, backend });
+    if (backend === "windows") return await prepareWindowsExec(request, { ...effective, backend });
+    if (backend === "external") return prepareExternalExec(request, { ...effective, backend });
+
+    return unavailableDecision(request, effective, {
+      available: false,
+      backend,
+      mode: effective.mode,
+      reason: `Sandbox backend ${backend} is not implemented for command execution.`
+    });
   }
 }
 
 export function createPolicyOnlySandboxAdapter(): SandboxAdapter {
   return new PolicyOnlySandboxAdapter();
+}
+
+export function createDefaultSandboxAdapter(): SandboxAdapter {
+  return new DefaultSandboxAdapter();
+}
+
+export function formatSandboxShellCommand(command: string, args: string[] | undefined): string {
+  return args && args.length > 0
+    ? [command, ...args].map(shellQuote).join(" ")
+    : command;
 }

--- a/packages/agent-core/src/tools/bash.ts
+++ b/packages/agent-core/src/tools/bash.ts
@@ -1,7 +1,6 @@
 import type { ToolExecutionContext, ToolResult } from "../types.js";
 import { evaluateExecPolicy, requestToolPermission, resolveWorkspacePath } from "../policy.js";
-import { runBashCommand } from "../command-runner.js";
-import { createPolicyOnlySandboxAdapter } from "../sandbox.js";
+import { runSandboxedBashCommand } from "../exec-runtime.js";
 
 interface BashArgs {
   command?: unknown;
@@ -81,33 +80,24 @@ export async function executeBashTool(args: unknown, context: ToolExecutionConte
 
   const timeoutSec = asNumber(parsed.timeoutSec) ?? context.commandTimeoutSec;
   const timeoutMs = Math.max(1, Math.floor(timeoutSec * 1000));
-  const sandboxAdapter = context.sandboxAdapter ?? (
-    context.sandbox?.mode === "disabled" ? undefined : createPolicyOnlySandboxAdapter()
-  );
-  const sandboxDecision = sandboxAdapter
-    ? await sandboxAdapter.prepareExec({
-        toolName: "bash",
-        command,
-        cwd,
-        env: process.env,
-        policy,
-        sandbox: context.sandbox
-      })
-    : { allowed: true };
-  if (!sandboxDecision.allowed) {
+  const execution = await runSandboxedBashCommand({
+    toolName: "bash",
+    command,
+    cwd,
+    env: process.env,
+    timeoutMs,
+    abortSignal: context.abortSignal,
+    policy,
+    context
+  });
+  if ("allowed" in execution) {
     return {
       ok: false,
-      content: sandboxDecision.reason ?? "Command was denied by sandbox policy.",
-      metadata: { execPolicy: policy, sandbox: sandboxDecision.metadata ?? { denied: true } }
+      content: execution.reason ?? "Command was denied by sandbox policy.",
+      metadata: { execPolicy: policy, sandbox: execution.metadata ?? { denied: true } }
     };
   }
-  const result = await runBashCommand({
-    command: sandboxDecision.command ?? command,
-    cwd: sandboxDecision.cwd ?? cwd,
-    env: sandboxDecision.env ?? process.env,
-    timeoutMs,
-    abortSignal: context.abortSignal
-  });
+  const { result, sandbox } = execution;
 
   if (result.error) {
     return {
@@ -121,7 +111,7 @@ export async function executeBashTool(args: unknown, context: ToolExecutionConte
         cancelled: result.cancelled,
         truncated: false,
         execPolicy: policy,
-        sandbox: sandboxDecision.metadata
+        sandbox
       }
     };
   }
@@ -147,7 +137,7 @@ export async function executeBashTool(args: unknown, context: ToolExecutionConte
       timedOut: result.timedOut,
       cancelled: result.cancelled,
       execPolicy: policy,
-      sandbox: sandboxDecision.metadata
+      sandbox
     }
   };
 }

--- a/packages/agent-core/src/tools/service.ts
+++ b/packages/agent-core/src/tools/service.ts
@@ -1,11 +1,10 @@
-import { spawn } from "node:child_process";
 import { closeSync, openSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import net from "node:net";
 import path from "node:path";
 import type { ToolExecutionContext, ToolResult } from "../types.js";
-import { bashExecutable, runBashCommand } from "../command-runner.js";
-import { requestToolPermission, resolveWorkspacePath } from "../policy.js";
+import { runSandboxedBashCommand, spawnSandboxedBashCommand } from "../exec-runtime.js";
+import { evaluateExecPolicy, requestToolPermission, resolveWorkspacePath } from "../policy.js";
 
 type ServiceAction = "start" | "status" | "logs" | "stop";
 
@@ -32,6 +31,7 @@ export interface ServiceRecord {
   logPath: string;
   keepAliveAfterRun: boolean;
   startedAt: string;
+  sandbox?: Record<string, unknown>;
 }
 
 export interface ServiceCleanupResult {
@@ -159,23 +159,30 @@ function connectPort(port: number): Promise<boolean> {
   });
 }
 
-async function readinessPassed(record: ServiceRecord, timeoutSec: number, abortSignal?: AbortSignal): Promise<"ready" | "not_ready" | "cancelled"> {
+async function readinessPassed(record: ServiceRecord, timeoutSec: number, context: ToolExecutionContext): Promise<"ready" | "not_ready" | "cancelled"> {
   if (!record.port && !record.readinessCommand) return "ready";
   const deadline = Date.now() + Math.max(1, Math.floor(timeoutSec * 1000));
   while (Date.now() <= deadline) {
-    if (abortSignal?.aborted) return "cancelled";
+    if (context.abortSignal?.aborted) return "cancelled";
     if (!isAlive(record.pid)) return "not_ready";
     const portReady = record.port ? await connectPort(record.port) : true;
     let commandReady = true;
     if (record.readinessCommand) {
-      const result = await runBashCommand({
+      const policy = evaluateExecPolicy(record.readinessCommand, context.execPolicy);
+      if (policy.action === "deny") return "not_ready";
+      const execution = await runSandboxedBashCommand({
+        toolName: "service",
         command: record.readinessCommand,
         cwd: record.cwd,
         env: process.env,
         timeoutMs: 2000,
         detachedProcessGroup: false,
-        abortSignal
+        abortSignal: context.abortSignal,
+        policy,
+        context
       });
+      if ("allowed" in execution) return "not_ready";
+      const { result } = execution;
       if (result.cancelled) return "cancelled";
       commandReady = !result.timedOut && result.exitCode === 0;
     }
@@ -213,11 +220,16 @@ async function startService(args: ServiceArgs, context: ToolExecutionContext): P
     return { ok: false, content: "service.start cancelled before start", metadata: { cancelled: true } };
   }
 
+  const policy = evaluateExecPolicy(command, context.execPolicy);
+  if (policy.action === "deny") {
+    return { ok: false, content: policy.reason, metadata: { execPolicy: policy } };
+  }
+
   const denied = await requestToolPermission(context, {
     toolName: "service",
     arguments: args,
-    risk: "execute",
-    reason: `Start background service ${name}`
+    risk: policy.risk === "read" ? "execute" : policy.risk,
+    reason: policy.action === "prompt" ? policy.reason : `Start background service ${name}`
   });
   if (denied) return denied;
 
@@ -240,14 +252,27 @@ async function startService(args: ServiceArgs, context: ToolExecutionContext): P
   await mkdir(path.dirname(logPath), { recursive: true });
   const outFd = openSync(logPath, "a");
   let pid: number | undefined;
+  let sandbox: Record<string, unknown> | undefined;
   try {
-    const child = spawn(bashExecutable(), ["-lc", command], {
+    const spawned = await spawnSandboxedBashCommand({
+      toolName: "service",
+      command,
       cwd,
       env: process.env,
+      policy,
+      context,
       detached: true,
-      stdio: ["ignore", outFd, outFd],
-      windowsHide: true
+      stdio: ["ignore", outFd, outFd]
     });
+    if ("allowed" in spawned) {
+      return {
+        ok: false,
+        content: spawned.reason ?? "Command was denied by sandbox policy.",
+        metadata: { execPolicy: policy, sandbox: spawned.metadata ?? { denied: true }, logPath }
+      };
+    }
+    const child = spawned.child;
+    sandbox = spawned.sandbox;
     child.on("error", () => {
       // Errors are reflected by readiness checks and logs; keep the detached child from emitting unhandled errors.
     });
@@ -270,7 +295,8 @@ async function startService(args: ServiceArgs, context: ToolExecutionContext): P
     ...(readinessCommand ? { readinessCommand } : {}),
     logPath,
     keepAliveAfterRun: defaultKeepAliveAfterRun(args, port, readinessCommand),
-    startedAt: new Date().toISOString()
+    startedAt: new Date().toISOString(),
+    ...(sandbox ? { sandbox } : {})
   };
 
   const existingServices = await readRegistry();
@@ -286,7 +312,7 @@ async function startService(args: ServiceArgs, context: ToolExecutionContext): P
   await writeRegistry(services);
 
   const timeoutSec = asNumber(args.readinessTimeoutSec) ?? DEFAULT_READINESS_TIMEOUT_SEC;
-  const ready = await readinessPassed(record, timeoutSec, context.abortSignal);
+  const ready = await readinessPassed(record, timeoutSec, context);
   if (ready !== "ready") {
     await stopRecord(record);
     await writeRegistry((await readRegistry()).filter((service) => service.name !== name));

--- a/packages/agent-core/src/tools/shell-session.ts
+++ b/packages/agent-core/src/tools/shell-session.ts
@@ -1,9 +1,10 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { truncateMiddle } from "../compaction.js";
-import { bashExecutable } from "../command-runner.js";
+import { spawnSandboxedInteractiveShell } from "../exec-runtime.js";
 import type { ToolExecutionContext, ToolResult } from "../types.js";
 import {
+  evaluateExecPolicy,
   isProbablyMutatingCommand,
   requestToolPermission,
   resolveWorkspacePath,
@@ -29,6 +30,7 @@ interface ShellSessionRecord {
   stderr: string;
   startedAt: string;
   sequence: number;
+  sandbox?: Record<string, unknown>;
 }
 
 interface ShellSessionStore {
@@ -122,6 +124,18 @@ function extractMarker(stdout: string, marker: string): { found: boolean; stdout
   };
 }
 
+function isCmdSession(session: ShellSessionRecord): boolean {
+  return session.sandbox?.shell === "cmd.exe";
+}
+
+function markerCommand(session: ShellSessionRecord, input: string, marker: string): string {
+  const normalizedInput = input.endsWith("\n") ? input : `${input}\n`;
+  if (isCmdSession(session)) {
+    return `${normalizedInput}echo ${marker}:%errorlevel%\r\n`;
+  }
+  return `${normalizedInput}printf '\\n${marker}:%s\\n' "$?"\n`;
+}
+
 async function startSession(args: ShellSessionArgs, context: ToolExecutionContext, store: ShellSessionStore): Promise<ToolResult> {
   const denied = await requestToolPermission(context, {
     toolName: "shell_session",
@@ -140,12 +154,25 @@ async function startSession(args: ShellSessionArgs, context: ToolExecutionContex
 
   const id = stringValue(args.sessionId) ?? randomUUID();
   if (store.sessions.has(id)) return { ok: false, content: `shell_session already exists: ${id}` };
-  const child = spawn(bashExecutable(), ["--noprofile", "--norc"], {
+  const policy = evaluateExecPolicy("bash --noprofile --norc", context.execPolicy);
+  if (policy.action === "deny") {
+    return { ok: false, content: policy.reason, metadata: { execPolicy: policy } };
+  }
+  const spawned = await spawnSandboxedInteractiveShell({
+    toolName: "shell_session",
     cwd,
     env: process.env,
-    detached: process.platform !== "win32",
-    windowsHide: true
+    policy,
+    context
   });
+  if ("allowed" in spawned) {
+    return {
+      ok: false,
+      content: spawned.reason ?? "Command was denied by sandbox policy.",
+      metadata: { execPolicy: policy, sandbox: spawned.metadata ?? { denied: true } }
+    };
+  }
+  const child = spawned.child;
   const session: ShellSessionRecord = {
     id,
     child,
@@ -153,7 +180,8 @@ async function startSession(args: ShellSessionArgs, context: ToolExecutionContex
     stdout: "",
     stderr: "",
     startedAt: new Date().toISOString(),
-    sequence: 0
+    sequence: 0,
+    ...(spawned.sandbox ? { sandbox: spawned.sandbox } : {})
   };
   child.stdout.on("data", (chunk: Buffer) => {
     session.stdout = appendBounded(session.stdout, chunk.toString("utf8"));
@@ -172,7 +200,7 @@ async function startSession(args: ShellSessionArgs, context: ToolExecutionContex
   return {
     ok: true,
     content: `shell_session ${id} started cwd=${workspaceRelativePath(context.workspacePath, cwd) || "."}`,
-    metadata: { sessionId: id, cwd, startedAt: session.startedAt }
+    metadata: { sessionId: id, cwd, startedAt: session.startedAt, ...(session.sandbox ? { sandbox: session.sandbox } : {}) }
   };
 }
 
@@ -196,7 +224,7 @@ async function sendToSession(args: ShellSessionArgs, context: ToolExecutionConte
   readAndClear(session);
   session.sequence += 1;
   const marker = `__SIGMA_SESSION_DONE_${session.id.replace(/[^A-Za-z0-9_]/g, "_")}_${session.sequence}__`;
-  const command = `${input.endsWith("\n") ? input : `${input}\n`}printf '\\n${marker}:%s\\n' "$?"\n`;
+  const command = markerCommand(session, input, marker);
   session.child.stdin.write(command);
 
   const timeoutSec = numberValue(args.timeoutSec, context.commandTimeoutSec, 1, 3600);

--- a/packages/agent-core/src/types.ts
+++ b/packages/agent-core/src/types.ts
@@ -7,6 +7,44 @@ export type ToolRisk = "read" | "write" | "execute" | "network" | "unknown";
 
 export type ToolApprovalMode = "auto" | "prompt" | "deny";
 export type ToolSandboxMode = "default" | "policy_only" | "bypass";
+export type SandboxMode =
+  | "read-only"
+  | "workspace-write"
+  | "danger-full-access"
+  | "policy-only"
+  | "external"
+  | "disabled"
+  | "policy_only";
+export type SandboxBackend =
+  | "auto"
+  | "bubblewrap"
+  | "seatbelt"
+  | "windows"
+  | "external"
+  | "policy-only"
+  | "policy_only";
+export type SandboxNetworkMode = "default" | "restricted" | "disabled";
+export type SandboxFilesystemMode = "workspace_write" | "read_only";
+
+export interface SandboxFilesystemConfig {
+  readRoots?: string[];
+  writeRoots?: string[];
+  denyRead?: string[];
+  denyWrite?: string[];
+  tempRoot?: string;
+}
+
+export interface SandboxNetworkConfig {
+  mode?: SandboxNetworkMode;
+  allowedHosts?: string[];
+  deniedHosts?: string[];
+  allowLocalhost?: boolean;
+}
+
+export interface SandboxExternalConfig {
+  command?: string;
+  args?: string[];
+}
 
 export interface ToolRuntimeMetadata {
   readOnly?: boolean;
@@ -42,15 +80,19 @@ export interface ExecIntentSummary {
 }
 
 export interface SandboxConfig {
-  mode?: "disabled" | "policy_only";
-  network?: "default" | "restricted";
-  filesystem?: "workspace_write" | "read_only";
+  mode?: SandboxMode;
+  backend?: SandboxBackend;
+  required?: boolean;
+  network?: SandboxNetworkConfig | SandboxNetworkMode;
+  filesystem?: SandboxFilesystemConfig | SandboxFilesystemMode;
+  external?: SandboxExternalConfig;
 }
 
 export interface SandboxExecRequest {
   toolName: string;
   command: string;
   cwd: string;
+  workspacePath?: string;
   env?: NodeJS.ProcessEnv;
   policy: ExecIntentSummary;
   sandbox?: SandboxConfig;
@@ -60,12 +102,22 @@ export interface SandboxExecDecision {
   allowed: boolean;
   reason?: string;
   command?: string;
+  args?: string[];
   cwd?: string;
   env?: NodeJS.ProcessEnv;
   metadata?: Record<string, unknown>;
 }
 
+export interface SandboxAvailability {
+  available: boolean;
+  backend: string;
+  mode: string;
+  reason?: string;
+  metadata?: Record<string, unknown>;
+}
+
 export interface SandboxAdapter {
+  checkAvailability?(sandbox: SandboxConfig | undefined, workspacePath: string): Promise<SandboxAvailability>;
   prepareExec(request: SandboxExecRequest): Promise<SandboxExecDecision>;
 }
 

--- a/packages/agent-core/src/types.ts
+++ b/packages/agent-core/src/types.ts
@@ -106,6 +106,7 @@ export interface SandboxExecDecision {
   cwd?: string;
   env?: NodeJS.ProcessEnv;
   metadata?: Record<string, unknown>;
+  cleanup?: () => Promise<void> | void;
 }
 
 export interface SandboxAvailability {
@@ -616,6 +617,7 @@ export interface HarnessCommandResult {
   cancelled?: boolean;
   settled_on?: string;
   signal?: string | null;
+  sandbox?: Record<string, unknown>;
   message: string;
   agent_summary?: string;
   trace_tail?: string;

--- a/packages/agent-tui/src/app.tsx
+++ b/packages/agent-tui/src/app.tsx
@@ -14,6 +14,7 @@ import {
   type ContextMode,
   type PermissionMode,
   type PermissionRequest,
+  type SandboxConfig,
   type TokenTotals,
   buildResumeInstruction,
   listSessions,
@@ -95,6 +96,7 @@ export interface TuiAppOptions {
   maxTurns?: number;
   maxWallTimeSec?: number;
   commandTimeoutSec?: number;
+  sandbox?: SandboxConfig;
   validationMode?: AgentHarnessValidationMode;
   validationCommands?: string[];
   validationRetryLimit?: number;
@@ -963,6 +965,7 @@ export class TuiApp {
         provider: this.options.provider,
         model: this.options.model,
         permissionMode: this.options.permissionMode,
+        sandbox: this.options.sandbox,
         maxTurns: this.options.maxTurns,
         maxWallTimeSec: this.options.maxWallTimeSec,
         commandTimeoutSec: this.options.commandTimeoutSec,
@@ -1117,6 +1120,7 @@ export class TuiApp {
       provider: this.options.provider,
       model: this.options.model,
       permissionMode: this.options.permissionMode,
+      sandbox: this.options.sandbox,
       validationMode: this.options.validationMode,
       finalEvidenceMode: this.options.finalEvidenceMode,
       maxTurns: this.options.maxTurns,

--- a/packages/agent-tui/src/components/status-bar.tsx
+++ b/packages/agent-tui/src/components/status-bar.tsx
@@ -9,6 +9,7 @@ import {
   type AgentHarnessValidationMode,
   type AgentRunResult,
   type PermissionMode,
+  type SandboxConfig,
   type TokenTotals
 } from "agent-core";
 import { box } from "../ui/box.js";
@@ -20,6 +21,7 @@ export interface StatusBarProps {
   provider: ProviderName;
   model?: string;
   permissionMode: PermissionMode;
+  sandbox?: SandboxConfig;
   validationMode?: AgentHarnessValidationMode;
   finalEvidenceMode?: AgentFinalEvidenceMode;
   running: boolean;
@@ -87,6 +89,13 @@ function observedToolCalls(events: AgentEvent[]): number {
   return seen.size + anonymous;
 }
 
+function sandboxState(sandbox: SandboxConfig | undefined): string {
+  if (!sandbox) return "default";
+  const network = typeof sandbox.network === "string" ? sandbox.network : sandbox.network?.mode;
+  const backend = sandbox.backend && sandbox.backend !== "auto" ? `/${sandbox.backend}` : "";
+  return `${sandbox.mode ?? "workspace-write"}${backend}${network ? `:${network}` : ""}`;
+}
+
 export function StatusBar(props: StatusBarProps): string {
   const g = glyphs();
   const width = props.width ?? 100;
@@ -115,7 +124,7 @@ export function StatusBar(props: StatusBarProps): string {
     color: props.color,
     lines: [
       `repo ${workspaceBase} ${g.separator} path ${workspace}`,
-      `${props.provider}/${model} ${g.separator} permission ${props.permissionMode} ${g.separator} state ${state}${finish}`,
+      `${props.provider}/${model} ${g.separator} permission ${props.permissionMode} ${g.separator} sandbox ${sandboxState(props.sandbox)} ${g.separator} state ${state}${finish}`,
       `turns ${turn}${turnLimit} ${g.separator} tools ${toolCalls} ${g.separator} tokens ${usage ? formatUsage(usage) : "unknown"} ${g.separator} validation ${validation} ${g.separator} evidence ${evidence} ${g.separator} mcp ${mcpState(props.result, props.enableMcp)}`,
       `${queue} ${g.separator} ${message}`
     ]

--- a/packages/agent-tui/src/components/tool-panel.tsx
+++ b/packages/agent-tui/src/components/tool-panel.tsx
@@ -60,6 +60,13 @@ function recentTerminalToolEvents(events: AgentEvent[], limit: number): AgentEve
     .slice(-limit);
 }
 
+function sandboxWarning(metadata: Record<string, unknown> | undefined): string {
+  const sandbox = metadata?.sandbox;
+  if (!sandbox || typeof sandbox !== "object") return "";
+  const warning = (sandbox as Record<string, unknown>).warning;
+  return typeof warning === "string" && warning ? `sandbox warning: ${truncate(oneLine(redactSecretText(warning)), 70)}` : "";
+}
+
 export function ToolPanel(events: AgentEvent[], result: AgentRunResult | null, width = 80, height?: number, color = false): string {
   const g = glyphs();
   const innerWidth = Math.max(20, width - 4);
@@ -86,8 +93,9 @@ export function ToolPanel(events: AgentEvent[], result: AgentRunResult | null, w
     const marker = res?.ok ? g.ok : g.fail;
     const duration = typeof res?.metadata?.durationMs === "number" ? `${res.metadata.durationMs}ms` : "";
     const tail = res?.content ? truncate(oneLine(redactSecretText(res.content)), 70) : truncate(oneLine(redactSecretText(String(meta.reason ?? ""))), 70);
+    const warning = sandboxWarning(res?.metadata);
     const status = aborted ? "aborted" : (res?.ok ? "ok" : "failed");
-    lines.push(truncateToWidth(`${marker} ${name} ${status} ${[duration, detail, tail].filter(Boolean).join(` ${g.separator} `)}`, innerWidth));
+    lines.push(truncateToWidth(`${marker} ${name} ${status} ${[duration, detail, warning, tail].filter(Boolean).join(` ${g.separator} `)}`, innerWidth));
   }
 
   return box({

--- a/packages/agent-tui/src/index.tsx
+++ b/packages/agent-tui/src/index.tsx
@@ -9,14 +9,19 @@ import type {
   CompactionFallbackMode,
   CompactionMode,
   ContextMode,
-  PermissionMode
+  PermissionMode,
+  SandboxBackend,
+  SandboxConfig,
+  SandboxMode,
+  SandboxNetworkMode
 } from "agent-core";
 import {
   DEFAULT_COMPACTION_MODE,
   DEFAULT_FINAL_EVIDENCE_MODE,
   DEFAULT_MAX_MESSAGE_HISTORY_CHARS,
   DEFAULT_SUBAGENTS_ENABLED,
-  DEFAULT_VALIDATION_MODE
+  DEFAULT_VALIDATION_MODE,
+  createDefaultSandboxConfig
 } from "agent-core";
 import { runTuiApp, type TuiAppOptions } from "./app.js";
 
@@ -32,6 +37,10 @@ Flags:
   --provider <deepseek|glm>      Model provider (default: deepseek)
   --model <name>                 Model name
   --permission-mode <ask|yolo>   Permission handling (default: ask)
+  --sandbox <read-only|workspace-write|danger-full-access|policy-only|external>
+  --sandbox-backend <auto|bubblewrap|seatbelt|windows|external|policy-only>
+  --sandbox-required
+  --sandbox-network <default|restricted|disabled>
   --max-turns <number>
   --max-wall-time-sec <number>
   --command-timeout-sec <number>
@@ -145,6 +154,74 @@ function permissionModeValue(value: string | true | undefined): PermissionMode {
   throw new Error("Unsupported permission mode. Use ask or yolo.");
 }
 
+function sandboxModeValue(value: string | true | undefined): SandboxMode | undefined {
+  if (value === undefined || value === true) return undefined;
+  if (
+    value === "read-only" ||
+    value === "workspace-write" ||
+    value === "danger-full-access" ||
+    value === "policy-only" ||
+    value === "policy_only" ||
+    value === "external" ||
+    value === "disabled"
+  ) return value;
+  if (value === "read_only") return "read-only";
+  if (value === "workspace_write") return "workspace-write";
+  throw new Error("Unsupported sandbox mode.");
+}
+
+function sandboxBackendValue(value: string | true | undefined): SandboxBackend | undefined {
+  if (value === undefined || value === true) return undefined;
+  if (
+    value === "auto" ||
+    value === "bubblewrap" ||
+    value === "seatbelt" ||
+    value === "windows" ||
+    value === "external" ||
+    value === "policy-only" ||
+    value === "policy_only"
+  ) return value;
+  throw new Error("Unsupported sandbox backend.");
+}
+
+function sandboxNetworkValue(value: string | true | undefined): SandboxNetworkMode | undefined {
+  if (value === undefined || value === true) return undefined;
+  if (value === "default" || value === "restricted" || value === "disabled") return value;
+  throw new Error("Unsupported sandbox network mode.");
+}
+
+function boolFlag(flags: Map<string, string | true>, name: string, fallback: boolean): boolean {
+  if (!flags.has(name)) return fallback;
+  const value = flags.get(name);
+  if (value === true) return true;
+  if (value === "true") return true;
+  if (value === "false") return false;
+  return fallback;
+}
+
+function sandboxConfig(flags: Map<string, string | true>): SandboxConfig {
+  const defaults = createDefaultSandboxConfig();
+  const mode = sandboxModeValue(flags.get("sandbox")) ?? defaults.mode;
+  const backend = sandboxBackendValue(flags.get("sandbox-backend")) ?? defaults.backend;
+  const network = sandboxNetworkValue(flags.get("sandbox-network")) ?? "restricted";
+  const externalCommand = flags.get("sandbox-external-command");
+  return {
+    mode,
+    backend,
+    required: boolFlag(flags, "sandbox-required", defaults.required ?? false),
+    network: { mode: network, allowLocalhost: true },
+    filesystem: {
+      readRoots: stringList(flags.get("sandbox-add-read")),
+      writeRoots: stringList(flags.get("sandbox-add-write")),
+      denyRead: stringList(flags.get("sandbox-deny-read")),
+      denyWrite: stringList(flags.get("sandbox-deny-write"))
+    },
+    external: typeof externalCommand === "string"
+      ? { command: externalCommand, args: stringList(flags.get("sandbox-external-args")) }
+      : defaults.external
+  };
+}
+
 function validationModeValue(value: string | true | undefined): AgentHarnessValidationMode | undefined {
   if (value === undefined || value === true) return DEFAULT_VALIDATION_MODE;
   if (value === "off" || value === "auto") return value;
@@ -224,6 +301,7 @@ export function parseTuiArgs(argv: string[]): CliOptions | "help" {
     provider: providerValue(flags.get("provider")),
     model: typeof model === "string" ? model : undefined,
     permissionMode: permissionModeValue(flags.get("permission-mode")),
+    sandbox: sandboxConfig(flags),
     maxTurns: numberFlag(flags, "max-turns"),
     maxWallTimeSec: numberFlag(flags, "max-wall-time-sec"),
     commandTimeoutSec: numberFlag(flags, "command-timeout-sec"),

--- a/packages/agent-tui/src/render/screen.ts
+++ b/packages/agent-tui/src/render/screen.ts
@@ -8,6 +8,7 @@ import {
   type AgentHarnessValidationMode,
   type AgentRunResult,
   type PermissionMode,
+  type SandboxConfig,
   type TokenTotals
 } from "agent-core";
 import { formatUsage, oneLine } from "../components/formatting.js";
@@ -27,6 +28,7 @@ export interface RenderScreenOptions {
   provider: ProviderName;
   model?: string;
   permissionMode: PermissionMode;
+  sandbox?: SandboxConfig;
   validationMode?: AgentHarnessValidationMode;
   finalEvidenceMode?: AgentFinalEvidenceMode;
   maxTurns?: number;
@@ -52,6 +54,13 @@ function stateName(options: RenderScreenOptions): string {
   return options.running ? "running" : options.result?.status ?? "idle";
 }
 
+function sandboxLabel(sandbox: SandboxConfig | undefined): string | null {
+  if (!sandbox) return null;
+  const network = typeof sandbox.network === "string" ? sandbox.network : sandbox.network?.mode;
+  const backend = sandbox.backend && sandbox.backend !== "auto" ? `/${sandbox.backend}` : "";
+  return `${sandbox.mode ?? "workspace-write"}${backend}${network ? `:${network}` : ""}`;
+}
+
 function stateRole(state: string, running: boolean): "danger" | "dim" | "success" | "warning" {
   if (running) return "warning";
   if (state === "error") return "danger";
@@ -67,9 +76,10 @@ export function renderTopBar(options: RenderScreenOptions): string {
   const state = stateName(options);
   const brand = roleColor("brand", sigmaBrandName(), options.color ?? false);
   const status = roleColor(stateRole(state, options.running), state, options.color ?? false);
+  const sandbox = sandboxLabel(options.sandbox);
   const chips = width < 72
     ? [options.mode, status]
-    : [`${options.provider}/${model}`, options.mode, options.permissionMode, status];
+    : [`${options.provider}/${model}`, options.mode, options.permissionMode, ...(sandbox ? [sandbox] : []), status];
   return fitStreamLine([
     brand,
     chips.join(` ${g.separator} `)

--- a/packages/agent-tui/src/run-session.ts
+++ b/packages/agent-tui/src/run-session.ts
@@ -10,7 +10,8 @@ import {
   type CompactionFallbackMode,
   type CompactionMode,
   type ContextMode,
-  type PermissionMode
+  type PermissionMode,
+  type SandboxConfig
 } from "agent-core";
 import type { TuiPermissionController } from "./permission.js";
 
@@ -23,6 +24,7 @@ export interface RunSessionOptions {
   maxTurns?: number;
   maxWallTimeSec?: number;
   commandTimeoutSec?: number;
+  sandbox?: SandboxConfig;
   validationMode?: AgentHarnessValidationMode;
   validationCommands?: string[];
   validationRetryLimit?: number;
@@ -82,6 +84,7 @@ export async function runSession(options: RunSessionOptions): Promise<AgentRunRe
       maxTurns: options.maxTurns,
       maxWallTimeSec: options.maxWallTimeSec,
       commandTimeoutSec: options.commandTimeoutSec,
+      sandbox: options.sandbox,
       validationMode: options.validationMode,
       validationCommands: options.validationCommands,
       validationRetryLimit: options.validationRetryLimit,

--- a/packages/agent-tui/src/view-model.ts
+++ b/packages/agent-tui/src/view-model.ts
@@ -53,6 +53,13 @@ function toolDuration(result: { metadata?: Record<string, unknown> } | undefined
   return typeof result?.metadata?.durationMs === "number" ? result.metadata.durationMs : undefined;
 }
 
+function sandboxWarning(metadata: Record<string, unknown> | undefined): string {
+  const sandbox = metadata?.sandbox;
+  if (!sandbox || typeof sandbox !== "object") return "";
+  const warning = (sandbox as Record<string, unknown>).warning;
+  return typeof warning === "string" && warning ? `sandbox warning: ${truncate(oneLine(redactSecretText(warning)), 90)}` : "";
+}
+
 function formatBytes(value: unknown): string {
   if (typeof value !== "number" || !Number.isFinite(value)) return "";
   if (value < 1024) return `${value} B`;
@@ -73,12 +80,13 @@ function toolEntry(start: AgentEvent, end: AgentEvent | undefined): TranscriptEn
   const detail = summarizeToolArguments(name, toolArgsFromEvent(start));
   const tail = result?.content ? truncate(oneLine(redactSecretText(result.content)), 90) : "";
   const size = formatBytes(result?.metadata?.sizeBytes);
+  const warning = sandboxWarning(result?.metadata);
   const aborted = end?.type === "tool_aborted" || result?.metadata?.cancelled === true;
   return {
     kind: "tool",
     name,
     status: end ? (aborted ? "aborted" : resultStatus(result)) : (start.type === "tool_queued" ? "queued" : "running"),
-    summary: [detail, size, tail].filter(Boolean).join("  "),
+    summary: [detail, size, warning, tail].filter(Boolean).join("  "),
     durationMs: toolDuration(result),
     timestamp: eventTime(end ?? start)
   };
@@ -90,11 +98,12 @@ function harnessEntry(start: AgentEvent, end: AgentEvent | undefined): Transcrip
   const ok = end ? meta.exitCode === 0 : false;
   const attempt = meta.attempt ? `attempt ${meta.attempt}` : "";
   const exit = end ? `exit ${meta.exitCode ?? "?"}` : "running";
+  const warning = sandboxWarning(meta);
   return {
     kind: "test",
     command,
     status: end ? (ok ? "ok" : "failed") : "running",
-    summary: [String(meta.kind ?? "validation"), attempt, exit].filter(Boolean).join("  "),
+    summary: [String(meta.kind ?? "validation"), attempt, exit, warning].filter(Boolean).join("  "),
     durationMs: typeof meta.durationMs === "number" ? meta.durationMs : undefined,
     timestamp: eventTime(end ?? start)
   };

--- a/scripts/verify-sandbox.mjs
+++ b/scripts/verify-sandbox.mjs
@@ -1,0 +1,278 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const requireOsSandbox = process.argv.includes("--require-os-sandbox");
+const requireWindowsNative = process.argv.includes("--require-windows-native");
+const root = process.cwd();
+const coreDist = path.join(root, "packages", "agent-core", "dist", "index.js");
+
+function log(message) {
+  process.stdout.write(`${message}\n`);
+}
+
+function fail(message) {
+  process.stderr.write(`FAIL ${message}\n`);
+  process.exitCode = 1;
+}
+
+function ok(message) {
+  log(`OK   ${message}`);
+}
+
+function skip(message) {
+  log(`SKIP ${message}`);
+}
+
+function commandAvailable(command, args = ["--version"]) {
+  const result = spawnSync(command, args, { stdio: "ignore", windowsHide: true });
+  return !result.error && result.status === 0;
+}
+
+function baseContext(workspacePath, sandbox) {
+  return {
+    workspacePath,
+    permissionMode: "yolo",
+    commandTimeoutSec: 8,
+    maxToolOutputChars: 4000,
+    runState: { todos: [], nextTodoId: 1, changedFiles: new Set() },
+    alwaysAllowTools: new Set(),
+    sandbox
+  };
+}
+
+async function expectTool(name, result, predicate, details) {
+  if (predicate(result)) {
+    ok(name);
+    return;
+  }
+  fail(`${name}: ${details(result)}`);
+}
+
+function windowsEscapeCommand(fileName) {
+  return `echo bad>..\\${fileName}`;
+}
+
+async function verifyWindowsNative(core, workspace) {
+  const {
+    executeBashTool,
+    executeServiceTool,
+    executeShellSessionTool
+  } = core;
+  if (process.platform !== "win32") {
+    const message = "not running on Windows; Windows native sandbox checks skipped.";
+    if (requireWindowsNative) fail(message);
+    else skip(message);
+    return;
+  }
+
+  const sandbox = { mode: "workspace-write", backend: "windows", required: true, network: { mode: "default" } };
+  const readOnlySandbox = { mode: "read-only", backend: "windows", required: true, network: { mode: "default" } };
+
+  await expectTool(
+    "windows native workspace-write allows workspace writes",
+    await executeBashTool({ command: "echo ok>inside-windows.txt" }, baseContext(workspace, sandbox)),
+    (result) => result.ok && existsSync(path.join(workspace, "inside-windows.txt")),
+    (result) => result.content
+  );
+
+  const escape = path.join(path.dirname(workspace), "windows-escape.txt");
+  await rm(escape, { force: true });
+  await expectTool(
+    "windows native blocks workspace escape writes",
+    await executeBashTool({ command: windowsEscapeCommand("windows-escape.txt") }, baseContext(workspace, sandbox)),
+    () => !existsSync(escape),
+    (result) => result.content
+  );
+
+  await expectTool(
+    "windows native read-only blocks workspace writes",
+    await executeBashTool({ command: "echo bad>readonly-windows.txt" }, baseContext(workspace, readOnlySandbox)),
+    (result) => !result.ok && !existsSync(path.join(workspace, "readonly-windows.txt")),
+    (result) => result.content
+  );
+
+  const serviceEscape = path.join(path.dirname(workspace), "windows-service-escape.txt");
+  await rm(serviceEscape, { force: true });
+  await executeServiceTool(
+    {
+      action: "start",
+      name: "windows-sandbox-escape",
+      command: windowsEscapeCommand("windows-service-escape.txt"),
+      keepAliveAfterRun: false,
+      readinessTimeoutSec: 1
+    },
+    baseContext(workspace, sandbox)
+  );
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  if (existsSync(serviceEscape)) {
+    fail("windows service.start escaped workspace sandbox");
+  } else {
+    ok("windows service.start cannot write outside workspace");
+  }
+
+  const sessionEscape = path.join(path.dirname(workspace), "windows-session-escape.txt");
+  await rm(sessionEscape, { force: true });
+  const sessionContext = baseContext(workspace, sandbox);
+  const start = await executeShellSessionTool({ action: "start", sessionId: "verify-windows-sandbox" }, sessionContext);
+  if (!start.ok) {
+    fail(`windows shell_session start failed: ${start.content}`);
+  } else {
+    await executeShellSessionTool(
+      { action: "send", sessionId: "verify-windows-sandbox", input: windowsEscapeCommand("windows-session-escape.txt"), timeoutSec: 3 },
+      sessionContext
+    );
+    if (existsSync(sessionEscape)) {
+      fail("windows shell_session escaped workspace sandbox");
+    } else {
+      ok("windows shell_session cannot write outside workspace");
+    }
+  }
+}
+
+async function main() {
+  if (!existsSync(coreDist)) {
+    fail("packages/agent-core/dist/index.js not found. Run pnpm build before scripts/verify-sandbox.mjs.");
+    return;
+  }
+
+  const core = await import(pathToFileURL(coreDist).href);
+  const {
+    executeBashTool,
+    executeServiceTool,
+    executeShellSessionTool,
+    closeShellSessions
+  } = core;
+
+  const workspace = await mkdtemp(path.join(os.tmpdir(), "sigma-sandbox-"));
+  const outside = path.join(path.dirname(workspace), `${path.basename(workspace)}-outside.txt`);
+  const policySandbox = { mode: "policy-only", network: "restricted" };
+
+  try {
+    await expectTool(
+      "policy-only compatibility",
+      await executeBashTool({ command: "echo sigma-sandbox" }, baseContext(workspace, policySandbox)),
+      (result) => result.ok && result.content.includes("sigma-sandbox"),
+      (result) => result.content
+    );
+
+    await expectTool(
+      "windows required restricted network fails closed",
+      await executeBashTool(
+        { command: "echo should-not-run" },
+        baseContext(workspace, { mode: "workspace-write", backend: "windows", required: true })
+      ),
+      (result) => !result.ok && (
+        result.content.includes("Windows native sandbox v1 does not implement WFP network isolation")
+        || result.content.includes("Windows sandbox backend is only available on Windows")
+      ),
+      (result) => result.content
+    );
+
+    await verifyWindowsNative(core, workspace);
+
+    const bwrapReady = process.platform === "linux" && commandAvailable("bwrap") && commandAvailable("unshare", ["-Ur", "true"]);
+    if (!bwrapReady) {
+      const message = process.platform === "linux"
+        ? "bubblewrap/user namespaces unavailable; install bwrap or enable unprivileged user namespaces."
+        : "not running on Linux/WSL2; bubblewrap OS sandbox checks skipped.";
+      if (requireOsSandbox) fail(message);
+      else skip(message);
+      return;
+    }
+
+    const sandbox = { mode: "workspace-write", backend: "bubblewrap", required: true, network: { mode: "restricted" } };
+    const readOnlySandbox = { mode: "read-only", backend: "bubblewrap", required: true, network: { mode: "restricted" } };
+    const dangerSandbox = { mode: "danger-full-access", backend: "auto", network: { mode: "default" } };
+    const runtime = commandAvailable("python3")
+      ? { command: "python3", snippet: "open('../escape.txt','w').write('bad')" }
+      : { command: "node", snippet: "require('fs').writeFileSync('../escape.txt','bad')" };
+
+    await expectTool(
+      "bubblewrap workspace-write allows workspace writes",
+      await executeBashTool({ command: "printf ok > inside.txt" }, baseContext(workspace, sandbox)),
+      (result) => result.ok && existsSync(path.join(workspace, "inside.txt")),
+      (result) => result.content
+    );
+
+    await expectTool(
+      "bubblewrap blocks workspace escape writes",
+      await executeBashTool({ command: `${runtime.command} -c ${JSON.stringify(runtime.snippet)}` }, baseContext(workspace, sandbox)),
+      () => !existsSync(path.join(path.dirname(workspace), "escape.txt")),
+      (result) => result.content
+    );
+
+    await expectTool(
+      "bubblewrap read-only blocks workspace writes",
+      await executeBashTool({ command: "printf bad > readonly.txt" }, baseContext(workspace, readOnlySandbox)),
+      (result) => !result.ok && !existsSync(path.join(workspace, "readonly.txt")),
+      (result) => result.content
+    );
+
+    const networkCommand = commandAvailable("curl")
+      ? "curl --max-time 3 https://example.com"
+      : "node -e \"require('https').get('https://example.com',()=>process.exit(0)).on('error',()=>process.exit(1)); setTimeout(()=>process.exit(2),3000)\"";
+    await expectTool(
+      "bubblewrap restricted network blocks external access",
+      await executeBashTool({ command: networkCommand, timeoutSec: 6 }, baseContext(workspace, sandbox)),
+      (result) => !result.ok,
+      (result) => result.content
+    );
+
+    await rm(outside, { force: true });
+    await expectTool(
+      "danger-full-access explicitly bypasses isolation",
+      await executeBashTool({ command: `printf ok > ${JSON.stringify(outside)}` }, baseContext(workspace, dangerSandbox)),
+      (result) => result.ok && existsSync(outside),
+      (result) => result.content
+    );
+
+    await rm(path.join(path.dirname(workspace), "service-escape.txt"), { force: true });
+    await executeServiceTool(
+      {
+        action: "start",
+        name: "sandbox-escape",
+        command: "node -e \"require('fs').writeFileSync('../service-escape.txt','bad')\"",
+        keepAliveAfterRun: false,
+        readinessTimeoutSec: 1
+      },
+      baseContext(workspace, sandbox)
+    );
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    if (existsSync(path.join(path.dirname(workspace), "service-escape.txt"))) {
+      fail("service.start escaped workspace sandbox");
+    } else {
+      ok("service.start cannot write outside workspace");
+    }
+
+    await rm(path.join(path.dirname(workspace), "session-escape.txt"), { force: true });
+    const sessionContext = baseContext(workspace, sandbox);
+    const start = await executeShellSessionTool({ action: "start", sessionId: "verify-sandbox" }, sessionContext);
+    if (!start.ok) {
+      fail(`shell_session start failed: ${start.content}`);
+    } else {
+      await executeShellSessionTool(
+        { action: "send", sessionId: "verify-sandbox", input: "node -e \"require('fs').writeFileSync('../session-escape.txt','bad')\"", timeoutSec: 3 },
+        sessionContext
+      );
+      if (existsSync(path.join(path.dirname(workspace), "session-escape.txt"))) {
+        fail("shell_session escaped workspace sandbox");
+      } else {
+        ok("shell_session cannot write outside workspace");
+      }
+    }
+  } finally {
+    await closeShellSessions().catch(() => {});
+    await rm(workspace, { recursive: true, force: true }).catch(() => {});
+    await rm(outside, { force: true }).catch(() => {});
+    await rm(path.join(path.dirname(workspace), "windows-escape.txt"), { force: true }).catch(() => {});
+    await rm(path.join(path.dirname(workspace), "windows-service-escape.txt"), { force: true }).catch(() => {});
+    await rm(path.join(path.dirname(workspace), "windows-session-escape.txt"), { force: true }).catch(() => {});
+  }
+}
+
+await main();

--- a/scripts/verify-sandbox.mjs
+++ b/scripts/verify-sandbox.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -31,6 +31,22 @@ function skip(message) {
 function commandAvailable(command, args = ["--version"]) {
   const result = spawnSync(command, args, { stdio: "ignore", windowsHide: true });
   return !result.error && result.status === 0;
+}
+
+function psSingleQuote(value) {
+  return `'${String(value).replace(/'/g, "''")}'`;
+}
+
+function aclSddl(target) {
+  const result = spawnSync(
+    "powershell.exe",
+    ["-NoProfile", "-Command", `(Get-Acl -LiteralPath ${psSingleQuote(target)}).Sddl`],
+    { encoding: "utf8", windowsHide: true }
+  );
+  if (result.status !== 0) {
+    throw new Error(result.stderr || `Get-Acl failed for ${target}`);
+  }
+  return result.stdout.trim();
 }
 
 function baseContext(workspacePath, sandbox) {
@@ -72,6 +88,7 @@ async function verifyWindowsNative(core, workspace) {
 
   const sandbox = { mode: "workspace-write", backend: "windows", required: true, network: { mode: "default" } };
   const readOnlySandbox = { mode: "read-only", backend: "windows", required: true, network: { mode: "default" } };
+  const workspaceAclBefore = aclSddl(workspace);
 
   await expectTool(
     "windows native workspace-write allows workspace writes",
@@ -79,6 +96,31 @@ async function verifyWindowsNative(core, workspace) {
     (result) => result.ok && existsSync(path.join(workspace, "inside-windows.txt")),
     (result) => result.content
   );
+  if (aclSddl(workspace) === workspaceAclBefore) {
+    ok("windows native restores workspace ACL after execution");
+  } else {
+    fail("windows native left workspace ACL changed after execution");
+  }
+
+  const protectedFile = path.join(workspace, "protected-acl.txt");
+  const protectedDir = path.join(workspace, "protected-acl-dir");
+  await writeFile(protectedFile, "protected", "utf8");
+  await mkdir(protectedDir, { recursive: true });
+  const protectedFileAcl = aclSddl(protectedFile);
+  const protectedDirAcl = aclSddl(protectedDir);
+  const aclSandbox = {
+    mode: "workspace-write",
+    backend: "windows",
+    required: true,
+    network: { mode: "default" },
+    filesystem: { denyWrite: ["protected-acl.txt", "protected-acl-dir"] }
+  };
+  await executeBashTool({ command: "type protected-acl.txt>NUL" }, baseContext(workspace, aclSandbox));
+  if (aclSddl(protectedFile) === protectedFileAcl && aclSddl(protectedDir) === protectedDirAcl) {
+    ok("windows native restores protected path ACLs after deny rules");
+  } else {
+    fail("windows native left protected path ACL changed after deny rules");
+  }
 
   const escape = path.join(path.dirname(workspace), "windows-escape.txt");
   await rm(escape, { force: true });
@@ -93,6 +135,21 @@ async function verifyWindowsNative(core, workspace) {
     "windows native read-only blocks workspace writes",
     await executeBashTool({ command: "echo bad>readonly-windows.txt" }, baseContext(workspace, readOnlySandbox)),
     (result) => !result.ok && !existsSync(path.join(workspace, "readonly-windows.txt")),
+    (result) => result.content
+  );
+
+  await rm(path.join(workspace, ".agent"), { recursive: true, force: true });
+  await expectTool(
+    "windows native blocks missing protected agent paths",
+    await executeBashTool(
+      { command: "if not exist .agent mkdir .agent & echo bad>.agent\\config.toml & echo bad>.agent\\mcp.json & if not exist .agent\\skills mkdir .agent\\skills & echo bad>.agent\\skills\\foo" },
+      baseContext(workspace, sandbox)
+    ),
+    () => (
+      !existsSync(path.join(workspace, ".agent", "config.toml")) &&
+      !existsSync(path.join(workspace, ".agent", "mcp.json")) &&
+      !existsSync(path.join(workspace, ".agent", "skills", "foo"))
+    ),
     (result) => result.content
   );
 
@@ -150,6 +207,8 @@ async function main() {
 
   const workspace = await mkdtemp(path.join(os.tmpdir(), "sigma-sandbox-"));
   const outside = path.join(path.dirname(workspace), `${path.basename(workspace)}-outside.txt`);
+  const outsideSecret = path.join(path.dirname(workspace), `${path.basename(workspace)}-outside-secret.txt`);
+  const readRoot = await mkdtemp(path.join(os.tmpdir(), "sigma-sandbox-readroot-"));
   const policySandbox = { mode: "policy-only", network: "restricted" };
 
   try {
@@ -199,10 +258,71 @@ async function main() {
       (result) => result.content
     );
 
+    await writeFile(outsideSecret, "OUTSIDE_SECRET", "utf8");
+    await expectTool(
+      "bubblewrap blocks reads outside workspace/readRoots",
+      await executeBashTool({ command: `cat ../${path.basename(outsideSecret)}` }, baseContext(workspace, sandbox)),
+      (result) => !result.content.includes("OUTSIDE_SECRET"),
+      (result) => result.content
+    );
+
+    const readRootFile = path.join(readRoot, "allowed.txt");
+    await writeFile(readRootFile, "READ_ROOT_SECRET", "utf8");
+    await expectTool(
+      "bubblewrap allows explicit readRoots",
+      await executeBashTool(
+        { command: `cat ${JSON.stringify(readRootFile)}` },
+        baseContext(workspace, { ...sandbox, filesystem: { readRoots: [readRoot] } })
+      ),
+      (result) => result.ok && result.content.includes("READ_ROOT_SECRET"),
+      (result) => result.content
+    );
+
+    await writeFile(path.join(workspace, "deny-secret.txt"), "DENY_READ_SECRET", "utf8");
+    await expectTool(
+      "bubblewrap blocks denyRead paths",
+      await executeBashTool(
+        { command: "cat deny-secret.txt" },
+        baseContext(workspace, { ...sandbox, filesystem: { denyRead: ["deny-secret.txt"] } })
+      ),
+      (result) => !result.content.includes("DENY_READ_SECRET"),
+      (result) => result.content
+    );
+
     await expectTool(
       "bubblewrap blocks workspace escape writes",
       await executeBashTool({ command: `${runtime.command} -c ${JSON.stringify(runtime.snippet)}` }, baseContext(workspace, sandbox)),
       () => !existsSync(path.join(path.dirname(workspace), "escape.txt")),
+      (result) => result.content
+    );
+
+    await mkdir(path.join(workspace, "writable"), { recursive: true });
+    const narrowSandbox = { ...sandbox, filesystem: { writeRoots: ["writable"] } };
+    await expectTool(
+      "bubblewrap blocks writes outside explicit writeRoots",
+      await executeBashTool({ command: "printf bad > blocked-root.txt" }, baseContext(workspace, narrowSandbox)),
+      () => !existsSync(path.join(workspace, "blocked-root.txt")),
+      (result) => result.content
+    );
+    await expectTool(
+      "bubblewrap allows writes inside explicit writeRoots",
+      await executeBashTool({ command: "printf ok > writable/ok.txt" }, baseContext(workspace, narrowSandbox)),
+      () => existsSync(path.join(workspace, "writable", "ok.txt")),
+      (result) => result.content
+    );
+
+    await rm(path.join(workspace, ".agent"), { recursive: true, force: true });
+    await expectTool(
+      "bubblewrap blocks missing protected agent paths",
+      await executeBashTool(
+        { command: "mkdir -p .agent/skills; printf bad > .agent/config.toml; printf bad > .agent/mcp.json; printf bad > .agent/skills/foo" },
+        baseContext(workspace, sandbox)
+      ),
+      () => (
+        !existsSync(path.join(workspace, ".agent", "config.toml")) &&
+        !existsSync(path.join(workspace, ".agent", "mcp.json")) &&
+        !existsSync(path.join(workspace, ".agent", "skills", "foo"))
+      ),
       (result) => result.content
     );
 
@@ -269,6 +389,8 @@ async function main() {
     await closeShellSessions().catch(() => {});
     await rm(workspace, { recursive: true, force: true }).catch(() => {});
     await rm(outside, { force: true }).catch(() => {});
+    await rm(outsideSecret, { force: true }).catch(() => {});
+    await rm(readRoot, { recursive: true, force: true }).catch(() => {});
     await rm(path.join(path.dirname(workspace), "windows-escape.txt"), { force: true }).catch(() => {});
     await rm(path.join(path.dirname(workspace), "windows-service-escape.txt"), { force: true }).catch(() => {});
     await rm(path.join(path.dirname(workspace), "windows-session-escape.txt"), { force: true }).catch(() => {});

--- a/tests/agent-cli.run.test.ts
+++ b/tests/agent-cli.run.test.ts
@@ -154,6 +154,14 @@ describe("agent-cli run", () => {
       "no-review-anti-gaming": true,
       "enable-mcp": true,
       "mcp-config": ".agent/custom-mcp.json",
+      "sandbox": "read-only",
+      "sandbox-backend": "bubblewrap",
+      "sandbox-required": true,
+      "sandbox-network": "disabled",
+      "sandbox-add-read": "../shared",
+      "sandbox-add-write": ".",
+      "sandbox-deny-read": "../secret.txt",
+      "sandbox-deny-write": ".agent/config.toml",
       "no-stream-ui": true
     });
 
@@ -180,6 +188,18 @@ describe("agent-cli run", () => {
       reviewAntiGaming: false,
       enableMcp: true,
       mcpConfig: ".agent/custom-mcp.json",
+      sandbox: {
+        mode: "read-only",
+        backend: "bubblewrap",
+        required: true,
+        network: { mode: "disabled" },
+        filesystem: {
+          readRoots: ["../shared"],
+          writeRoots: ["."],
+          denyRead: ["../secret.txt"],
+          denyWrite: [".agent/config.toml"]
+        }
+      },
       noStreamUi: true
     });
   });
@@ -254,6 +274,22 @@ describe("agent-cli run", () => {
         "enabled = true",
         'config = ".agent/mcp.json"',
         "",
+        "[sandbox]",
+        'mode = "workspace-write"',
+        'backend = "external"',
+        "required = true",
+        'external_command = "sandbox-wrapper"',
+        'external_args = ["--flag"]',
+        "",
+        "[sandbox.network]",
+        'mode = "restricted"',
+        "allow_localhost = false",
+        'allowed_hosts = ["registry.npmjs.org"]',
+        "",
+        "[sandbox.filesystem]",
+        'write_roots = [".", "../generated"]',
+        'deny_write = [".agent/mcp.json"]',
+        "",
         "[tui]",
         "stream_ui = true"
       ].join("\n"),
@@ -280,6 +316,24 @@ describe("agent-cli run", () => {
       disabledTools: ["bash"],
       enableMcp: true,
       mcpConfig: ".agent/mcp.json",
+      sandbox: {
+        mode: "workspace-write",
+        backend: "external",
+        required: true,
+        network: {
+          mode: "restricted",
+          allowLocalhost: false,
+          allowedHosts: ["registry.npmjs.org"]
+        },
+        filesystem: {
+          writeRoots: [".", "../generated"],
+          denyWrite: [".agent/mcp.json"]
+        },
+        external: {
+          command: "sandbox-wrapper",
+          args: ["--flag"]
+        }
+      },
       noStreamUi: false
     });
   });

--- a/tests/agent-core.exec-policy.test.ts
+++ b/tests/agent-core.exec-policy.test.ts
@@ -80,12 +80,36 @@ describe("exec policy", () => {
       mode: "workspace-write",
       backend: "auto",
       required: false,
-      network: { mode: "restricted", allowLocalhost: true }
+      network: { mode: "restricted", allowLocalhost: true },
+      filesystem: {
+        readRoots: [ctx.workspacePath],
+        writeRoots: [ctx.workspacePath]
+      }
     });
     expect(normalizeSandboxConfig(ctx.workspacePath, { mode: "policy_only", filesystem: "read_only" })).toMatchObject({
       mode: "read-only",
-      backend: "policy-only"
+      backend: "policy-only",
+      filesystem: {
+        readRoots: [ctx.workspacePath],
+        writeRoots: []
+      }
     });
+  });
+
+  it("warns when an unavailable optional OS backend falls back to policy-only", async () => {
+    const ctx = await context();
+    ctx.permissionMode = "yolo";
+    ctx.sandbox = { mode: "workspace-write", backend: "external", required: false };
+    ctx.sandboxAdapter = createDefaultSandboxAdapter();
+    const result = await executeBashTool({ command: "echo fallback" }, ctx);
+    expect(result.ok).toBe(true);
+    expect(result.metadata?.sandbox).toMatchObject({
+      enforcement: "policy-only",
+      backendAvailable: false,
+      fallbackAllowed: true,
+      osSandbox: false
+    });
+    expect(String((result.metadata?.sandbox as Record<string, unknown> | undefined)?.warning ?? "")).toContain("policy-only");
   });
 
   it("fails closed for explicitly required Windows sandbox backend", async () => {

--- a/tests/agent-core.exec-policy.test.ts
+++ b/tests/agent-core.exec-policy.test.ts
@@ -1,12 +1,15 @@
-import { mkdtemp } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   classifyShellCommand,
+  createDefaultSandboxAdapter,
   createPolicyOnlySandboxAdapter,
   evaluateExecPolicy,
   executeBashTool,
+  normalizeSandboxConfig,
   type ToolExecutionContext
 } from "../packages/agent-core/src/index.js";
 
@@ -58,7 +61,7 @@ describe("exec policy", () => {
     const result = await executeBashTool({ command: "node -e \"console.log(42)\"" }, ctx);
     expect(result.ok).toBe(true);
     expect(result.metadata?.execPolicy).toMatchObject({ action: "prompt", executesCode: true });
-    expect(result.metadata?.sandbox).toMatchObject({ sandboxMode: "policy_only" });
+    expect(result.metadata?.sandbox).toMatchObject({ mode: "workspace-write", backend: "policy-only" });
     expect(decisions).toBe(1);
   });
 
@@ -69,5 +72,64 @@ describe("exec policy", () => {
     const result = await executeBashTool({ command: "curl https://example.com" }, ctx);
     expect(result.ok).toBe(false);
     expect(result.content).toContain("network");
+  });
+
+  it("normalizes modern sandbox defaults and legacy names", async () => {
+    const ctx = await context();
+    expect(normalizeSandboxConfig(ctx.workspacePath)).toMatchObject({
+      mode: "workspace-write",
+      backend: "auto",
+      required: false,
+      network: { mode: "restricted", allowLocalhost: true }
+    });
+    expect(normalizeSandboxConfig(ctx.workspacePath, { mode: "policy_only", filesystem: "read_only" })).toMatchObject({
+      mode: "read-only",
+      backend: "policy-only"
+    });
+  });
+
+  it("fails closed for explicitly required Windows sandbox backend", async () => {
+    const ctx = await context();
+    ctx.permissionMode = "yolo";
+    ctx.sandbox = { mode: "workspace-write", backend: "windows", required: true };
+    ctx.sandboxAdapter = createDefaultSandboxAdapter();
+    const result = await executeBashTool({ command: "echo hi" }, ctx);
+    expect(result.ok).toBe(false);
+    expect(result.content).toMatch(/Windows native sandbox v1 does not implement WFP network isolation|Windows sandbox backend is only available on Windows/);
+  });
+
+  it("enforces Windows native filesystem sandbox when network is default", async () => {
+    if (process.platform !== "win32") return;
+    const ctx = await context();
+    ctx.permissionMode = "yolo";
+    ctx.commandTimeoutSec = 10;
+    ctx.sandbox = { mode: "workspace-write", backend: "windows", required: true, network: { mode: "default" } };
+    ctx.sandboxAdapter = createDefaultSandboxAdapter();
+    const escapePath = path.join(path.dirname(ctx.workspacePath), "escape.txt");
+    await rm(escapePath, { force: true });
+    try {
+      const inside = await executeBashTool({ command: "echo ok>inside.txt" }, ctx);
+      expect(inside.ok).toBe(true);
+      expect(existsSync(path.join(ctx.workspacePath, "inside.txt"))).toBe(true);
+      expect(inside.metadata?.sandbox).toMatchObject({ backend: "windows", enforcement: "windows-restricted-token" });
+
+      const escape = await executeBashTool({ command: "echo bad>..\\escape.txt" }, ctx);
+      expect(escape.ok).toBe(false);
+      expect(existsSync(escapePath)).toBe(false);
+    } finally {
+      await rm(escapePath, { force: true });
+    }
+  });
+
+  it("enforces Windows native read-only filesystem sandbox", async () => {
+    if (process.platform !== "win32") return;
+    const ctx = await context();
+    ctx.permissionMode = "yolo";
+    ctx.commandTimeoutSec = 10;
+    ctx.sandbox = { mode: "read-only", backend: "windows", required: true, network: { mode: "default" } };
+    ctx.sandboxAdapter = createDefaultSandboxAdapter();
+    const result = await executeBashTool({ command: "echo bad>readonly.txt" }, ctx);
+    expect(result.ok).toBe(false);
+    expect(existsSync(path.join(ctx.workspacePath, "readonly.txt"))).toBe(false);
   });
 });

--- a/tests/agent-core.harness.test.ts
+++ b/tests/agent-core.harness.test.ts
@@ -15,7 +15,9 @@ import {
   type RunControllerCleanupResult,
   type RunControllerCommandResult,
   type RunControllerRetryDecision,
-  type RunControllerServiceCleanupResult
+  type RunControllerServiceCleanupResult,
+  type SandboxAdapter,
+  type SandboxExecRequest
 } from "../packages/agent-core/src/index.js";
 
 class SequenceModel implements ModelClient {
@@ -179,6 +181,44 @@ describe("agent-core harness", () => {
     expect(result.settled_on).toMatch(/close|exit-drain/);
     expect(result.timed_out).toBeUndefined();
     expect(Date.now() - startedAt).toBeLessThan(3000);
+  });
+
+  it("runs harness commands through the sandbox adapter and records metadata", async () => {
+    const dir = await tempWorkspace();
+    const seenRequests: SandboxExecRequest[] = [];
+    const adapter: SandboxAdapter = {
+      async prepareExec(request) {
+        seenRequests.push(request);
+        return {
+          allowed: true,
+          command: process.execPath,
+          args: ["-e", "process.stdout.write('sandboxed')"],
+          cwd: request.cwd,
+          env: request.env,
+          metadata: { enforcement: "test-sandbox", fallbackAllowed: false }
+        };
+      }
+    };
+
+    const result = await runHarnessCommand({
+      kind: "validation",
+      source: "test",
+      command: "echo should-be-transformed",
+      workspacePath: dir,
+      attempt: 1,
+      timeoutSec: 5,
+      sandbox: { mode: "workspace-write", backend: "external" },
+      sandboxAdapter: adapter
+    });
+
+    expect(result.exit_code).toBe(0);
+    expect(result.stdout_tail).toBe("sandboxed");
+    expect(result.sandbox).toMatchObject({ enforcement: "test-sandbox", fallbackAllowed: false });
+    expect(seenRequests[0]).toMatchObject({
+      toolName: "harness.validation",
+      command: "echo should-be-transformed",
+      workspacePath: dir
+    });
   });
 
   it("plans cheap syntax checks for changed files", async () => {

--- a/tests/agent-core.sandbox-availability.test.ts
+++ b/tests/agent-core.sandbox-availability.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", { value: platform });
+}
+
+function restorePlatform(): void {
+  if (originalPlatform) Object.defineProperty(process, "platform", originalPlatform);
+}
+
+function allowedPolicy(command = "echo hi") {
+  return {
+    command,
+    risk: "read" as const,
+    mutatesWorkspace: false,
+    usesNetwork: false,
+    changesGitState: false,
+    executesCode: false,
+    action: "allow" as const,
+    reason: "test"
+  };
+}
+
+async function importSandboxWithSpawn(spawnSync: ReturnType<typeof vi.fn>) {
+  vi.resetModules();
+  vi.doMock("node:child_process", () => ({ spawnSync }));
+  return await import("../packages/agent-core/src/sandbox.js");
+}
+
+afterEach(() => {
+  restorePlatform();
+  vi.doUnmock("node:child_process");
+  vi.doUnmock("node:fs");
+  vi.resetModules();
+});
+
+describe("sandbox backend availability", () => {
+  it("does not report bubblewrap available when bwrap exists but user namespace probes fail", async () => {
+    setPlatform("linux");
+    const spawnSync = vi.fn((command: string, args: string[] = []) => {
+      if (command === "bwrap" && args[0] === "--version") return { status: 0, error: undefined };
+      if (command === "unshare" && args.join(" ") === "-Ur true") return { status: 1, error: undefined };
+      if (command === "bwrap" && args.includes("--ro-bind")) return { status: 1, error: undefined };
+      return { status: 127, error: undefined };
+    });
+    const { createDefaultSandboxAdapter } = await importSandboxWithSpawn(spawnSync);
+
+    const availability = await createDefaultSandboxAdapter().checkAvailability?.(
+      { mode: "workspace-write", backend: "bubblewrap" },
+      process.cwd()
+    );
+
+    expect(availability).toMatchObject({ available: false, backend: "bubblewrap" });
+    expect(availability?.reason).toContain("Linux user namespaces are unavailable");
+    expect(availability?.reason).toContain("Enable unprivileged user namespaces");
+  });
+
+  it("reports bubblewrap available when bwrap exists and unshare user namespace probe succeeds", async () => {
+    setPlatform("linux");
+    const spawnSync = vi.fn((command: string, args: string[] = []) => {
+      if (command === "bwrap" && args[0] === "--version") return { status: 0, error: undefined };
+      if (command === "unshare" && args.join(" ") === "-Ur true") return { status: 0, error: undefined };
+      return { status: 127, error: undefined };
+    });
+    const { createDefaultSandboxAdapter } = await importSandboxWithSpawn(spawnSync);
+
+    const availability = await createDefaultSandboxAdapter().checkAvailability?.(
+      { mode: "workspace-write", backend: "bubblewrap" },
+      process.cwd()
+    );
+
+    expect(availability).toMatchObject({ available: true, backend: "bubblewrap" });
+    expect(spawnSync).not.toHaveBeenCalledWith("bwrap", ["--ro-bind", "/", "/", "true"], expect.anything());
+  });
+
+  it("does not report detected macOS seatbelt available while execution is unimplemented", async () => {
+    setPlatform("darwin");
+    const spawnSync = vi.fn();
+    vi.resetModules();
+    vi.doMock("node:child_process", () => ({ spawnSync }));
+    vi.doMock("node:fs", async () => {
+      const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+      return {
+        ...actual,
+        existsSync: (target: string) => target === "/usr/bin/sandbox-exec" || actual.existsSync(target)
+      };
+    });
+    const { createDefaultSandboxAdapter } = await import("../packages/agent-core/src/sandbox.js");
+
+    const availability = await createDefaultSandboxAdapter().checkAvailability?.(
+      { mode: "workspace-write", backend: "seatbelt" },
+      process.cwd()
+    );
+
+    expect(availability).toMatchObject({ available: false, backend: "seatbelt" });
+    expect(availability?.reason).toContain("command execution is not implemented yet");
+  });
+
+  it("fails closed for required auto sandbox on macOS while seatbelt execution is unimplemented", async () => {
+    setPlatform("darwin");
+    const spawnSync = vi.fn();
+    vi.resetModules();
+    vi.doMock("node:child_process", () => ({ spawnSync }));
+    vi.doMock("node:fs", async () => {
+      const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+      return {
+        ...actual,
+        existsSync: (target: string) => target === "/usr/bin/sandbox-exec" || actual.existsSync(target)
+      };
+    });
+    const { createDefaultSandboxAdapter } = await import("../packages/agent-core/src/sandbox.js");
+
+    const decision = await createDefaultSandboxAdapter().prepareExec({
+      toolName: "bash",
+      command: "echo hi",
+      cwd: process.cwd(),
+      workspacePath: process.cwd(),
+      policy: allowedPolicy(),
+      sandbox: { mode: "workspace-write", backend: "auto", required: true }
+    });
+
+    expect(decision).toMatchObject({ allowed: false });
+    expect(decision.reason).toContain("command execution is not implemented yet");
+    expect(decision.metadata).toMatchObject({ backendAvailable: false, fallbackAllowed: false, osSandbox: false });
+  });
+
+  it("falls back to policy-only with warning for optional auto sandbox on macOS while seatbelt execution is unimplemented", async () => {
+    setPlatform("darwin");
+    const spawnSync = vi.fn();
+    vi.resetModules();
+    vi.doMock("node:child_process", () => ({ spawnSync }));
+    vi.doMock("node:fs", async () => {
+      const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+      return {
+        ...actual,
+        existsSync: (target: string) => target === "/usr/bin/sandbox-exec" || actual.existsSync(target)
+      };
+    });
+    const { createDefaultSandboxAdapter } = await import("../packages/agent-core/src/sandbox.js");
+
+    const decision = await createDefaultSandboxAdapter().prepareExec({
+      toolName: "bash",
+      command: "echo hi",
+      cwd: process.cwd(),
+      workspacePath: process.cwd(),
+      policy: allowedPolicy(),
+      sandbox: { mode: "workspace-write", backend: "auto", required: false }
+    });
+
+    expect(decision).toMatchObject({ allowed: true, cwd: process.cwd() });
+    expect(decision.metadata).toMatchObject({
+      backend: "policy-only",
+      enforcement: "policy-only",
+      backendAvailable: false,
+      fallbackAllowed: true,
+      fallbackFrom: "seatbelt",
+      osSandbox: false
+    });
+    expect(String(decision.metadata?.warning ?? "")).toContain("policy-only");
+    expect(String(decision.metadata?.fallbackReason ?? "")).toContain("command execution is not implemented yet");
+  });
+});

--- a/tests/agent-core.tool-runtime.test.ts
+++ b/tests/agent-core.tool-runtime.test.ts
@@ -77,7 +77,7 @@ describe("ToolRuntime", () => {
     );
     const durationMs = Date.now() - startedAt;
     expect(results.map((result) => result.result.content)).toEqual(["read_a", "read_b", "write_a", "read_c"]);
-    expect(durationMs).toBeLessThan(180);
+    expect(durationMs).toBeLessThan(260);
     expect(runtime.summary()).toMatchObject({ queued: 4, started: 4, completed: 4, parallel_batches: 2, serial_batches: 1 });
     expect(events).toContain("tool_queued");
     expect(events).toContain("tool_progress");

--- a/tests/agent-core.tools.test.ts
+++ b/tests/agent-core.tools.test.ts
@@ -42,6 +42,21 @@ function freePort(): Promise<number> {
   });
 }
 
+async function waitForFileContaining(filePath: string, needle: string, timeoutMs = 2000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastText = "";
+  while (Date.now() <= deadline) {
+    try {
+      lastText = await readFile(filePath, "utf8");
+      if (lastText.includes(needle)) return;
+    } catch {
+      // The service may not have opened the log yet.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  expect(lastText).toContain(needle);
+}
+
 describe("agent-core tools", () => {
   it("runs bash successfully", async () => {
     const { context } = await workspace();
@@ -241,23 +256,33 @@ describe("agent-core tools", () => {
 
   it("fails readiness timeouts while keeping service logs", async () => {
     const { dir, context } = await workspace();
+    const previousRegistry = process.env.AGENT_SERVICE_REGISTRY;
+    const previousLogDir = process.env.AGENT_SERVICE_LOG_DIR;
     process.env.AGENT_SERVICE_REGISTRY = path.join(dir, "services.json");
+    delete process.env.AGENT_SERVICE_LOG_DIR;
     const logPath = path.join(dir, "not-ready.log");
     const port = await freePort();
 
-    const result = await executeServiceTool(
-      {
-        action: "start",
-        name: "not-ready",
-        command: "node -e \"console.error('booting'); setInterval(()=>{}, 1000)\"",
-        port,
-        logPath,
-        readinessTimeoutSec: 0.2
-      },
-      context
-    );
+    try {
+      const result = await executeServiceTool(
+        {
+          action: "start",
+          name: "not-ready",
+          command: "node -e \"console.log('booting'); setInterval(function(){}, 1000)\"",
+          port,
+          logPath,
+          readinessTimeoutSec: 3
+        },
+        context
+      );
 
-    expect(result.ok).toBe(false);
-    await expect(readFile(logPath, "utf8")).resolves.toContain("booting");
+      expect(result.ok).toBe(false);
+      await waitForFileContaining(logPath, "booting");
+    } finally {
+      if (previousRegistry === undefined) delete process.env.AGENT_SERVICE_REGISTRY;
+      else process.env.AGENT_SERVICE_REGISTRY = previousRegistry;
+      if (previousLogDir === undefined) delete process.env.AGENT_SERVICE_LOG_DIR;
+      else process.env.AGENT_SERVICE_LOG_DIR = previousLogDir;
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Add a unified sandbox-aware exec runtime for bash, service, and shell sessions.
- Add sandbox config/CLI/TUI support for modern modes, backends, filesystem roots, and network policy metadata.
- Add WSL/Linux bubblewrap verification plus a Windows native filesystem sandbox helper based on restricted tokens and capability ACLs.
- Keep Windows restricted network fail-closed until a WFP/network backend is implemented.

## Impact

`ask` and `yolo` can now run through the same sandbox-aware execution path. Windows hosts get native filesystem write isolation when using `backend=windows` with `network=default`; WSL2 remains the recommended path for network-restricted OS sandbox validation.

## Validation

- `pnpm build`
- `pnpm exec vitest run tests/agent-core.exec-policy.test.ts tests/agent-core.tools.test.ts tests/agent-core.new-tools.test.ts tests/agent-cli.run.test.ts tests/agent-tui.render.test.ts`
- `pnpm test`
- `pnpm verify:sandbox`
- `node scripts/verify-sandbox.mjs --require-windows-native`
- `wsl.exe -d Ubuntu -- bash -lc "cd /mnt/d/software/sigma && node scripts/verify-sandbox.mjs --require-os-sandbox"`
- `git diff --check`