### PR TITLE
fix(kernel): converge repeated execution failures

### DIFF
--- a/packages/agent-kernel/src/reducer.ts
+++ b/packages/agent-kernel/src/reducer.ts
@@ -4,7 +4,7 @@ import { completionSummary, incompleteModelCompletion, requestedInput, toolBatch
 import { receiptContent, toolReceipt } from "./receipt-parsing.js";
 import { durableReducers, type KernelEventReducer } from "./durable-reducers.js";
 import { isCurrentModelTurn, modelMessage, modelToolCalls, modelTurn } from "./model-event-parsing.js";
-import { recordSemanticToolResult, SEMANTIC_INFRASTRUCTURE_FAILURE_CODE } from "./semantic-failures.js";
+import { recordSemanticToolResult, semanticInfrastructureFailureMessage, SEMANTIC_INFRASTRUCTURE_FAILURE_CODE } from "./semantic-failures.js";
 function objectPayload(value: unknown): Record<string, JsonValue> {
   return value && typeof value === "object" && !Array.isArray(value)
     ? value as Record<string, JsonValue>
@@ -259,7 +259,7 @@ const toolFinished: EventReducer = (state, event) => {
     continuationAttempts: 0,
     phase: nextPhase(pendingTools)
   };
-  const semantic = recordSemanticToolResult(next, receipt);
+  const semantic = recordSemanticToolResult(next, receipt, pending.request.name);
   const progressed = semantic.state;
   const inputMessage = requestedInput(receipt);
   if (inputMessage) {
@@ -282,7 +282,7 @@ const toolFinished: EventReducer = (state, event) => {
     return propose(progressed, {
       kind: "recoverable_failure",
       code: SEMANTIC_INFRASTRUCTURE_FAILURE_CODE,
-      message: `Execution infrastructure repeatedly failed without workspace or durable evidence progress (${cluster.family}, ${cluster.attempts} attempts; diagnostics: ${cluster.diagnosticCodes.join(", ")}).`
+      message: semanticInfrastructureFailureMessage(cluster)
     });
   }
   return progressed;

--- a/packages/agent-kernel/src/semantic-failures.ts
+++ b/packages/agent-kernel/src/semantic-failures.ts
@@ -20,6 +20,33 @@ export interface SemanticFailureUpdate {
   limitReached: boolean;
 }
 
+/**
+ * Built-in tools whose successful receipt proves that a new process was
+ * launched. Other process tools share the process.spawn.readonly effect for
+ * policy purposes, but polling, writing to, or terminating an existing handle
+ * is not execution-infrastructure recovery.
+ */
+const PROCESS_LAUNCH_TOOL_NAMES = new Set(["exec", "shell", "validate", "process_spawn"]);
+
+function isExecutionInfrastructureCluster(cluster: SemanticFailureCluster | undefined): boolean {
+  return cluster?.family.startsWith("execution_") === true;
+}
+
+export function semanticInfrastructureFailureMessage(cluster: SemanticFailureCluster): string {
+  const recoveryBoundary = isExecutionInfrastructureCluster(cluster)
+    ? "a successful process launch"
+    : "workspace or durable evidence progress";
+  return `Infrastructure repeatedly failed without ${recoveryBoundary} (${cluster.family}, ${cluster.attempts} attempts; diagnostics: ${cluster.diagnosticCodes.join(", ")}).`;
+}
+
+function successfulProcessLaunch(receipt: ToolReceipt, toolName: string): boolean {
+  if (!receipt.ok || !PROCESS_LAUNCH_TOOL_NAMES.has(toolName)) return false;
+  // An explicitly empty V3 actual-effects projection is authoritative. Only
+  // legacy receipts that omit it may fall back to the V2 observed projection.
+  const effects = receipt.actualEffects === undefined ? receipt.observedEffects : receipt.actualEffects;
+  return effects.some((effect) => effect === "process.spawn" || effect === "process.spawn.readonly");
+}
+
 function classifyFailure(receipt: ToolReceipt): InfrastructureFailureClassificationV1 | undefined {
   if (receipt.ok) return undefined;
   return classifyInfrastructureFailureCodesV1([
@@ -75,31 +102,57 @@ function nextCluster(
   };
 }
 
-export function recordSemanticToolResult(state: KernelState, receipt: ToolReceipt): SemanticFailureUpdate {
+function withWorkspaceProgress(
+  state: KernelState,
+  workspaceChanges: number,
+  preserveExecutionCluster: boolean
+): KernelState {
+  if (workspaceChanges === 0) return state;
+  const semanticProgress = advancedProgress(state.semanticProgress, state.revision, workspaceChanges, 0);
+  return {
+    ...state,
+    semanticProgress,
+    semanticFailureCluster: preserveExecutionCluster && state.semanticFailureCluster
+      ? { ...state.semanticFailureCluster, progress: semanticProgress }
+      : undefined
+  };
+}
+
+export function recordSemanticToolResult(
+  state: KernelState,
+  receipt: ToolReceipt,
+  toolName: string
+): SemanticFailureUpdate {
   const workspaceChanges = deltaSize(receipt.workspaceDelta);
-  if (workspaceChanges > 0) {
+  const executionCluster = isExecutionInfrastructureCluster(state.semanticFailureCluster);
+  if (successfulProcessLaunch(receipt, toolName)) {
     return {
-      state: {
-        ...state,
-        semanticProgress: advancedProgress(state.semanticProgress, state.revision, workspaceChanges, 0),
-        semanticFailureCluster: undefined
-      },
+      state: withWorkspaceProgress({ ...state, semanticFailureCluster: undefined }, workspaceChanges, false),
       limitReached: false
     };
   }
-  if ((state.semanticFailureCluster?.attempts ?? 0) >= SEMANTIC_INFRASTRUCTURE_FAILURE_LIMIT) {
-    return { state, limitReached: true };
+  if (workspaceChanges > 0 && !executionCluster) {
+    return { state: withWorkspaceProgress(state, workspaceChanges, false), limitReached: false };
+  }
+  const progressed = withWorkspaceProgress(state, workspaceChanges, executionCluster);
+  if ((progressed.semanticFailureCluster?.attempts ?? 0) >= SEMANTIC_INFRASTRUCTURE_FAILURE_LIMIT) {
+    return { state: progressed, limitReached: true };
   }
   const classification = classifyFailure(receipt);
   if (!classification) {
     return {
-      state,
-      limitReached: (state.semanticFailureCluster?.attempts ?? 0) >= SEMANTIC_INFRASTRUCTURE_FAILURE_LIMIT
+      state: progressed,
+      limitReached: (progressed.semanticFailureCluster?.attempts ?? 0) >= SEMANTIC_INFRASTRUCTURE_FAILURE_LIMIT
     };
   }
-  const cluster = nextCluster(state.semanticFailureCluster, classification, state.semanticProgress, state.revision);
+  const cluster = nextCluster(
+    progressed.semanticFailureCluster,
+    classification,
+    progressed.semanticProgress,
+    progressed.revision
+  );
   return {
-    state: { ...state, semanticFailureCluster: cluster },
+    state: { ...progressed, semanticFailureCluster: cluster },
     limitReached: cluster.attempts >= SEMANTIC_INFRASTRUCTURE_FAILURE_LIMIT
   };
 }
@@ -109,21 +162,29 @@ export function recordSemanticEvidenceProgress(state: KernelState, evidence: Evi
   const evidenceFromFailedTool = evidence.producer.authority === "tool"
     && state.receipts.some((receipt) => receipt.callId === evidence.producer.id && !receipt.ok);
   if (evidenceFromFailedTool) return state;
-  const clearsPendingFailure = state.phase === "outcome_pending"
+  const executionCluster = isExecutionInfrastructureCluster(state.semanticFailureCluster);
+  const clearsPendingFailure = !executionCluster && state.phase === "outcome_pending"
     && state.proposedOutcome?.kind === "recoverable_failure"
     && state.proposedOutcome.code === SEMANTIC_INFRASTRUCTURE_FAILURE_CODE;
+  const semanticProgress = advancedProgress(state.semanticProgress, state.revision, 0, 1);
   return {
     ...state,
-    semanticProgress: advancedProgress(state.semanticProgress, state.revision, 0, 1),
-    semanticFailureCluster: undefined,
+    semanticProgress,
+    semanticFailureCluster: executionCluster && state.semanticFailureCluster
+      ? { ...state.semanticFailureCluster, progress: semanticProgress }
+      : undefined,
     ...(clearsPendingFailure ? { phase: "ready_model" as const, proposedOutcome: undefined } : {})
   };
 }
 
 export function recordSemanticWorkspaceRestore(state: KernelState): KernelState {
+  const executionCluster = isExecutionInfrastructureCluster(state.semanticFailureCluster);
+  const semanticProgress = advancedProgress(state.semanticProgress, state.revision, 1, 0);
   return {
     ...state,
-    semanticProgress: advancedProgress(state.semanticProgress, state.revision, 1, 0),
-    semanticFailureCluster: undefined
+    semanticProgress,
+    semanticFailureCluster: executionCluster && state.semanticFailureCluster
+      ? { ...state.semanticFailureCluster, progress: semanticProgress }
+      : undefined
   };
 }

--- a/packages/agent-kernel/src/state.ts
+++ b/packages/agent-kernel/src/state.ts
@@ -59,7 +59,8 @@ export interface SemanticFailureCluster {
   firstRevision: number;
   lastRevision: number;
   diagnosticCodes: string[];
-  /** Progress watermark shared by every attempt in this no-progress cluster. */
+  /** Latest global progress watermark. Execution clusters are rebased across
+   * unrelated evidence or workspace progress until a process launch succeeds. */
   progress: SemanticProgressWatermark;
 }
 

--- a/tests/agent-kernel.semantic-failure.test.ts
+++ b/tests/agent-kernel.semantic-failure.test.ts
@@ -4,10 +4,14 @@ import {
   type AgentEventEnvelope,
   type AgentEventType,
   type EvidenceRecord,
-  type JsonValue
+  type JsonValue,
+  type ToolEffect,
+  type WorkspaceDelta
 } from "../packages/agent-protocol/src/index.js";
 import {
+  assertKernelInvariants,
   createKernelState,
+  decide,
   evolve,
   rehydrate,
   SEMANTIC_INFRASTRUCTURE_FAILURE_CODE,
@@ -77,19 +81,61 @@ function queueTool(
 
 function queueTools(
   state: KernelState,
-  calls: Array<{ id: string; name: string }>
+  calls: Array<{ id: string; name: string }>,
+  events?: AgentEventEnvelope[]
 ): KernelState {
   let next = state;
-  if (next.phase === "idle") next = apply(next, "user.message", { text: "diagnose" }, undefined, "user");
+  if (next.phase === "idle") next = apply(next, "user.message", { text: "diagnose" }, events, "user");
   const turnId = next.toolCallIds.length + 1;
-  next = apply(next, "model.started", { turnId, effectRevision: next.revision });
+  next = apply(next, "model.started", { turnId, effectRevision: next.revision }, events);
   const turn = next.activeModelTurn!;
   return apply(next, "model.completed", {
     ...turn,
     message: { role: "assistant", content: "" },
     toolCalls: calls.map((call) => ({ id: call.id, name: call.name, arguments: {} })),
     finishReason: "tool_calls"
-  });
+  }, events);
+}
+
+interface SuccessfulReceiptOptions {
+  observedEffects?: ToolEffect[];
+  actualEffects?: ToolEffect[];
+  workspaceDelta?: WorkspaceDelta;
+}
+
+function completePendingTool(
+  state: KernelState,
+  callId: string,
+  options: SuccessfulReceiptOptions = {},
+  events?: AgentEventEnvelope[]
+): KernelState {
+  const pending = state.pendingTools.find((item) => item.request.callId === callId)!;
+  const observedEffects = options.observedEffects ?? ["filesystem.read"];
+  return apply(state, "tool.completed", {
+    callId,
+    ...pending.modelTurn,
+    ok: true,
+    output: "completed",
+    outcome: { status: "succeeded", output: "completed", diagnosticCodes: [] },
+    observedEffects,
+    ...(options.actualEffects === undefined ? {} : { actualEffects: options.actualEffects }),
+    ...(options.workspaceDelta ? { workspaceDelta: options.workspaceDelta } : {}),
+    artifacts: [],
+    diagnostics: [],
+    evidence: [],
+    startedAt: "start",
+    completedAt: "end"
+  }, events, "tool");
+}
+
+function successfulReceipt(
+  state: KernelState,
+  callId: string,
+  toolName: string,
+  options: SuccessfulReceiptOptions = {},
+  events?: AgentEventEnvelope[]
+): KernelState {
+  return completePendingTool(queueTool(state, callId, toolName, events), callId, options, events);
 }
 
 function failedReceipt(
@@ -180,7 +226,8 @@ describe("semantic execution failure convergence", () => {
       semanticFailureCluster: { family: "execution_capability", attempts: 3 },
       proposedOutcome: {
         kind: "recoverable_failure",
-        code: SEMANTIC_INFRASTRUCTURE_FAILURE_CODE
+        code: SEMANTIC_INFRASTRUCTURE_FAILURE_CODE,
+        message: expect.stringContaining("successful process launch")
       }
     });
   });
@@ -278,33 +325,180 @@ describe("semantic execution failure convergence", () => {
     })).toMatchObject({ actualEffects: [] });
   });
 
-  it("resets a failure cluster on durable evidence progress, workspace progress, and steer", () => {
+  it("keeps an execution cluster across read/list work and informational evidence", () => {
     let state = failAlternative(initial(), "first", "exec", "process_spawn_failed");
     state = failAlternative(state, "second", "shell", "executable_not_found");
+    state = successfulReceipt(state, "read-progress", "read_file", {
+      observedEffects: ["filesystem.read"], actualEffects: ["filesystem.read"]
+    });
+    state = successfulReceipt(state, "list-progress", "list_files", {
+      observedEffects: ["filesystem.read"], actualEffects: ["filesystem.read"]
+    });
     const evidence: EvidenceRecord = {
       evidenceId: "real-progress",
       sessionId: state.sessionId,
       runId: state.runId,
       kind: "diagnostic",
-      status: "passed",
+      status: "informational",
       createdAt: "2026-07-12T00:00:00.000Z",
       producer: { authority: "runtime" },
       summary: "A capability was independently verified.",
       data: { source: "probe", diagnostic: { available: true } }
     };
     state = apply(state, "evidence.recorded", evidence);
-    expect(state.semanticFailureCluster).toBeUndefined();
+    expect(state.semanticFailureCluster).toMatchObject({ family: "execution_capability", attempts: 2 });
     expect(state.semanticProgress.durableEvidence).toBe(1);
+    expect(state.semanticFailureCluster?.progress).toEqual(state.semanticProgress);
 
-    state = failAlternative(state, "after-evidence", "exec", "process_spawn_failed");
+    state = failAlternative(state, "third", "validate", "shell_unavailable");
+    expect(state).toMatchObject({
+      phase: "outcome_pending",
+      semanticFailureCluster: { family: "execution_capability", attempts: 3 },
+      proposedOutcome: { code: SEMANTIC_INFRASTRUCTURE_FAILURE_CODE }
+    });
+
+    state = apply(state, "evidence.recorded", {
+      ...evidence,
+      evidenceId: "post-threshold-information",
+      summary: "A read-only inventory completed after the execution failures."
+    });
+    expect(state).toMatchObject({
+      phase: "outcome_pending",
+      semanticFailureCluster: { attempts: 3 },
+      proposedOutcome: { code: SEMANTIC_INFRASTRUCTURE_FAILURE_CODE }
+    });
+    expect(decide(state)).toEqual([expect.objectContaining({
+      type: "finish_run",
+      outcome: expect.objectContaining({ code: SEMANTIC_INFRASTRUCTURE_FAILURE_CODE })
+    })]);
+  });
+
+  it("only treats a verified launch-tool receipt as execution recovery", () => {
+    let state = failAlternative(initial(), "first", "exec", "process_spawn_failed");
+    state = failAlternative(state, "second", "shell", "executable_not_found");
+    for (const toolName of ["process_poll", "process_write", "process_terminate"]) {
+      state = successfulReceipt(state, `successful-${toolName}`, toolName, {
+        observedEffects: ["process.spawn.readonly"], actualEffects: ["process.spawn.readonly"]
+      });
+      expect(state.semanticFailureCluster?.attempts).toBe(2);
+    }
+
+    state = successfulReceipt(state, "real-launch", "exec", {
+      observedEffects: ["process.spawn.readonly"], actualEffects: ["process.spawn.readonly"]
+    });
+    expect(state.semanticFailureCluster).toBeUndefined();
+    state = failAlternative(state, "after-recovery", "exec", "process_spawn_failed");
     expect(state.semanticFailureCluster?.attempts).toBe(1);
-    state = failedReceipt(
-      queueTool(state, "workspace-progress", "shell"),
-      "workspace-progress",
-      "shell_unavailable",
-      undefined,
-      { added: [], modified: ["src/recovered.ts"], deleted: [] }
-    );
+
+    state = successfulReceipt(state, "legacy-launch", "shell", {
+      observedEffects: ["process.spawn.readonly"]
+    });
+    expect(state.semanticFailureCluster).toBeUndefined();
+  });
+
+  it("does not fall back to observed effects when actualEffects is explicitly empty", () => {
+    let state = failAlternative(initial(), "first", "exec", "process_spawn_failed");
+    state = failAlternative(state, "second", "shell", "executable_not_found");
+    state = successfulReceipt(state, "empty-actual-launch", "exec", {
+      observedEffects: ["process.spawn.readonly"], actualEffects: []
+    });
+    expect(state.semanticFailureCluster?.attempts).toBe(2);
+    state = failAlternative(state, "third", "validate", "shell_unavailable");
+    expect(state).toMatchObject({
+      phase: "outcome_pending",
+      semanticFailureCluster: { attempts: 3 },
+      proposedOutcome: { code: SEMANTIC_INFRASTRUCTURE_FAILURE_CODE }
+    });
+  });
+
+  it("preserves the reached execution cluster through a fourth receipt and failed workspace delta", () => {
+    const events: AgentEventEnvelope[] = [];
+    let state = queueTools(initial(), [
+      { id: "first", name: "exec" },
+      { id: "second", name: "shell" },
+      { id: "third", name: "validate" },
+      { id: "fourth", name: "exec" }
+    ], events);
+    state = failedReceipt(state, "first", "process_spawn_failed", events);
+    state = failedReceipt(state, "second", "executable_not_found", events);
+    state = failedReceipt(state, "third", "shell_unavailable", events, {
+      added: [], modified: ["src/transient-third.ts"], deleted: []
+    });
+    expect(state).toMatchObject({
+      phase: "tool_pending",
+      semanticProgress: { workspaceChanges: 1 },
+      semanticFailureCluster: { family: "execution_capability", attempts: 3 }
+    });
+
+    state = failedReceipt(state, "fourth", "process_spawn_failed", events, {
+      added: [], modified: ["src/transient-fourth.ts"], deleted: []
+    });
+    expect(state).toMatchObject({
+      phase: "outcome_pending",
+      semanticProgress: { workspaceChanges: 2 },
+      semanticFailureCluster: { family: "execution_capability", attempts: 3 },
+      proposedOutcome: { code: SEMANTIC_INFRASTRUCTURE_FAILURE_CODE }
+    });
+    expect(state.semanticFailureCluster?.progress).toEqual(state.semanticProgress);
+
+    const replayed = rehydrate(initial(), events);
+    assertKernelInvariants(replayed);
+    expect(replayed).toMatchObject({
+      phase: "outcome_pending",
+      semanticFailureCluster: { family: "execution_capability", attempts: 3 }
+    });
+    expect(decide(replayed)).toEqual(decide(state));
+  });
+
+  it("allows an already-started successful launch to recover a threshold cluster", () => {
+    let state = queueTools(initial(), [
+      { id: "first", name: "exec" },
+      { id: "second", name: "shell" },
+      { id: "third", name: "validate" },
+      { id: "recovery", name: "process_spawn" }
+    ]);
+    state = failedReceipt(state, "first", "process_spawn_failed");
+    state = failedReceipt(state, "second", "executable_not_found");
+    state = failedReceipt(state, "third", "shell_unavailable");
+    expect(state.semanticFailureCluster?.attempts).toBe(3);
+    state = completePendingTool(state, "recovery", {
+      observedEffects: ["process.spawn.readonly"], actualEffects: ["process.spawn.readonly"]
+    });
+    expect(state).toMatchObject({ phase: "ready_model" });
+    expect(state.semanticFailureCluster).toBeUndefined();
+    expect(state.proposedOutcome).toBeUndefined();
+  });
+
+  it("retains legacy reset behavior for non-execution infrastructure clusters", () => {
+    let state = failAlternative(initial(), "first", "edit", "workspace_transaction_root_unavailable");
+    state = failAlternative(state, "second", "write", "workspace_transaction_cleanup_failed");
+    state = failAlternative(state, "third", "apply_patch", "workspace_transaction_root_unavailable");
+    expect(state).toMatchObject({
+      phase: "outcome_pending",
+      semanticFailureCluster: { family: "workspace_transaction", attempts: 3 }
+    });
+    const evidence: EvidenceRecord = {
+      evidenceId: "non-execution-progress",
+      sessionId: state.sessionId,
+      runId: state.runId,
+      kind: "diagnostic",
+      status: "passed",
+      createdAt: "2026-07-12T00:00:00.000Z",
+      producer: { authority: "runtime" },
+      summary: "The workspace transaction service recovered.",
+      data: { source: "transaction-probe", diagnostic: { available: true } }
+    };
+    state = apply(state, "evidence.recorded", evidence);
+    expect(state).toMatchObject({ phase: "ready_model" });
+    expect(state.semanticFailureCluster).toBeUndefined();
+    expect(state.proposedOutcome).toBeUndefined();
+
+    state = failAlternative(state, "after-evidence", "edit", "workspace_transaction_root_unavailable");
+    state = successfulReceipt(state, "workspace-progress", "write_file", {
+      observedEffects: ["filesystem.write"],
+      actualEffects: ["filesystem.write"],
+      workspaceDelta: { added: [], modified: ["src/recovered.ts"], deleted: [] }
+    });
     expect(state.semanticFailureCluster).toBeUndefined();
     expect(state.semanticProgress.workspaceChanges).toBe(1);
 


### PR DESCRIPTION
## Scope

Implements one general convergence invariant: after three same-family execution-infrastructure failures, ordinary read/list work and informational evidence must not reset the fail-fast cluster; only a verified successful process-launch receipt may recover it.

## Root cause

The kernel previously treated any durable evidence or workspace delta as semantic recovery. Read-only inventory work between failed execution attempts could therefore reset the counter and allow an unbounded retry loop.

## Changes

- Preserve and rebase `execution_*` clusters across read/list receipts, informational evidence, workspace restore events, and failed-tool deltas.
- Recover only from a successful built-in launch tool (`exec`, `shell`, `validate`, or `process_spawn`) whose authoritative actual effects contain `process.spawn*`.
- Treat explicit `actualEffects: []` as authoritative and prevent poll/write/terminate operations from masquerading as launch recovery.
- Keep existing recovery behavior for non-execution infrastructure families and user-steer boundaries.
- Add durable replay, in-flight fourth receipt, threshold, recovery, and non-regression tests.

## Validation

- `pnpm eval:conformance`: 171 TypeScript tests + 52 Rust tests
- `pnpm lint`
- `pnpm build`
- fairness scan and `git diff --check`

## Evaluation boundary

This is a manually initiated draft candidate for the explicit general invariant, stacked on the V2 evaluation foundation. No live model run or formal A/B was executed, no verifier/score feedback was supplied to the implementation task, and no `OptimizationExperimentV1` is fabricated while trusted launcher attestations are unavailable. Merge requires separate human review.