### PR TITLE
Fix clean release runner setup

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -74,6 +74,11 @@ jobs:
       GLM_API_KEY: ${{ secrets.GLM_API_KEY }}
     steps:
       - uses: actions/checkout@v4
+      - name: Configure canonical runner temp directory
+        if: runner.os == 'Windows'
+        run: |
+          "TEMP=$env:RUNNER_TEMP" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "TMP=$env:RUNNER_TEMP" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}

--- a/scripts/release/stage-graph.ts
+++ b/scripts/release/stage-graph.ts
@@ -34,6 +34,7 @@ const neutral = [
 ] as const;
 
 const releaseQuality = [
+  stage("build", "pnpm", "build"),
   stage("lint", "pnpm", "lint"),
   stage("coverage", "pnpm", "test:coverage"),
   stage("native-coverage", "pnpm", "test:coverage:native-protocol"),

--- a/tests/package-scripts.test.ts
+++ b/tests/package-scripts.test.ts
@@ -41,7 +41,7 @@ describe("package script semantics", () => {
 
   it("keeps target release stages explicit, ordered, and isolated from secrets", async () => {
     expect(stageIds("release-linux")).toEqual([
-      "lint", "coverage", "native-coverage", "v4-replay", "product-smoke", "tui-smoke",
+      "build", "lint", "coverage", "native-coverage", "v4-replay", "product-smoke", "tui-smoke",
       "package", "sandbox", "lsp-sandbox", "provider-smoke", "readiness"
     ]);
     expect(stageIds("release-windows")).toEqual(stageIds("release-linux"));


### PR DESCRIPTION
## Summary

- build workspace packages before release coverage on clean runners
- canonicalize Windows TEMP/TMP to RUNNER_TEMP as in the proven CI job
- update the release stage graph contract test

## Root cause

The first v4.0.0 workflow_dispatch dry run exposed two clean-runner differences: coverage ran before the bundled TypeScript server entry was built, and the Windows release job used an 8.3 temporary path that disagreed with sandbox path canonicalization.

## Validation

- pnpm build
- pnpm lint
- pnpm test:coverage
- pnpm exec vitest run tests/package-scripts.test.ts tests/agent-cli.doctor.coverage.test.ts tests/agent-cli.test.ts
- release workflow YAML parse
- git diff --check