### PR TITLE
fix(native): ignore unvisited dangling read links

### DIFF
--- a/native/sigma-exec/src/sandbox.rs
+++ b/native/sigma-exec/src/sandbox.rs
@@ -451,9 +451,7 @@ fn validate_roots(params: &ProcessParams) -> Result<(), RpcError> {
                 "sandbox roots must be absolute",
             ));
         }
-        let canonical = root.canonicalize().map_err(|error| {
-            RpcError::new("policy_denied", format!("invalid sandbox root: {error}"))
-        })?;
+        let canonical = canonicalize_sandbox_root(root)?;
         contained |= cwd.starts_with(canonical);
     }
     if !contained {
@@ -498,11 +496,8 @@ fn validate_roots(params: &ProcessParams) -> Result<(), RpcError> {
         .read_roots
         .iter()
         .chain(params.policy.write_roots.iter())
-        .map(|root| root.canonicalize())
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|error| {
-            RpcError::new("policy_denied", format!("invalid sandbox root: {error}"))
-        })?;
+        .map(|root| canonicalize_sandbox_root(root))
+        .collect::<Result<Vec<_>, _>>()?;
     let mut protected_paths = params.policy.protected_paths.clone();
     protected_paths.extend(
         minimal_roots(&read_roots)
@@ -670,12 +665,21 @@ fn canonicalize_allow_missing(path: &Path) -> Result<PathBuf, RpcError> {
 fn canonical_roots(roots: &[PathBuf]) -> Result<Vec<PathBuf>, RpcError> {
     roots
         .iter()
-        .map(|root| {
-            root.canonicalize().map_err(|error| {
-                RpcError::new("policy_denied", format!("invalid sandbox root: {error}"))
-            })
-        })
+        .map(|root| canonicalize_sandbox_root(root))
         .collect()
+}
+
+fn canonicalize_sandbox_root(root: &Path) -> Result<PathBuf, RpcError> {
+    #[cfg(target_os = "windows")]
+    {
+        crate::windows_sandbox::canonicalize_policy_root(root)
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        root.canonicalize().map_err(|error| {
+            RpcError::new("policy_denied", format!("invalid sandbox root: {error}"))
+        })
+    }
 }
 
 pub(crate) fn minimal_roots(roots: &[PathBuf]) -> Vec<&PathBuf> {

--- a/native/sigma-exec/src/windows_sandbox.rs
+++ b/native/sigma-exec/src/windows_sandbox.rs
@@ -1772,6 +1772,16 @@ fn inspect_read_acl_target_path(
     path: &Path,
     read_roots: &[PathBuf],
 ) -> Result<Option<(bool, Option<RecoveryRootIdentity>)>, RpcError> {
+    // Some Windows filesystems reject a WRITE_DAC handle to a dangling
+    // junction before FILE_FLAG_OPEN_REPARSE_POINT can expose the link object.
+    // Classify the target failure through a metadata-only preflight first;
+    // the durable handle and identity checks below still guard every valid
+    // reparse target against retargeting races.
+    let preflight_resolved = std::fs::symlink_metadata(path)
+        .ok()
+        .filter(|metadata| metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0)
+        .map(|_| resolve_read_reparse_target(path))
+        .transpose()?;
     let handle = open_acl_target(path)?;
     let information = acl_target_information(handle.0)?;
     let tag = acl_target_tag(handle.0)?;
@@ -1792,15 +1802,10 @@ fn inspect_read_acl_target_path(
         )));
     }
 
-    let resolved = path.canonicalize().map_err(|error| {
-        RpcError::new(
-            SANDBOX_REPARSE_TARGET_UNRESOLVABLE,
-            format!(
-                "cannot resolve read-only sandbox reparse target '{}': {error}",
-                path.display()
-            ),
-        )
-    })?;
+    let resolved = match preflight_resolved {
+        Some(resolved) => resolved,
+        None => resolve_read_reparse_target(path)?,
+    };
     if !read_roots
         .iter()
         .any(|root| windows_path_within(root, &resolved))
@@ -1817,6 +1822,18 @@ fn inspect_read_acl_target_path(
     // Never inherit through or enumerate a reparse point. The resolved target
     // is covered independently through its real path under a declared root.
     Ok(Some((false, Some(target))))
+}
+
+fn resolve_read_reparse_target(path: &Path) -> Result<PathBuf, RpcError> {
+    path.canonicalize().map_err(|error| {
+        RpcError::new(
+            SANDBOX_REPARSE_TARGET_UNRESOLVABLE,
+            format!(
+                "cannot resolve read-only sandbox reparse target '{}': {error}",
+                path.display()
+            ),
+        )
+    })
 }
 
 fn assert_read_reparse_target(

--- a/native/sigma-exec/src/windows_sandbox.rs
+++ b/native/sigma-exec/src/windows_sandbox.rs
@@ -96,6 +96,7 @@ const MAX_RECOVERY_JOURNAL_BYTES: u64 = 16 * 1024 * 1024;
 const MAX_RECOVERY_ENTRIES: usize = 100_000;
 const MAX_RECOVERY_SCAN_DEPTH: usize = 256;
 const ACCESS_ALLOWED_ACE_TYPE_VALUE: u8 = 0;
+const SANDBOX_REPARSE_TARGET_UNRESOLVABLE: &str = "sandbox_reparse_target_unresolvable";
 static PROFILE_SEQUENCE: AtomicU64 = AtomicU64::new(1);
 
 #[derive(Deserialize, Serialize)]
@@ -465,12 +466,13 @@ fn validate_launcher_params(params: &ProcessParams) -> Result<(), RpcError> {
         .chain(params.policy.write_roots.iter())
         .chain(params.policy.execution_roots.iter())
     {
-        if !root.is_absolute() || !root.exists() {
+        if !root.is_absolute() {
             return Err(RpcError::new(
                 "policy_denied",
-                "all AppContainer roots must be existing absolute paths",
+                "all AppContainer roots must be absolute paths",
             ));
         }
+        canonicalize_policy_root(root)?;
     }
     Ok(())
 }
@@ -870,8 +872,18 @@ fn plan_read_tree(
         return Ok(());
     }
     check_acl_plan_limits(plan, planned_objects, depth)?;
-    let Some((is_directory, read_reparse_target)) = inspect_read_acl_target_path(path, read_roots)?
-    else {
+    let inspected = inspect_read_acl_target_path(path, read_roots);
+    let Some((is_directory, read_reparse_target)) = (match inspected {
+        // A descendant discovered while enumerating a declared read tree is
+        // not itself an authorization request. If its reparse target no
+        // longer resolves, leave the link object and target ungranted and
+        // continue planning the unrelated tree. An explicitly declared root
+        // (depth zero) still fails closed with the stable sandbox code.
+        Err(error) if depth > 0 && error.code == SANDBOX_REPARSE_TARGET_UNRESOLVABLE => {
+            return Ok(());
+        }
+        result => result?,
+    }) else {
         // An existing read-only link outside every declared read root gets no
         // ACE and is never traversed. Parent grants are path-local, so the
         // AppContainer cannot acquire access through it.
@@ -1000,7 +1012,29 @@ fn canonical_unique(paths: &[PathBuf]) -> Result<Vec<PathBuf>, RpcError> {
     let mut seen = HashSet::new();
     let mut result = Vec::new();
     for path in paths {
-        let canonical = path.canonicalize().map_err(|error| {
+        let canonical = canonicalize_policy_root(path)?;
+        let key = canonical.to_string_lossy().to_lowercase();
+        if seen.insert(key) {
+            result.push(canonical);
+        }
+    }
+    Ok(result)
+}
+
+pub(crate) fn canonicalize_policy_root(path: &Path) -> Result<PathBuf, RpcError> {
+    path.canonicalize().map_err(|error| {
+        let is_reparse_point = std::fs::symlink_metadata(path)
+            .map(|metadata| metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0)
+            .unwrap_or(false);
+        if is_reparse_point {
+            RpcError::new(
+                SANDBOX_REPARSE_TARGET_UNRESOLVABLE,
+                format!(
+                    "cannot resolve sandbox reparse root '{}': {error}",
+                    path.display()
+                ),
+            )
+        } else {
             RpcError::new(
                 "policy_denied",
                 format!(
@@ -1008,13 +1042,8 @@ fn canonical_unique(paths: &[PathBuf]) -> Result<Vec<PathBuf>, RpcError> {
                     path.display()
                 ),
             )
-        })?;
-        let key = canonical.to_string_lossy().to_lowercase();
-        if seen.insert(key) {
-            result.push(canonical);
         }
-    }
-    Ok(result)
+    })
 }
 
 fn minimal_windows_roots(roots: &[PathBuf]) -> Vec<PathBuf> {
@@ -1765,7 +1794,7 @@ fn inspect_read_acl_target_path(
 
     let resolved = path.canonicalize().map_err(|error| {
         RpcError::new(
-            "sandbox_reparse_target_unresolvable",
+            SANDBOX_REPARSE_TARGET_UNRESOLVABLE,
             format!(
                 "cannot resolve read-only sandbox reparse target '{}': {error}",
                 path.display()
@@ -4672,6 +4701,39 @@ mod tests {
         );
     }
 
+    fn read_tree_content_fingerprint(root: &Path) -> Vec<(String, u32, Vec<u8>)> {
+        fn visit(root: &Path, path: &Path, entries: &mut Vec<(String, u32, Vec<u8>)>) {
+            let metadata = std::fs::symlink_metadata(path).expect("inspect read fixture entry");
+            let attributes = metadata.file_attributes();
+            let relative = path
+                .strip_prefix(root)
+                .expect("fixture entry remains below root")
+                .to_string_lossy()
+                .replace('\\', "/");
+            let is_reparse = attributes & FILE_ATTRIBUTE_REPARSE_POINT != 0;
+            let bytes = if metadata.is_file() && !is_reparse {
+                std::fs::read(path).expect("read fixture file")
+            } else {
+                Vec::new()
+            };
+            entries.push((relative, attributes, bytes));
+            if metadata.is_dir() && !is_reparse {
+                let mut children = std::fs::read_dir(path)
+                    .expect("enumerate read fixture")
+                    .map(|entry| entry.expect("read fixture entry").path())
+                    .collect::<Vec<_>>();
+                children.sort();
+                for child in children {
+                    visit(root, &child, entries);
+                }
+            }
+        }
+
+        let mut entries = Vec::new();
+        visit(root, root, &mut entries);
+        entries
+    }
+
     #[test]
     fn quotes_windows_arguments_without_losing_backslashes() {
         assert_eq!(quote_windows_argument("plain"), "plain");
@@ -4929,10 +4991,153 @@ mod tests {
 
         let error = inspect_read_acl_target_path(&junction, std::slice::from_ref(&root))
             .expect_err("direct dangling junction inspection must fail closed");
-        assert_eq!(error.code, "sandbox_reparse_target_unresolvable");
+        assert_eq!(error.code, SANDBOX_REPARSE_TARGET_UNRESOLVABLE);
+
+        let mut plan = Vec::new();
+        let mut planned_objects = 0;
+        let error = plan_read_tree(
+            &junction,
+            std::slice::from_ref(&junction),
+            &[],
+            &mut plan,
+            &mut planned_objects,
+            0,
+        )
+        .expect_err("a dangling junction declared as the read root must fail closed");
+        assert_eq!(error.code, SANDBOX_REPARSE_TARGET_UNRESOLVABLE);
+
+        let error = canonicalize_policy_root(&junction)
+            .expect_err("a dangling junction policy root must retain its stable failure code");
+        assert_eq!(error.code, SANDBOX_REPARSE_TARGET_UNRESOLVABLE);
 
         std::fs::remove_dir(&junction).expect("remove dangling junction");
         std::fs::remove_dir_all(&fixture).expect("remove dangling junction fixture");
+    }
+
+    #[test]
+    fn read_tree_skips_100_deterministic_dangling_descendants_without_residue() {
+        let unique = ephemeral_profile_name()
+            .expect("create deterministic reparse profile name")
+            .replace('.', "-");
+        let fixture = std::env::temp_dir().join(format!("sigma-dangling-descendants-{unique}"));
+        let recovery = fixture
+            .join("host")
+            .join("SigmaCode")
+            .join(RECOVERY_DIRECTORY);
+        let root = fixture.join("workspace");
+        let removed_targets = fixture.join("removed-targets");
+        let outside = fixture.join("outside");
+        let outside_link = root.join("outside-link");
+        let ordinary = root.join("ordinary.txt");
+        std::fs::create_dir_all(&root).expect("create deterministic read root");
+        std::fs::create_dir_all(&removed_targets).expect("create removed target parent");
+        std::fs::create_dir_all(&outside).expect("create outside target");
+        std::fs::write(&ordinary, b"ordinary read-only content")
+            .expect("create ordinary read target");
+        std::fs::write(outside.join("secret.txt"), b"outside").expect("create outside sentinel");
+        create_test_junction(&outside_link, &outside);
+
+        let mut dangling = Vec::with_capacity(100);
+        let mut ordinary_descendants = Vec::with_capacity(100);
+        for seed in 0_usize..100 {
+            let mut branch = root.join(format!("case-{seed:03}"));
+            let depth = (seed.wrapping_mul(37) % 5) + 1;
+            for level in 0..depth {
+                branch = branch.join(format!(
+                    "level-{:02}",
+                    seed.wrapping_mul(17).wrapping_add(level) % 23
+                ));
+            }
+            std::fs::create_dir_all(&branch).expect("create deterministic nested branch");
+            let ordinary_descendant = branch.join(format!("visible-{seed:03}.txt"));
+            std::fs::write(&ordinary_descendant, format!("seed={seed}\n"))
+                .expect("create deterministic ordinary descendant");
+            ordinary_descendants.push(ordinary_descendant);
+
+            let target = removed_targets.join(format!("target-{seed:03}"));
+            let link = branch.join(format!("unavailable-{seed:03}"));
+            std::fs::create_dir(&target).expect("create temporary junction target");
+            create_test_junction(&link, &target);
+            std::fs::remove_dir(&target).expect("make deterministic junction dangling");
+            dangling.push(link);
+        }
+
+        let before = read_tree_content_fingerprint(&root);
+        let mut plan = Vec::new();
+        let mut planned_objects = 0;
+        plan_read_tree(
+            &root,
+            std::slice::from_ref(&root),
+            &[],
+            &mut plan,
+            &mut planned_objects,
+            0,
+        )
+        .expect("unresolvable descendants must not reject the unrelated read tree");
+        for link in &dangling {
+            assert!(
+                plan.iter().all(|entry| entry.path != *link),
+                "a dangling descendant must receive no ACL grant: '{}'",
+                link.display()
+            );
+        }
+        assert!(plan.iter().all(|entry| entry.path != outside_link));
+        assert!(plan.iter().any(|entry| entry.path == ordinary));
+        for path in &ordinary_descendants {
+            assert!(plan.iter().any(|entry| entry.path == *path));
+        }
+
+        let mut profile = test_profile();
+        let mut journal = RecoveryJournal::create(&recovery, &profile.name)
+            .expect("create deterministic dangling-link recovery journal");
+        journal
+            .prepare(&plan, profile.sid)
+            .expect("journal only authorized read-tree entries");
+        journal
+            .apply(&plan, profile.sid)
+            .expect("grant the unrelated read tree");
+        assert!(count_allowed_aces(&root, profile.sid) > 0);
+        assert!(count_allowed_aces(&ordinary, profile.sid) > 0);
+        for link in &dangling {
+            assert_eq!(
+                count_allowed_aces(link, profile.sid),
+                0,
+                "a skipped dangling descendant must receive no run-SID ACE"
+            );
+        }
+        for path in [&outside_link, &outside, &outside.join("secret.txt")] {
+            assert_eq!(
+                count_allowed_aces(path, profile.sid),
+                0,
+                "an out-of-root link and target must receive no run-SID ACE"
+            );
+        }
+
+        cleanup_recovery_snapshot(&journal.snapshot, profile.sid)
+            .expect("recover deterministic dangling-link ACL grants");
+        assert_tree_has_no_allowed_ace(&root, profile.sid);
+        assert_eq!(count_allowed_aces(&outside, profile.sid), 0);
+        assert_eq!(
+            count_allowed_aces(&outside.join("secret.txt"), profile.sid),
+            0
+        );
+        journal
+            .remove()
+            .expect("remove deterministic dangling-link journal");
+        profile
+            .delete()
+            .expect("delete deterministic dangling-link profile");
+        assert_eq!(
+            read_tree_content_fingerprint(&root),
+            before,
+            "ACL grant and recovery must preserve workspace content and structure"
+        );
+
+        for link in dangling {
+            std::fs::remove_dir(&link).expect("remove deterministic dangling junction");
+        }
+        std::fs::remove_dir(&outside_link).expect("remove outside junction");
+        std::fs::remove_dir_all(&fixture).expect("remove deterministic dangling fixture");
     }
 
     #[test]

--- a/scripts/ci/linux-sandbox-smoke.py
+++ b/scripts/ci/linux-sandbox-smoke.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import os
 import shutil
+import stat
 import struct
 import subprocess
 import tempfile
@@ -18,6 +19,28 @@ def sha256_file(file_path: Path) -> str:
     with file_path.open("rb") as source:
         for chunk in iter(lambda: source.read(1024 * 1024), b""):
             digest.update(chunk)
+    return digest.hexdigest()
+
+
+def read_tree_fingerprint(root: Path) -> str:
+    """Hash a workspace tree without following symbolic links."""
+    digest = hashlib.sha256()
+
+    def visit(path: Path) -> None:
+        info = path.lstat()
+        relative = path.relative_to(root).as_posix().encode("utf-8")
+        digest.update(struct.pack(">I", len(relative)))
+        digest.update(relative)
+        digest.update(struct.pack(">I", info.st_mode))
+        if stat.S_ISLNK(info.st_mode):
+            digest.update(os.readlink(path).encode("utf-8"))
+        elif stat.S_ISREG(info.st_mode):
+            digest.update(path.read_bytes())
+        elif stat.S_ISDIR(info.st_mode):
+            for child in sorted(path.iterdir(), key=lambda item: item.name):
+                visit(child)
+
+    visit(root)
     return digest.hexdigest()
 
 
@@ -105,6 +128,80 @@ def poll_until_settled(broker: Broker, handle_id: str) -> dict:
     raise RuntimeError(f"process did not settle: {result}")
 
 
+def verify_dangling_read_only_conformance(
+    broker: Broker, workspace: Path, external: Path
+) -> dict:
+    root = workspace / "dangling-read-conformance"
+    target_parent = external / "removed-targets"
+    outside = external / "read-only-outside"
+    outside_link = root / "outside-link"
+    dangling: list[Path] = []
+    root.mkdir()
+    target_parent.mkdir()
+    outside.mkdir()
+    (root / "ordinary.txt").write_text("ordinary read-only content\n", encoding="utf-8")
+    (outside / "secret.txt").write_text("outside\n", encoding="utf-8")
+    outside_link.symlink_to(outside, target_is_directory=True)
+    try:
+        for seed in range(100):
+            branch = root / f"case-{seed:03d}"
+            depth = (seed * 37 % 5) + 1
+            for level in range(depth):
+                branch /= f"level-{(seed * 17 + level) % 23:02d}"
+            branch.mkdir(parents=True)
+            (branch / f"visible-{seed:03d}.txt").write_text(
+                f"seed={seed}\n", encoding="utf-8"
+            )
+            target = target_parent / f"target-{seed:03d}"
+            link = branch / f"unavailable-{seed:03d}"
+            target.mkdir()
+            link.symlink_to(target, target_is_directory=True)
+            target.rmdir()
+            dangling.append(link)
+
+        before = read_tree_fingerprint(root)
+        request = params(
+            root,
+            "test \"$(cat ordinary.txt)\" = \"ordinary read-only content\" "
+            "&& ! cat outside-link/secret.txt >/dev/null 2>&1",
+        )
+        request["policy"]["writeRoots"] = []
+        spawned = require_ok(broker.request("process.spawn", request))
+        settled = poll_until_settled(broker, spawned["handleId"])
+        if settled.get("exitCode") != 0:
+            raise RuntimeError(
+                "dangling symlink descendants blocked an unrelated read-only process or "
+                f"exposed an outside target: {settled}"
+            )
+
+        direct = params(root, "true")
+        direct["policy"]["writeRoots"] = []
+        direct["policy"]["readRoots"].append(str(dangling[37]))
+        direct_result = broker.request("exec", {**direct, "timeoutMs": 10000})
+        if direct_result.get("ok"):
+            raise RuntimeError(
+                "a dangling symlink declared as a read root was not rejected: "
+                f"{direct_result}"
+            )
+        if read_tree_fingerprint(root) != before:
+            raise RuntimeError("read-only symlink conformance mutated workspace content")
+        if (outside / "secret.txt").read_text(encoding="utf-8") != "outside\n":
+            raise RuntimeError("read-only symlink conformance mutated the outside target")
+        return {
+            "deterministicSeeds": 100,
+            "unrelatedSpawn": True,
+            "outsideReadDenied": True,
+            "directDanglingRootRejected": True,
+            "workspaceUnchanged": True,
+            "processSettled": True,
+        }
+    finally:
+        for link in dangling:
+            link.unlink(missing_ok=True)
+        outside_link.unlink(missing_ok=True)
+        shutil.rmtree(root, ignore_errors=True)
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--broker", type=Path, required=True)
@@ -129,6 +226,10 @@ def main() -> int:
             or not hardening.get("seccompFilter")
         ):
             raise RuntimeError(f"required Linux hardening self-test failed: {setup}")
+
+        dangling_read_conformance = verify_dangling_read_only_conformance(
+            broker, workspace, external
+        )
 
         scoped = require_ok(broker.request("exec", {
             **params(workspace, "printf allowed > out/allowed.txt; printf escaped > escape.txt || true"),
@@ -213,6 +314,7 @@ def main() -> int:
             "brokerSha256": sha256_file(args.broker.resolve()),
             "backend": setup["sandbox"]["backend"],
             "hardening": hardening,
+            "danglingReadConformance": dangling_read_conformance,
         }
         if args.output:
             args.output.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/ci/windows-sandbox-smoke.py
+++ b/scripts/ci/windows-sandbox-smoke.py
@@ -259,17 +259,20 @@ def verify_dangling_read_only_conformance(
             dangling.append(link)
 
         before = read_tree_fingerprint(root)
-        probe_request = params(root, "type ordinary.txt >nul")
+        probe_request = params(root, "type ordinary.txt")
         probe_request["policy"]["writeRoots"] = []
         spawned = require_ok(broker.request("process.spawn", probe_request))
         probe = poll_until_settled(broker, spawned["handleId"])
-        if probe["exitCode"] != 0:
+        if (
+            probe["exitCode"] != 0
+            or probe["stdout"]["data"].strip() != "ordinary read-only content"
+        ):
             raise RuntimeError(
                 "dangling descendants blocked an unrelated read-only process: "
                 f"{probe}"
             )
 
-        outside_request = params(root, "type outside-link\\secret.txt >nul")
+        outside_request = params(root, "type outside-link\\secret.txt")
         outside_request["policy"]["writeRoots"] = []
         outside_probe = require_ok(
             broker.request("exec", {**outside_request, "timeoutMs": 10000})

--- a/scripts/ci/windows-sandbox-smoke.py
+++ b/scripts/ci/windows-sandbox-smoke.py
@@ -259,18 +259,25 @@ def verify_dangling_read_only_conformance(
             dangling.append(link)
 
         before = read_tree_fingerprint(root)
-        probe_request = params(
-            root,
-            "type ordinary.txt >nul && "
-            "if exist outside-link\\secret.txt (exit /b 93) else (exit /b 0)",
-        )
+        probe_request = params(root, "type ordinary.txt >nul")
         probe_request["policy"]["writeRoots"] = []
         spawned = require_ok(broker.request("process.spawn", probe_request))
         probe = poll_until_settled(broker, spawned["handleId"])
         if probe["exitCode"] != 0:
             raise RuntimeError(
-                "dangling descendants blocked an unrelated read-only process or exposed "
-                f"an outside target: {probe}"
+                "dangling descendants blocked an unrelated read-only process: "
+                f"{probe}"
+            )
+
+        outside_request = params(root, "type outside-link\\secret.txt >nul")
+        outside_request["policy"]["writeRoots"] = []
+        outside_probe = require_ok(
+            broker.request("exec", {**outside_request, "timeoutMs": 10000})
+        )
+        if outside_probe["exitCode"] == 0:
+            raise RuntimeError(
+                "an out-of-root junction exposed its target to the read-only process: "
+                f"{outside_probe}"
             )
 
         direct = params(root, "exit /b 0")

--- a/scripts/ci/windows-sandbox-smoke.py
+++ b/scripts/ci/windows-sandbox-smoke.py
@@ -7,6 +7,7 @@ import hashlib
 import json
 import os
 import shutil
+import stat
 import struct
 import subprocess
 import tempfile
@@ -22,6 +23,36 @@ def sha256_file(file_path: Path) -> str:
         for chunk in iter(lambda: source.read(1024 * 1024), b""):
             digest.update(chunk)
     return digest.hexdigest()
+
+
+def read_tree_fingerprint(root: Path) -> str:
+    """Hash names, types, attributes, and file bytes without following reparse points."""
+    digest = hashlib.sha256()
+
+    def visit(path: Path) -> None:
+        info = path.stat(follow_symlinks=False)
+        attributes = getattr(info, "st_file_attributes", 0)
+        is_reparse = bool(attributes & stat.FILE_ATTRIBUTE_REPARSE_POINT)
+        relative = path.relative_to(root).as_posix().encode("utf-8")
+        digest.update(struct.pack(">I", len(relative)))
+        digest.update(relative)
+        digest.update(struct.pack(">II", stat.S_IFMT(info.st_mode), attributes))
+        if stat.S_ISREG(info.st_mode) and not is_reparse:
+            digest.update(path.read_bytes())
+        if stat.S_ISDIR(info.st_mode) and not is_reparse:
+            for child in sorted(path.iterdir(), key=lambda item: item.name):
+                visit(child)
+
+    visit(root)
+    return digest.hexdigest()
+
+
+def create_junction(link: Path, target: Path) -> None:
+    subprocess.run(
+        [os.environ["COMSPEC"], "/d", "/c", "mklink", "/J", str(link), str(target)],
+        check=True,
+        capture_output=True,
+    )
 
 
 def appcontainer_sid_string(profile_name: str) -> str:
@@ -176,6 +207,118 @@ def require_ok(response: dict) -> dict:
     return response["result"]
 
 
+def poll_until_settled(broker: Broker, handle_id: str) -> dict:
+    result: dict = {}
+    for _ in range(300):
+        result = require_ok(
+            broker.request(
+                "process.poll",
+                {"handleId": handle_id, "stdoutOffset": 0, "stderrOffset": 0},
+            )
+        )
+        if result["state"] != "running":
+            return result
+        time.sleep(0.05)
+    raise RuntimeError(f"process did not settle: {result}")
+
+
+def verify_dangling_read_only_conformance(
+    broker: Broker,
+    workspace: Path,
+    external: Path,
+    packages_directory: Path,
+    preexisting_profiles: set[str],
+) -> dict:
+    root = workspace / "dangling-read-conformance"
+    target_parent = external / "removed-targets"
+    outside = external / "read-only-outside"
+    ordinary = root / "ordinary.txt"
+    outside_link = root / "outside-link"
+    dangling: list[Path] = []
+    root.mkdir()
+    target_parent.mkdir()
+    outside.mkdir()
+    ordinary.write_text("ordinary read-only content\n", encoding="utf-8")
+    (outside / "secret.txt").write_text("outside\n", encoding="utf-8")
+    create_junction(outside_link, outside)
+    try:
+        for seed in range(100):
+            branch = root / f"case-{seed:03d}"
+            depth = (seed * 37 % 5) + 1
+            for level in range(depth):
+                branch /= f"level-{(seed * 17 + level) % 23:02d}"
+            branch.mkdir(parents=True)
+            (branch / f"visible-{seed:03d}.txt").write_text(
+                f"seed={seed}\n", encoding="utf-8"
+            )
+            target = target_parent / f"target-{seed:03d}"
+            link = branch / f"unavailable-{seed:03d}"
+            target.mkdir()
+            create_junction(link, target)
+            target.rmdir()
+            dangling.append(link)
+
+        before = read_tree_fingerprint(root)
+        probe_request = params(
+            root,
+            "type ordinary.txt >nul && "
+            "if exist outside-link\\secret.txt (exit /b 93) else (exit /b 0)",
+        )
+        probe_request["policy"]["writeRoots"] = []
+        spawned = require_ok(broker.request("process.spawn", probe_request))
+        probe = poll_until_settled(broker, spawned["handleId"])
+        if probe["exitCode"] != 0:
+            raise RuntimeError(
+                "dangling descendants blocked an unrelated read-only process or exposed "
+                f"an outside target: {probe}"
+            )
+
+        direct = params(root, "exit /b 0")
+        direct["policy"]["writeRoots"] = []
+        direct["policy"]["readRoots"].append(str(dangling[37]))
+        direct_result = broker.request("exec", {**direct, "timeoutMs": 10000})
+        direct_code = (direct_result.get("error") or {}).get("code")
+        if direct_result.get("ok") or direct_code != "sandbox_reparse_target_unresolvable":
+            raise RuntimeError(
+                "a dangling junction declared as a read root did not fail with the stable code: "
+                f"{direct_result}"
+            )
+        if read_tree_fingerprint(root) != before:
+            raise RuntimeError("read-only reparse conformance mutated workspace content")
+        if (outside / "secret.txt").read_text(encoding="utf-8") != "outside\n":
+            raise RuntimeError("read-only reparse conformance mutated the outside target")
+
+        leaked_profiles = [
+            profile
+            for profile in packages_directory.glob("sigmacode.exec.*")
+            if profile.name.lower() not in preexisting_profiles
+        ]
+        if leaked_profiles:
+            raise RuntimeError(
+                f"read-only reparse conformance left AppContainer profiles: {leaked_profiles}"
+            )
+        return {
+            "deterministicSeeds": 100,
+            "unrelatedSpawn": True,
+            "outsideReadDenied": True,
+            "directDanglingRootStableCode": True,
+            "workspaceUnchanged": True,
+            "processSettled": True,
+            "profilesRemoved": True,
+        }
+    finally:
+        for link in dangling:
+            try:
+                os.rmdir(link)
+            except FileNotFoundError:
+                pass
+        try:
+            os.rmdir(outside_link)
+        except FileNotFoundError:
+            pass
+        shutil.rmtree(root, ignore_errors=True)
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--broker", type=Path, required=True)
@@ -205,6 +348,14 @@ def main() -> int:
         hardening = setup["sandbox"].get("hardening") or {}
         if not hardening.get("lessPrivilegedAppContainer"):
             raise RuntimeError(f"LPAC token self-test failed: {setup}")
+
+        dangling_read_conformance = verify_dangling_read_only_conformance(
+            broker,
+            workspace,
+            external,
+            packages_directory,
+            preexisting_profiles,
+        )
 
         node_version = require_ok(
             broker.request("exec", {**node_params(workspace, node, ["--version"]), "timeoutMs": 10000})
@@ -714,6 +865,7 @@ setTimeout(() => process.exit(4), 3000);
                 "esmEntry": True,
                 "symlinkMainPreserved": True,
                 "sandboxRuntimeEnvironment": {"NODE_OPTIONS": NODE_LPAC_OPTIONS},
+                "danglingReadConformance": dangling_read_conformance,
                 "crashRecovery": {
                     "journalDurable": True,
                     "exactAceRemoved": True,

--- a/scripts/ci/windows-sandbox-smoke.py
+++ b/scripts/ci/windows-sandbox-smoke.py
@@ -261,8 +261,9 @@ def verify_dangling_read_only_conformance(
         before = read_tree_fingerprint(root)
         probe_request = params(root, "type ordinary.txt")
         probe_request["policy"]["writeRoots"] = []
-        spawned = require_ok(broker.request("process.spawn", probe_request))
-        probe = poll_until_settled(broker, spawned["handleId"])
+        probe = require_ok(
+            broker.request("exec", {**probe_request, "timeoutMs": 10000})
+        )
         if (
             probe["exitCode"] != 0
             or probe["stdout"]["data"].strip() != "ordinary read-only content"
@@ -309,7 +310,7 @@ def verify_dangling_read_only_conformance(
             )
         return {
             "deterministicSeeds": 100,
-            "unrelatedSpawn": True,
+            "unrelatedExecution": True,
             "outsideReadDenied": True,
             "directDanglingRootStableCode": True,
             "workspaceUnchanged": True,


### PR DESCRIPTION
## Scope

Implements one general sandbox invariant: an unvisited dangling directory link inside a declared read tree must not block an unrelated read-only process, while a directly declared dangling root and an out-of-root target remain denied.

## Root cause

The Windows read-tree ACL planner treated failure to resolve any descendant reparse target as a failure of the declared policy root. On some Windows filesystems, opening a dangling junction with `WRITE_DAC` fails before `FILE_FLAG_OPEN_REPARSE_POINT` can classify the link, so a stale junction elsewhere in the tree aborted sandbox setup before process launch.

## Changes

- Classify reparse targets with a metadata-only preflight before requesting the ACL handle.
- Skip only the stable `sandbox_reparse_target_unresolvable` error for descendants discovered during read-tree enumeration.
- Keep depth-zero/direct policy roots fail-closed with the stable code; ordinary missing roots remain `policy_denied`.
- Preserve the no-follow/no-ACE behavior for valid out-of-root links and retain handle/path/target-identity checks against retargeting.
- Add 100-seed Windows ACL planning/apply/recovery coverage and Windows/Linux packaged-broker conformance checks for unrelated execution, outside denial, direct denial, cleanup, and zero content mutation.

## Validation

- `pnpm eval:conformance`: 166 TypeScript tests + 53 Rust tests
- exact 100-seed debug-broker conformance: all invariants true
- `pnpm lint`
- `pnpm build`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
- fairness scan and `git diff --check`

The exact Windows conformance segment passed locally. The remainder of the existing release smoke could not complete because this host lacks the packaged Node runtime and its legacy NVM root contains an ACL-inaccessible object; CI remains the authoritative packaged run.

## Evaluation boundary

This is a manually initiated draft candidate for the explicit general invariant, stacked on the V2 evaluation foundation. No live model run or formal A/B was executed, no verifier/score feedback was supplied to the implementation task, and no `OptimizationExperimentV1` is fabricated while trusted launcher attestations are unavailable. Merge requires separate human review.