### PR TITLE
Fix cross-platform release CI

### DIFF
--- a/native/sigma-exec/src/sandbox.rs
+++ b/native/sigma-exec/src/sandbox.rs
@@ -1874,8 +1874,6 @@ mod tests {
     #[cfg(target_os = "linux")]
     #[test]
     fn executable_replacement_keeps_the_pin_but_fails_destination_attestation() {
-        use std::os::unix::process::CommandExt;
-
         let root = std::env::temp_dir().join(format!(
             "sigma-pinned-executable-{}-{}",
             std::process::id(),
@@ -1913,13 +1911,16 @@ mod tests {
             .expect_err("replacement must fail before bwrap setup");
         assert_eq!(error.code, "policy_denied");
 
-        let output = Command::new(executable.source.fd_path())
-            .arg0("sh")
-            .args(["-c", "printf pinned-executable-ok"])
-            .output()
-            .expect("execute pinned file object");
-        assert!(output.status.success());
-        assert_eq!(output.stdout, b"pinned-executable-ok");
+        let pinned = executable
+            .source
+            .fd_path()
+            .metadata()
+            .expect("inspect pinned file object");
+        let original = std::fs::metadata(&moved).expect("inspect moved original executable");
+        assert_eq!(
+            (pinned.dev(), pinned.ino()),
+            (original.dev(), original.ino())
+        );
         std::fs::remove_dir_all(root).expect("remove executable test root");
     }
 

--- a/native/sigma-exec/src/windows_sandbox.rs
+++ b/native/sigma-exec/src/windows_sandbox.rs
@@ -3942,6 +3942,18 @@ fn pin_executable(
     executable: &Path,
     expected_sha256: Option<&str>,
 ) -> Result<OwnedHandle, RpcError> {
+    // GetFinalPathNameByHandleW expands short (8.3) path components. Resolve the
+    // requested path through Windows first so equivalent short and long aliases
+    // compare equal while the post-open check still detects target changes.
+    let executable = executable.canonicalize().map_err(|error| {
+        RpcError::new(
+            "executable_unavailable",
+            format!(
+                "cannot resolve executable '{}' for launch: {error}",
+                executable.display()
+            ),
+        )
+    })?;
     let wide = wide_null(executable.as_os_str());
     let handle = unsafe {
         CreateFileW(
@@ -3978,7 +3990,7 @@ fn pin_executable(
         ));
     }
     let actual = final_handle_path(handle.0)?;
-    if !windows_path_eq(&actual, executable) {
+    if !windows_path_eq(&actual, &executable) {
         return Err(RpcError::new(
             "executable_unavailable",
             format!(
@@ -3989,7 +4001,7 @@ fn pin_executable(
         ));
     }
     if let Some(expected) = expected_sha256 {
-        let mut file = std::fs::File::open(executable).map_err(|error| {
+        let mut file = std::fs::File::open(&executable).map_err(|error| {
             RpcError::new(
                 "executable_unavailable",
                 format!(

--- a/tests/agent-eval-report.test.ts
+++ b/tests/agent-eval-report.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, symlink, writeFile } from "node:fs/promises";
+import { mkdir, readFile, realpath, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
@@ -429,12 +429,13 @@ describe("agent evaluation report", () => {
     const result = await runReportCli([
       "--input", inputPath, "--output-dir", outputDir, "--eval-root", root
     ]);
+    const canonicalOutputDir = await realpath(outputDir);
 
-    expect(result.humanAuditJsonPath).toBe(path.join(outputDir, "human-audit.json"));
-    expect(result.humanAuditMarkdownPath).toBe(path.join(outputDir, "human-audit.md"));
+    expect(result.humanAuditJsonPath).toBe(path.join(canonicalOutputDir, "human-audit.json"));
+    expect(result.humanAuditMarkdownPath).toBe(path.join(canonicalOutputDir, "human-audit.md"));
     await expect(readFile(result.humanAuditJsonPath, "utf8")).resolves.toContain('"audience": "human_only"');
     expect(result.publishedHumanAuditJsonPath)
-      .toBe(path.join(outputDir, `human-audit.${result.bundleDigest}.json`));
+      .toBe(path.join(canonicalOutputDir, `human-audit.${result.bundleDigest}.json`));
   });
 
   it("keeps the default report destination inside the configured results root", async () => {

--- a/tests/agent-eval-runner.test.ts
+++ b/tests/agent-eval-runner.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { access, lstat, mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { access, lstat, mkdtemp, mkdir, readFile, realpath, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -259,7 +259,8 @@ describe("agent experience evaluation runner", () => {
         return { exitCode: 0, sessionId: "session", result: { status: "completed" }, events: successfulEvents() };
       }
     });
-    expect(result.latestPath).toBe(path.join(path.dirname(runDir), "latest.json"));
+    const canonicalResultsRoot = await realpath(path.dirname(runDir));
+    expect(result.latestPath).toBe(path.join(canonicalResultsRoot, "latest.json"));
     expect(JSON.parse(await readFile(result.latestPath, "utf8"))).toMatchObject({ runDir: "run-one" });
     expect(await readFile(repositoryLatest, "utf8").catch(() => null)).toBe(before);
   });

--- a/tests/agent-execution.test.ts
+++ b/tests/agent-execution.test.ts
@@ -31,6 +31,7 @@ import {
   parseExecutionValue,
   parseHandleId,
   parseHello,
+  parseProcessHandoff,
   parseProcessValue,
   parseSpawnedProcess
 } from "../packages/agent-execution/src/values.js";
@@ -536,6 +537,15 @@ describe("agent-execution protocol validation", () => {
     ]);
     expect(parseDoctor({
       ...doctor,
+      capabilities: {
+        ...doctor.capabilities,
+        shells: [{ kind: "bash", executable: "/bin/bash", verified: true, supportsChildProcesses: true }]
+      }
+    }).capabilities.shells).toEqual([
+      { kind: "bash", executable: "/bin/bash", verified: true, supportsChildProcesses: true }
+    ]);
+    expect(parseDoctor({
+      ...doctor,
       sandbox: { ...doctor.sandbox, hardening: { ...doctor.sandbox.hardening, landlockAbi: undefined } }
     }).sandbox.hardening).not.toHaveProperty("landlockAbi");
     expect(() => parseDoctor({ ...doctor, protocolVersion: 2 })).toThrow(BrokerProtocolError);
@@ -549,6 +559,21 @@ describe("agent-execution protocol validation", () => {
     expect(() => parseDoctor({
       ...doctor,
       capabilities: { ...doctor.capabilities, shells: [{ kind: "powershell", executable: "powershell.exe", verified: false }] }
+    })).toThrow(BrokerProtocolError);
+    expect(() => parseDoctor({
+      ...doctor,
+      capabilities: { ...doctor.capabilities, shells: {} }
+    })).toThrow(BrokerProtocolError);
+    expect(() => parseDoctor({
+      ...doctor,
+      capabilities: { ...doctor.capabilities, shells: [{ kind: "fish", executable: "/bin/fish", verified: true }] }
+    })).toThrow(BrokerProtocolError);
+    expect(() => parseDoctor({
+      ...doctor,
+      capabilities: {
+        ...doctor.capabilities,
+        shells: [{ kind: "bash", executable: "/bin/bash", verified: true, supportsChildProcesses: "yes" }]
+      }
     })).toThrow(BrokerProtocolError);
     expect(() => parseDoctor({
       ...doctor,
@@ -607,6 +632,15 @@ describe("agent-execution protocol validation", () => {
       ...processValue,
       failure: { phase: "sandbox_launch", code: "policy-denied\nforged", message: "bad code" }
     })).toThrow(BrokerProtocolError);
+    expect(() => parseProcessValue({
+      ...processValue,
+      failure: { phase: "sandbox_launch", code: "sandbox_unavailable", message: "bad\0message" }
+    })).toThrow(BrokerProtocolError);
+    expect(() => parseProcessValue({
+      ...processValue,
+      state: "running",
+      failure: { phase: "sandbox_launch", code: "sandbox_unavailable", message: "failed" }
+    })).toThrow(BrokerProtocolError);
     expect(parseExecutionValue({ ...processValue, timedOut: false, idleTimedOut: false, cancelled: false })).toMatchObject({ state: "exited" });
     expect(() => parseExecutionValue({ ...processValue, timedOut: "false", idleTimedOut: false, cancelled: false }))
       .toThrow(BrokerProtocolError);
@@ -658,6 +692,13 @@ describe("agent-execution protocol validation", () => {
     expect(parseSpawnedProcess({ handleId: "spawned", processId: 42 })).toEqual({ id: "spawned", systemProcessId: 42 });
     expect(() => parseSpawnedProcess({ handleId: "spawned", processId: 1.5 })).toThrow(BrokerProtocolError);
     expect(() => parseSpawnedProcess({ handleId: "spawned", processId: 0 })).toThrow(BrokerProtocolError);
+    expect(parseProcessHandoff({ handoffId: "handoff" })).toEqual({ handoffId: "handoff" });
+    expect(parseProcessHandoff({ handoffId: "handoff", processId: 42 })).toEqual({
+      handoffId: "handoff", systemProcessId: 42
+    });
+    expect(() => parseProcessHandoff({ handoffId: "" })).toThrow(BrokerProtocolError);
+    expect(() => parseProcessHandoff({ handoffId: "handoff", processId: 1.5 })).toThrow(BrokerProtocolError);
+    expect(() => parseProcessHandoff({ handoffId: "handoff", processId: 0 })).toThrow(BrokerProtocolError);
   });
 
   it("resolves platform-specific helper names", () => {

--- a/tests/package-agent-cli.test.ts
+++ b/tests/package-agent-cli.test.ts
@@ -128,6 +128,7 @@ function approvedWindowsNodeFixtureAvailable() {
 }
 
 const approvedWindowsPackageIt = windowsZipFixtureAvailable() && approvedWindowsNodeFixtureAvailable() ? it : it.skip;
+const linuxPackagingIt = process.platform === "win32" ? it.skip : it;
 
 async function writeFakeWindowsNodeRuntimeZip(tmpDir: string, arch = "x64") {
   const runtimeRoot = path.join(tmpDir, "runtime-win");
@@ -369,7 +370,7 @@ describe("package-agent-cli", () => {
     expect(probes).toBe(0);
   });
 
-  it("creates the Linux x64 artifact with bin/agent and bundled node", async () => {
+  linuxPackagingIt("creates the Linux x64 artifact with bin/agent and bundled node", async () => {
     const rootDir = await writePackageFixture();
     const runtimeTarball = await writeFakeNodeRuntimeTarball(rootDir);
 
@@ -415,7 +416,7 @@ describe("package-agent-cli", () => {
     expect(readme).not.toContain("Harbor task containers");
   });
 
-  it("recursively deploys target optional dependencies and preserves nested version conflicts", async () => {
+  linuxPackagingIt("recursively deploys target optional dependencies and preserves nested version conflicts", async () => {
     const rootDir = await mkdtemp(path.join(os.tmpdir(), "sigma-package-dependency-graph-"));
     await writeFile(path.join(rootDir, "LICENSE"), "MIT License\n", "utf8");
     await writeBuiltPackage(rootDir, "agent-tui", { "@opentui/core": "0.4.3", "root-dep": "1.0.0" });
@@ -464,7 +465,7 @@ describe("package-agent-cli", () => {
     expect(wrapper).toContain("--experimental-ffi");
   });
 
-  it("uses a cached Node runtime tarball when env override is absent", async () => {
+  linuxPackagingIt("uses a cached Node runtime tarball when env override is absent", async () => {
     const rootDir = await writePackageFixture();
     const artifactsDir = path.join(rootDir, ".artifacts");
     const cacheDir = path.join(artifactsDir, "cache");
@@ -506,7 +507,7 @@ describe("package-agent-cli", () => {
     })).rejects.toThrow("exactly one SHA-256 digest for the exact file");
   });
 
-  it("auto-downloads the Node runtime tarball into cache when missing", async () => {
+  linuxPackagingIt("auto-downloads the Node runtime tarball into cache when missing", async () => {
     const rootDir = await writePackageFixture();
     const sourceTarball = await writeFakeNodeRuntimeTarball(rootDir);
     const sourceDigest = createHash("sha256").update(await readFile(sourceTarball)).digest("hex");
@@ -540,7 +541,7 @@ describe("package-agent-cli", () => {
     });
   });
 
-  it("verifies the release bundle structure and product metadata", async () => {
+  linuxPackagingIt("verifies the release bundle structure and product metadata", async () => {
     const rootDir = await writePackageFixture();
     const runtimeTarball = await writeFakeNodeRuntimeTarball(rootDir);
     const artifactsDir = path.join(rootDir, ".artifacts");
@@ -654,7 +655,7 @@ describe("package-agent-cli", () => {
     })).rejects.toThrow("is not an ELF binary");
   });
 
-  it("packages V3 broker/LSP assets with integrity, SBOM, checksum, and provenance", async () => {
+  linuxPackagingIt("packages V3 broker/LSP assets with integrity, SBOM, checksum, and provenance", async () => {
     const { rootDir, broker, version } = await writeV3PackageFixture();
     const runtimeTarball = await writeFakeNodeRuntimeTarball(rootDir);
     const runtimeSha256 = createHash("sha256").update(await readFile(runtimeTarball)).digest("hex");
@@ -742,7 +743,7 @@ describe("package-agent-cli", () => {
     })).rejects.toThrow("unexpected builder identity");
   });
 
-  it("rejects every unmanifested file in the portable bundle tree", async () => {
+  linuxPackagingIt("rejects every unmanifested file in the portable bundle tree", async () => {
     const { rootDir, broker } = await writeV3PackageFixture("linux");
     const runtimeTarball = await writeFakeNodeRuntimeTarball(rootDir);
     const artifactsDir = path.join(rootDir, ".artifacts");
@@ -774,7 +775,7 @@ describe("package-agent-cli", () => {
     })).rejects.toThrow("Integrity manifest omits portable bundle file");
   });
 
-  it("binds sidecar and provenance verification to the initially inspected archive bytes", async () => {
+  linuxPackagingIt("binds sidecar and provenance verification to the initially inspected archive bytes", async () => {
     const { rootDir, broker } = await writeV3PackageFixture("linux");
     const runtimeTarball = await writeFakeNodeRuntimeTarball(rootDir);
     const artifactsDir = path.join(rootDir, ".artifacts");
@@ -829,7 +830,7 @@ describe("package-agent-cli", () => {
     expect(replaced).toBe(true);
   });
 
-  it("verifies release provenance only against an externally trusted Ed25519 key", async () => {
+  linuxPackagingIt("verifies release provenance only against an externally trusted Ed25519 key", async () => {
     const { rootDir, broker } = await writeV3PackageFixture("linux");
     const runtimeTarball = await writeFakeNodeRuntimeTarball(rootDir);
     const artifactsDir = path.join(rootDir, ".artifacts");
@@ -1006,7 +1007,7 @@ describe("package-agent-cli", () => {
   // runner from a stuck package operation.
   }, 60_000);
 
-  it("can require the target wrapper smoke for release environments", async () => {
+  linuxPackagingIt("can require the target wrapper smoke for release environments", async () => {
     const rootDir = await writePackageFixture();
     const runtimeTarball = await writeFakeNodeRuntimeTarball(rootDir);
     const artifactsDir = path.join(rootDir, ".artifacts");


### PR DESCRIPTION
## What changed

- compare canonical evaluation output paths on Windows
- keep Linux pinned-executable coverage without executing a just-renamed file descriptor
- keep Linux archive integration tests on non-Windows hosts while retaining Windows package coverage
- cover process handoff and verified-shell validation branches

## Why

The release pipeline was blocked by Windows long/short path aliases, Linux `ETXTBSY` in a redundant test assertion, and Linux-container archive tests running against the Windows-hosted Docker daemon. After those failures were removed, an existing branch-coverage gap in `agent-execution/src/values.ts` became visible.

## Validation

- `pnpm test:coverage -- --maxWorkers=2 --testTimeout=20000` (126 files, 1163 tests passed)
- `pnpm eval:conformance` (214 tests passed)
- `pnpm lint`
- `cargo test --locked --manifest-path native/sigma-exec/Cargo.toml`
- `cargo fmt --manifest-path native/sigma-exec/Cargo.toml -- --check`
