### PR TITLE
Normalize provider credentials at header boundary

### DIFF
--- a/packages/agent-model/src/openai-gateway.ts
+++ b/packages/agent-model/src/openai-gateway.ts
@@ -84,7 +84,10 @@ export class OpenAIModelGateway implements ModelGateway {
     this.provider = options.provider;
     this.model = options.model;
     this.baseUrl = options.baseUrl.replace(/\/+$/, "");
-    this.apiKey = options.apiKey;
+    // Secrets copied from files or CI settings can carry a UTF-8 BOM or a
+    // trailing line ending. Neither is credential material, and Fetch rejects
+    // non-ByteString header characters before the request reaches the provider.
+    this.apiKey = options.apiKey?.trim();
     this.apiKeyName = options.apiKeyName;
     this.capabilities = { ...defaultOpenAICapabilities, ...options.capabilities };
     this.maxRetries = Math.max(0, Math.trunc(options.maxRetries ?? 2));

--- a/tests/agent-model.gateway.test.ts
+++ b/tests/agent-model.gateway.test.ts
@@ -50,6 +50,17 @@ afterEach(() => {
 });
 
 describe("OpenAI-compatible model gateway", () => {
+  it("removes invisible file and CI framing from API keys before building headers", async () => {
+    let authorization = "";
+    const gateway = createGateway((async (_url, init) => {
+      authorization = (init?.headers as Record<string, string> | undefined)?.Authorization ?? "";
+      return jsonResponse("ok");
+    }) as typeof fetch, { apiKey: "\uFEFF  secret\r\n" });
+
+    await expect(gateway.complete(request())).resolves.toMatchObject({ message: { content: "ok" } });
+    expect(authorization).toBe("Bearer secret");
+  });
+
   it("parses split CRLF and multi-line SSE frames without losing the terminal payload", async () => {
     const encoder = new TextEncoder();
     const chunks = [


### PR DESCRIPTION
## Summary

- trim UTF-8 BOM and surrounding line endings from API keys before constructing Authorization headers
- add a regression test for CI/file-framed credentials

## Root cause

The v4.0.0 dry run reached the live DeepSeek provider smoke, where the configured secret began with U+FEFF. Fetch rejected the non-ByteString Authorization header before making a network request.

## Validation

- pnpm build
- pnpm lint
- pnpm test:coverage
- pnpm exec vitest run tests/agent-model.gateway.test.ts
- git diff --check