### PR TITLE
refactor: centralize durable task control

### DIFF
--- a/packages/agent-checkpoint/src/checkpoint-manager.ts
+++ b/packages/agent-checkpoint/src/checkpoint-manager.ts
@@ -12,6 +12,7 @@ import type {
   CheckpointReviewMaterial,
   CreateCheckpointInput,
   OpenCheckpointInspection,
+  RunRestorationInspection,
   SealedCheckpointInspection
 } from "./types.js";
 import { CheckpointConflictError, isCheckpointRecord } from "./types.js";
@@ -24,6 +25,9 @@ import { CheckpointCasStore } from "./cas-store.js";
 import { buildCheckpointReviewMaterial } from "./checkpoint-review.js";
 import { checkpointOpaqueArtifacts } from "./opaque-artifacts.js";
 import type { CheckpointRestoreFaultInjector } from "./fault-injection.js";
+import { runScopePaths } from "./run-restoration.js";
+import type { RestoreFinalization } from "./restore-transaction.js";
+import { RunRestorationCoordinator } from "./run-restoration-coordinator.js";
 
 export { checkpointDelta } from "./manifest.js";
 export class CheckpointManager {
@@ -201,6 +205,14 @@ export class CheckpointManager {
     return restored;
   }
 
+  async inspectRunRestoration(sessionId: string, runId: string): Promise<RunRestorationInspection> {
+    return await this.runRestorationCoordinator().inspect(sessionId, runId);
+  }
+
+  async restoreRunChanges(sessionId: string, runId: string): Promise<RunRestorationInspection> {
+    return await this.runRestorationCoordinator().restore(sessionId, runId);
+  }
+
   async restoreOpen(
     sessionId: string,
     checkpointId: string,
@@ -316,6 +328,10 @@ export class CheckpointManager {
     await durableReplaceFile(target, JSON.stringify(record, null, 2), { mode: 0o600 });
   }
 
+  private async writeRecords(records: readonly CheckpointRecord[]): Promise<void> {
+    for (const record of records) await this.writeRecord(record);
+  }
+
   private async readRecord(sessionId: string, checkpointId: string): Promise<CheckpointRecord> {
     const value: unknown = JSON.parse(await readFile(this.recordPath(sessionId, checkpointId), "utf8"));
     if (!isCheckpointRecord(value) || value.sessionId !== sessionId || value.checkpointId !== checkpointId) {
@@ -337,22 +353,26 @@ export class CheckpointManager {
     await recoverCheckpointTransactions({
       workspacePath: canonical,
       transactionRootDir: await this.transactionRoot(canonical),
-      finalize: async ({ record, desiredManifestDigest }) => {
-        if (record.schemaVersion !== 1 || record.status !== "restored"
-          || path.resolve(record.workspacePath) !== canonical
-          || record.preManifestDigest !== desiredManifestDigest) {
-          throw new CheckpointConflictError("Checkpoint recovery finalization identity is invalid.");
-        }
-        // Recompute the target through validated identifiers; never trust a path from the workspace journal.
-        this.recordPath(record.sessionId, record.checkpointId);
-        const current = await this.capture(canonical, record.scopePaths);
-        const currentDigest = await this.putManifest(current);
-        if (currentDigest !== desiredManifestDigest) {
-          throw new CheckpointConflictError("Verified checkpoint recovery no longer matches its desired manifest.");
-        }
-        await this.writeRecord(record);
-      }
+      finalize: async (finalization) => await this.finalizeRecovery(canonical, finalization)
     });
+  }
+
+  private async finalizeRecovery(canonical: string, finalization: RestoreFinalization): Promise<void> {
+    const records = finalization.kind === "run" ? finalization.records : [finalization.record];
+    if (records.some((record) => record.schemaVersion !== 1 || record.status !== "restored"
+      || path.resolve(record.workspacePath) !== canonical)) {
+      throw new CheckpointConflictError("Checkpoint recovery finalization identity is invalid.");
+    }
+    for (const record of records) this.recordPath(record.sessionId, record.checkpointId);
+    const scopes = finalization.kind === "run" ? runScopePaths(records) : records[0]!.scopePaths;
+    const current = await this.capture(canonical, scopes);
+    const currentDigest = await this.putManifest(current);
+    if (currentDigest !== finalization.desiredManifestDigest
+      || (finalization.kind !== "run"
+        && records[0]!.preManifestDigest !== finalization.desiredManifestDigest)) {
+      throw new CheckpointConflictError("Verified checkpoint recovery no longer matches its desired manifest.");
+    }
+    await this.writeRecords(records);
   }
 
   private async transactionRoot(workspacePath: string): Promise<string> {
@@ -360,6 +380,21 @@ export class CheckpointManager {
       workspacePath,
       stateRootDir: this.rootDir,
       namespace: "checkpoint-restore"
+    });
+  }
+
+  private runRestorationCoordinator(): RunRestorationCoordinator {
+    return new RunRestorationCoordinator({
+      list: async (sessionId) => await this.list(sessionId),
+      recover: async (workspacePath) => await this.recover(workspacePath),
+      capture: async (workspacePath, scopePaths, ignoredRootName) =>
+        await this.capture(workspacePath, scopePaths, ignoredRootName),
+      getManifest: async (digest) => await this.getManifest(digest),
+      putManifest: async (manifest) => await this.putManifest(manifest),
+      transactionRoot: async (workspacePath) => await this.transactionRoot(workspacePath),
+      writeRecords: async (records) => await this.writeRecords(records),
+      readCas: (digest) => this.cas.stream(digest),
+      ...(this.restoreFaultInjector ? { restoreFaultInjector: this.restoreFaultInjector } : {})
     });
   }
 }

--- a/packages/agent-checkpoint/src/restore-recovery-schema.ts
+++ b/packages/agent-checkpoint/src/restore-recovery-schema.ts
@@ -21,7 +21,7 @@ export interface RecoveryOperation {
 }
 
 export interface RecoveryJournal {
-  schemaVersion: 1 | 2 | 3;
+  schemaVersion: 1 | 2 | 3 | 4;
   phase: string;
   operations: RecoveryOperation[];
   directoryModes?: RestoreDirectoryMode[];
@@ -86,12 +86,22 @@ function recoveryOperation(value: unknown, schemaVersion: number): value is Reco
 
 function recoveryFinalization(value: unknown): value is RestoreFinalization {
   if (!value || typeof value !== "object" || Array.isArray(value)) return false;
-  const finalization = value as Partial<RestoreFinalization>;
-  return typeof finalization.desiredManifestDigest === "string"
-    && /^[a-f0-9]{64}$/u.test(finalization.desiredManifestDigest)
-    && isCheckpointRecord(finalization.record)
-    && finalization.record.status === "restored"
-    && finalization.record.preManifestDigest === finalization.desiredManifestDigest;
+  const finalization = value as Record<string, unknown>;
+  if (typeof finalization.desiredManifestDigest !== "string"
+    || !/^[a-f0-9]{64}$/u.test(finalization.desiredManifestDigest)) return false;
+  if (finalization.kind !== "run") {
+    return isCheckpointRecord(finalization.record)
+      && finalization.record.status === "restored"
+      && finalization.record.preManifestDigest === finalization.desiredManifestDigest;
+  }
+  if (!Array.isArray(finalization.records) || finalization.records.length === 0
+    || !finalization.records.every(isCheckpointRecord)
+    || finalization.records.some((record) => record.status !== "restored")) return false;
+  const records = finalization.records;
+  return new Set(records.map((record) => record.checkpointId)).size === records.length
+    && records.every((record) => record.sessionId === records[0]!.sessionId
+      && record.runId === records[0]!.runId
+      && record.workspacePath === records[0]!.workspacePath);
 }
 
 function recoveryDirectoryMode(value: unknown): value is RestoreDirectoryMode {
@@ -107,7 +117,7 @@ function recoveryDirectoryMode(value: unknown): value is RestoreDirectoryMode {
 }
 
 function recoverySchemaVersion(value: unknown): value is RecoveryJournal["schemaVersion"] {
-  return value === 1 || value === 2 || value === 3;
+  return value === 1 || value === 2 || value === 3 || value === 4;
 }
 
 function recoveryPhase(value: unknown): value is string {
@@ -120,7 +130,7 @@ function operationsHaveUniqueIndices(operations: readonly RecoveryOperation[]): 
 }
 
 function validDirectoryModes(candidate: Partial<RecoveryJournal>): boolean {
-  if (candidate.schemaVersion !== 3) return true;
+  if ((candidate.schemaVersion ?? 0) < 3) return true;
   return Array.isArray(candidate.directoryModes)
     && candidate.directoryModes.every(recoveryDirectoryMode);
 }

--- a/packages/agent-checkpoint/src/restore-transaction-operations.ts
+++ b/packages/agent-checkpoint/src/restore-transaction-operations.ts
@@ -120,7 +120,7 @@ function journalValue(
       ...(desired.has(entryPath) ? { desiredMode: desired.get(entryPath) } : {})
     }));
   return JSON.stringify({
-    schemaVersion: 3,
+    schemaVersion: 4,
     phase,
     finalization: options.finalization,
     directoryModes,

--- a/packages/agent-checkpoint/src/restore-transaction-types.ts
+++ b/packages/agent-checkpoint/src/restore-transaction-types.ts
@@ -31,10 +31,19 @@ export interface RestoreTransactionOptions {
   faultInjector?: (event: CheckpointRestoreFaultEvent) => void | Promise<void>;
 }
 
-export interface RestoreFinalization {
+export interface CheckpointRestoreFinalization {
+  kind?: "checkpoint";
   record: CheckpointRecord;
   desiredManifestDigest: string;
 }
+
+export interface RunRestoreFinalization {
+  kind: "run";
+  records: CheckpointRecord[];
+  desiredManifestDigest: string;
+}
+
+export type RestoreFinalization = CheckpointRestoreFinalization | RunRestoreFinalization;
 
 export interface RestoreDirectoryMode {
   path: string;

--- a/packages/agent-checkpoint/src/run-restoration-coordinator.ts
+++ b/packages/agent-checkpoint/src/run-restoration-coordinator.ts
@@ -1,0 +1,114 @@
+import type {
+  CheckpointManifest,
+  CheckpointRecord,
+  RunRestorationInspection
+} from "./types.js";
+import { CheckpointConflictError } from "./types.js";
+import type { CheckpointRestoreFaultInjector } from "./fault-injection.js";
+import {
+  reconstructRunBaseline,
+  runScopePaths,
+  semanticManifestDigest,
+  type RunCheckpointImage
+} from "./run-restoration.js";
+import { manifestEqual } from "./restore-manifest-validation.js";
+import { restoreCheckpointTransaction } from "./restore-transaction.js";
+import type { RestoreCasReader } from "./restore-cas.js";
+
+export interface RunRestorationDependencies {
+  list(sessionId: string): Promise<CheckpointRecord[]>;
+  recover(workspacePath: string): Promise<void>;
+  capture(workspacePath: string, scopePaths: readonly string[], ignoredRootName?: string): Promise<CheckpointManifest>;
+  getManifest(digest: string): Promise<CheckpointManifest>;
+  putManifest(manifest: CheckpointManifest): Promise<string>;
+  transactionRoot(workspacePath: string): Promise<string>;
+  writeRecords(records: readonly CheckpointRecord[]): Promise<void>;
+  readCas: RestoreCasReader;
+  restoreFaultInjector?: CheckpointRestoreFaultInjector;
+}
+
+/** Coordinates whole-run restoration while CheckpointManager remains the
+ * authority for storage, capture, recovery, and transaction paths. */
+export class RunRestorationCoordinator {
+  constructor(private readonly dependencies: RunRestorationDependencies) {}
+
+  async inspect(sessionId: string, runId: string): Promise<RunRestorationInspection> {
+    const records = (await this.dependencies.list(sessionId)).filter((item) => item.runId === runId);
+    if (records.length === 0) {
+      throw new CheckpointConflictError(`Run ${runId} has no checkpoint history to confirm.`);
+    }
+    const workspacePath = records[0]!.workspacePath;
+    await this.dependencies.recover(workspacePath);
+    const currentRecords = (await this.dependencies.list(sessionId)).filter((item) => item.runId === runId);
+    const images = await this.runImages(currentRecords);
+    const scopes = runScopePaths(currentRecords);
+    const current = await this.dependencies.capture(workspacePath, scopes);
+    const desired = reconstructRunBaseline(current, images).desired;
+    return {
+      checkpoints: currentRecords,
+      baselineManifestDigest: semanticManifestDigest(desired),
+      currentManifestDigest: semanticManifestDigest(current),
+      restored: manifestEqual(current, desired)
+    };
+  }
+
+  async restore(sessionId: string, runId: string): Promise<RunRestorationInspection> {
+    const all = await this.dependencies.list(sessionId);
+    const unresolved = all.filter((item) => item.status !== "restored");
+    if (unresolved.some((item) => item.status === "open")) {
+      throw new CheckpointConflictError("Resolve the open checkpoint before restoring run changes.");
+    }
+    const first = unresolved.findIndex((item) => item.runId === runId);
+    if (first < 0 || unresolved.slice(first).some((item) => item.runId !== runId)) {
+      throw new CheckpointConflictError(`Run ${runId} is not the latest restorable checkpoint group.`);
+    }
+    const records = unresolved.slice(first);
+    const workspacePath = records[0]!.workspacePath;
+    if (records.some((item) => item.workspacePath !== workspacePath || !item.postManifestDigest)) {
+      throw new CheckpointConflictError("Run checkpoint history is incomplete or crosses workspace roots.");
+    }
+    await this.dependencies.recover(workspacePath);
+    const scopes = runScopePaths(records);
+    const current = await this.dependencies.capture(workspacePath, scopes);
+    const reconstructed = reconstructRunBaseline(current, await this.runImages(records));
+    if (!reconstructed.chainMatches) {
+      throw new CheckpointConflictError("Workspace no longer matches the recorded run checkpoint chain.");
+    }
+    const desiredManifestDigest = await this.dependencies.putManifest(reconstructed.desired);
+    const restoredAt = new Date().toISOString();
+    const restored = records.map((record): CheckpointRecord => ({ ...record, status: "restored", restoredAt }));
+    await restoreCheckpointTransaction({
+      workspacePath,
+      transactionRootDir: await this.dependencies.transactionRoot(workspacePath),
+      desired: reconstructed.desired,
+      current,
+      readCas: (digest) => this.dependencies.readCas(digest),
+      capture: async (ignoredRootName) => await this.dependencies.capture(workspacePath, scopes, ignoredRootName),
+      finalization: { kind: "run", records: restored, desiredManifestDigest },
+      finalize: async () => await this.dependencies.writeRecords(restored),
+      ...(this.dependencies.restoreFaultInjector
+        ? { faultInjector: this.dependencies.restoreFaultInjector }
+        : {})
+    });
+    const manifestDigest = semanticManifestDigest(reconstructed.desired);
+    return {
+      checkpoints: restored,
+      baselineManifestDigest: manifestDigest,
+      currentManifestDigest: manifestDigest,
+      restored: true
+    };
+  }
+
+  private async runImages(records: readonly CheckpointRecord[]): Promise<RunCheckpointImage[]> {
+    return await Promise.all(records.map(async (record) => {
+      if (!record.postManifestDigest) {
+        throw new CheckpointConflictError(`Checkpoint ${record.checkpointId} has no sealed postimage.`);
+      }
+      return {
+        record,
+        before: await this.dependencies.getManifest(record.preManifestDigest),
+        after: await this.dependencies.getManifest(record.postManifestDigest)
+      };
+    }));
+  }
+}

--- a/packages/agent-checkpoint/src/run-restoration.ts
+++ b/packages/agent-checkpoint/src/run-restoration.ts
@@ -1,0 +1,74 @@
+import { createHash } from "node:crypto";
+import { manifestEqual } from "./restore-manifest-validation.js";
+import type { CheckpointManifest, CheckpointRecord } from "./types.js";
+
+export interface RunCheckpointImage {
+  record: CheckpointRecord;
+  before: CheckpointManifest;
+  after: CheckpointManifest;
+}
+
+function inScopes(entryPath: string, scopes: readonly string[]): boolean {
+  return scopes.some((scope) => scope === "." || entryPath === scope || entryPath.startsWith(`${scope}/`));
+}
+
+function manifest(entries: CheckpointManifest["entries"]): CheckpointManifest {
+  const ordered = [...entries].sort((left, right) => left.path.localeCompare(right.path));
+  return {
+    entries: ordered,
+    fileCount: ordered.length,
+    totalBytes: ordered.reduce((total, entry) => total + (entry.kind === "file" ? entry.size : 0), 0)
+  };
+}
+
+function scoped(source: CheckpointManifest, scopes: readonly string[]): CheckpointManifest {
+  return manifest(source.entries.filter((entry) => inScopes(entry.path, scopes)));
+}
+
+function replaceScopes(
+  source: CheckpointManifest,
+  scopes: readonly string[],
+  replacement: CheckpointManifest
+): CheckpointManifest {
+  return manifest([
+    ...source.entries.filter((entry) => !inScopes(entry.path, scopes)),
+    ...replacement.entries
+  ]);
+}
+
+/** Reconstruct the state before the first checkpoint without touching the
+ * workspace. Reverse postimage checks establish that a destructive restore
+ * still starts from the exact recorded checkpoint chain. */
+export function reconstructRunBaseline(
+  current: CheckpointManifest,
+  images: readonly RunCheckpointImage[]
+): { desired: CheckpointManifest; chainMatches: boolean } {
+  let image = current;
+  let chainMatches = true;
+  for (const checkpoint of [...images].reverse()) {
+    if (!manifestEqual(scoped(image, checkpoint.record.scopePaths), checkpoint.after)) {
+      chainMatches = false;
+    }
+    image = replaceScopes(image, checkpoint.record.scopePaths, checkpoint.before);
+  }
+  return { desired: image, chainMatches };
+}
+
+export function runScopePaths(records: readonly CheckpointRecord[]): string[] {
+  const candidates = [...new Set(records.flatMap((record) => record.scopePaths))]
+    .sort((left, right) => left.length - right.length || left.localeCompare(right));
+  return candidates.filter((value, index) => !candidates.slice(0, index).some((parent) =>
+    parent === "." || value === parent || value.startsWith(`${parent}/`)));
+}
+
+export function semanticManifestDigest(value: CheckpointManifest): string {
+  return createHash("sha256").update(JSON.stringify(value.entries.map((entry) => ({
+    path: entry.path,
+    kind: entry.kind,
+    mode: entry.mode,
+    size: entry.size,
+    digest: entry.digest ?? null,
+    linkTarget: entry.linkTarget ?? null,
+    linkType: entry.linkType ?? null
+  })))).digest("hex");
+}

--- a/packages/agent-checkpoint/src/types.ts
+++ b/packages/agent-checkpoint/src/types.ts
@@ -157,6 +157,13 @@ export interface SealedCheckpointInspection {
   changed: boolean;
 }
 
+export interface RunRestorationInspection {
+  checkpoints: CheckpointRecord[];
+  baselineManifestDigest: string;
+  currentManifestDigest: string;
+  restored: boolean;
+}
+
 export class CheckpointConflictError extends Error {
   readonly code = "checkpoint_conflict";
 

--- a/packages/agent-cli/src/config.ts
+++ b/packages/agent-cli/src/config.ts
@@ -56,6 +56,7 @@ export interface CliConfig {
   outputFormat: "text" | "json" | "stream-json";
   outputSchema: 2 | 3;
   streamJsonMaxLineBytes: number;
+  initialMode: "analyze" | "change";
   tuiFps: number;
   mcpServers: McpServerConfigValue[];
   mcpSource: McpConfigSource;
@@ -246,6 +247,7 @@ function cliConfig(
     outputFormat: values.outputFormat as CliConfig["outputFormat"],
     outputSchema: Number(values.outputSchema) as 2 | 3,
     streamJsonMaxLineBytes: Number(values.streamJsonMaxLineBytes),
+    initialMode: values.initialMode as CliConfig["initialMode"],
     tuiFps: Number(values.tuiFps),
     mcpServers,
     mcpSource: source,

--- a/packages/agent-cli/src/index.ts
+++ b/packages/agent-cli/src/index.ts
@@ -57,7 +57,7 @@ async function runTuiCommand(argv: string[], options: AgentCliMainOptions): Prom
   const tuiOptions: TuiAppOptions = {
     runtime: configured.runtime,
     workspace: configured.workspace,
-    mode: "change",
+    mode: cliConfig.initialMode,
     maxFps: cliConfig.tuiFps,
     sessionId: typeof flags.session === "string" ? flags.session : undefined
   };

--- a/packages/agent-config/src/schema.ts
+++ b/packages/agent-config/src/schema.ts
@@ -197,6 +197,7 @@ export const SIGMA_CONFIG_SCHEMA: readonly ConfigField[] = [
       throw new Error("Configuration 'streamJsonMaxLineBytes' must be 0 or an integer of at least 4096.");
     return value;
   } },
+  { key: "initialMode", flag: "initial-mode", description: "Initial TUI session mode", defaultValue: "change", parse: (raw) => enumValue(raw, "initialMode", ["analyze", "change"] as const) },
   { key: "tuiFps", flag: "tui-fps", env: "SIGMA_TUI_FPS", toml: "tui.fps", description: "Maximum TUI frames per second", defaultValue: 30, parse: (raw) => numberValue(raw, "tuiFps", 1, 30) },
   { key: "mcpServers", flag: "mcp-server", kind: "repeatable", env: "SIGMA_MCP_SERVERS", toml: "mcp.servers", description: "MCP stdio server JSON (repeatable)", defaultValue: [], parse: mcpServersValue },
   {

--- a/packages/agent-kernel/src/durable-reducers.ts
+++ b/packages/agent-kernel/src/durable-reducers.ts
@@ -15,6 +15,14 @@ import { frontierAfterCheckpoint, frontierAfterEvidence } from "./mutation-front
 import { nextPhase } from "./terminal-reducer-helpers.js";
 import { recordSemanticEvidenceProgress, recordSemanticWorkspaceRestore } from "./semantic-failures.js";
 import { durableBudgetReducers } from "./durable-budget-reducers.js";
+import { reviewTaskControl } from "./review-task-control-reducer.js";
+import {
+  advanceReviewRepair,
+  completionEvidenceObligation,
+  recordSemanticFact,
+  resolveTaskObligation,
+  terminalResolutionObligation
+} from "./task-control.js";
 
 export type KernelEventReducer = (
   state: KernelState,
@@ -41,39 +49,112 @@ function evidenceAuthorityAllowed(event: AgentEventEnvelope, evidence: EvidenceR
 }
 
 function isEvidenceAcquisitionRepair(state: KernelState): boolean {
-  if (state.completionRepair?.kind === "evidence_acquisition") return true;
-  return state.completionRepair === undefined
-    && state.completionRepairAttempts > 0
-    && !state.evidence.some((item) =>
-      isCompletionReferenceableEvidence(item, state.sessionId, state.runId));
+  return state.taskControl.obligation?.kind === "completion_evidence"
+    && state.taskControl.obligation.stage === "acquire";
 }
 
-const evidenceRecorded: KernelEventReducer = (state, event) => {
-  const evidence = event.payload;
-  if (!isEvidenceRecord(evidence) || evidence.sessionId !== state.sessionId || evidence.runId !== state.runId
-    || event.runId !== state.runId || !evidenceAuthorityAllowed(event, evidence)
-    || state.evidence.some((item) => item.evidenceId === evidence.evidenceId)) return state;
-  if (evidence.kind === "user_waiver" && state.evidence.some((item) => item.kind === "user_waiver")) return state;
-  const firstCompletionEvidence = isEvidenceAcquisitionRepair(state)
-    && isCompletionReferenceableEvidence(evidence, state.sessionId, state.runId)
-    && !state.evidence.some((item) => isCompletionReferenceableEvidence(item, state.sessionId, state.runId));
+function canRecordEvidence(
+  state: KernelState,
+  event: AgentEventEnvelope,
+  evidence: EvidenceRecord
+): boolean {
+  return evidence.sessionId === state.sessionId && evidence.runId === state.runId
+    && event.runId === state.runId && evidenceAuthorityAllowed(event, evidence)
+    && !state.evidence.some((item) => item.evidenceId === evidence.evidenceId)
+    && !(evidence.kind === "user_waiver" && state.evidence.some((item) => item.kind === "user_waiver"));
+}
+
+function appendEvidence(state: KernelState, evidence: EvidenceRecord): KernelState {
   const mutationEvidence = MUTATION_EVIDENCE_KINDS.has(evidence.kind)
     && !state.mutationEvidence.some((item) => item.evidenceId === evidence.evidenceId)
     ? [...state.mutationEvidence, evidence]
     : state.mutationEvidence;
-  const progressed = recordSemanticEvidenceProgress({
+  return applyWorkspaceRestorationEvidence(recordSemanticEvidenceProgress({
     ...state,
     evidence: [...state.evidence, evidence],
     mutationEvidence,
     mutationFrontier: frontierAfterEvidence(state.mutationFrontier, mutationEvidence, evidence)
-  }, evidence);
-  const repaired: KernelState = firstCompletionEvidence
-    ? isCompletionEligibleEvidence(evidence, state.sessionId, state.runId)
-      ? { ...progressed, completionRepairAttempts: 0, completionRepair: undefined }
-      : { ...progressed, completionRepairAttempts: Math.max(1, state.completionRepairAttempts), completionRepair: { kind: "terminal_action" } }
-    : progressed;
-  return repaired;
+  }, evidence), evidence);
+}
+
+function settleFirstCompletionEvidence(
+  state: KernelState,
+  evidence: EvidenceRecord,
+  firstCompletionEvidence: boolean
+): KernelState {
+  if (!firstCompletionEvidence) return state;
+  if (isCompletionEligibleEvidence(evidence, state.sessionId, state.runId)) {
+    return { ...state, taskControl: resolveTaskObligation(state.taskControl) };
+  }
+  return {
+    ...state,
+    taskControl: completionEvidenceObligation(
+      state.taskControl,
+      state.revision,
+      "terminal",
+      currentReferenceableEvidenceCount(state)
+    )
+  };
+}
+
+const evidenceRecorded: KernelEventReducer = (state, event) => {
+  const evidence = event.payload;
+  if (!isEvidenceRecord(evidence) || !canRecordEvidence(state, event, evidence)) return state;
+  const firstCompletionEvidence = isEvidenceAcquisitionRepair(state)
+    && isCompletionReferenceableEvidence(evidence, state.sessionId, state.runId)
+    && !state.evidence.some((item) => isCompletionReferenceableEvidence(item, state.sessionId, state.runId));
+  const repaired = settleFirstCompletionEvidence(appendEvidence(state, evidence), evidence, firstCompletionEvidence);
+  return advanceEvidenceObligation(
+    evidence.kind === "review" ? reviewTaskControl(repaired, evidence) : repaired,
+    evidence
+  );
 };
+
+function applyWorkspaceRestorationEvidence(state: KernelState, evidence: EvidenceRecord): KernelState {
+  if (evidence.kind !== "restoration" || evidence.status !== "passed") return state;
+  const data = evidence.data;
+  const frontier = state.mutationFrontier;
+  const explicitRestore = data.restoredCheckpointIds.length > 0;
+  if (data.goalEpoch !== state.taskControl.goalEpoch
+    || data.frontierRevision !== frontier.revision
+    || data.frontierStateDigest !== frontier.currentStateDigest
+    || data.baselineManifestDigest !== data.currentManifestDigest
+    || (!explicitRestore && state.taskControl.goalEpochSource !== "steer")
+    || frontier.repositoryStateDigest !== undefined) return state;
+  return {
+    ...state,
+    mutationFrontier: {
+      revision: frontier.revision + 1,
+      baselineManifestDigest: data.currentManifestDigest,
+      currentStateDigest: data.currentManifestDigest,
+      changedPaths: [],
+      sourceCheckpointIds: []
+    }
+  };
+}
+
+function advanceEvidenceObligation(state: KernelState, evidence: EvidenceRecord): KernelState {
+  const obligation = state.taskControl.obligation;
+  if (obligation?.kind !== "review_repair") return state;
+  if (obligation.stage === "mutate" && evidence.kind === "workspace_delta"
+    && isCompletionEligibleEvidence(evidence, state.sessionId, state.runId)) {
+    return { ...state, taskControl: advanceReviewRepair(state.taskControl, "validate", state.revision) };
+  }
+  if (obligation.stage === "validate" && evidence.kind === "validation") {
+    return {
+      ...state,
+      taskControl: evidence.status === "passed"
+        ? advanceReviewRepair(state.taskControl, "re_review", state.revision)
+        : terminalResolutionObligation(state.taskControl, state.revision, "validation_failed")
+    };
+  }
+  return state;
+}
+
+function currentReferenceableEvidenceCount(state: KernelState): number {
+  return state.evidence.filter((item) =>
+    isCompletionReferenceableEvidence(item, state.sessionId, state.runId)).length;
+}
 
 const usageRecorded: KernelEventReducer = (state, event) => {
   const usage = event.payload;
@@ -85,7 +166,12 @@ const usageRecorded: KernelEventReducer = (state, event) => {
 const planUpdated: KernelEventReducer = (state, _event, payload) => {
   if (!isPlanGraph(payload.plan) || !Number.isSafeInteger(payload.previousRevision)
     || payload.previousRevision !== state.plan.revision || payload.plan.revision !== state.plan.revision + 1) return state;
-  return { ...state, plan: payload.plan };
+  const fact = recordSemanticFact(state.taskControl, "plan", {
+    revision: payload.plan.revision,
+    activeNodeId: payload.plan.activeNodeId,
+    nodes: payload.plan.nodes.map((node) => ({ id: node.id, status: node.status }))
+  }, state.revision);
+  return { ...state, plan: payload.plan, taskControl: fact.control };
 };
 
 function pruneRestoredCheckpointEvidence(
@@ -109,16 +195,14 @@ function pruneRestoredCheckpointEvidence(
 function checkpointRepairUpdate(
   state: KernelState,
   evidence: readonly EvidenceRecord[]
-): Partial<Pick<KernelState, "completionRepairAttempts" | "completionRepair" | "messages">> {
-  const repair = state.completionRepair;
-  const protectedOrTerminal = repair?.kind === "protected_completion"
-    || repair?.kind === "protected_recovery"
-    || repair?.kind === "terminal_action";
+): Partial<Pick<KernelState, "taskControl" | "messages">> {
+  const repair = state.taskControl.obligation;
+  const protectedOrTerminal = repair?.kind === "completion_evidence" && repair.stage === "terminal"
+    || repair?.kind === "terminal_resolution";
   if (!protectedOrTerminal || evidence.some((item) =>
     isCompletionReferenceableEvidence(item, state.sessionId, state.runId))) return {};
   return {
-    completionRepairAttempts: Math.max(1, state.completionRepairAttempts),
-    completionRepair: { kind: "evidence_acquisition" },
+    taskControl: completionEvidenceObligation(state.taskControl, state.revision, "acquire", 0),
     messages: [...state.messages, {
       role: "developer",
       content: "Checkpoint restoration removed the durable evidence for the pending terminal result. Obtain fresh current-run evidence before finalizing; request user input only if a concrete decision is genuinely required."
@@ -230,12 +314,26 @@ const processSpawned: KernelEventReducer = (state, event, payload) => {
   if (event.authority !== "runtime" || event.runId !== state.runId
     || typeof payload.processId !== "string" || !payload.processId
     || state.activeProcessIds.includes(payload.processId)) return state;
-  return { ...state, activeProcessIds: [...state.activeProcessIds, payload.processId] };
+  const fact = recordSemanticFact(state.taskControl, "process_lifecycle", {
+    processId: payload.processId, status: "spawned"
+  }, state.revision);
+  return {
+    ...state,
+    activeProcessIds: [...state.activeProcessIds, payload.processId],
+    taskControl: fact.control
+  };
 };
 
 const processSettled: KernelEventReducer = (state, event, payload) => {
   if (event.authority !== "runtime" || typeof payload.processId !== "string") return state;
-  return { ...state, activeProcessIds: state.activeProcessIds.filter((id) => id !== payload.processId) };
+  const fact = recordSemanticFact(state.taskControl, "process_lifecycle", {
+    processId: payload.processId, status: event.type
+  }, state.revision);
+  return {
+    ...state,
+    activeProcessIds: state.activeProcessIds.filter((id) => id !== payload.processId),
+    taskControl: fact.control
+  };
 };
 
 export const durableReducers: Partial<Record<AgentEventType, KernelEventReducer>> = {

--- a/packages/agent-kernel/src/durable-reducers.ts
+++ b/packages/agent-kernel/src/durable-reducers.ts
@@ -123,6 +123,7 @@ function applyWorkspaceRestorationEvidence(state: KernelState, evidence: Evidenc
     || frontier.repositoryStateDigest !== undefined) return state;
   return {
     ...state,
+    taskControl: resolveTaskObligation(state.taskControl),
     mutationFrontier: {
       revision: frontier.revision + 1,
       baselineManifestDigest: data.currentManifestDigest,

--- a/packages/agent-kernel/src/index.ts
+++ b/packages/agent-kernel/src/index.ts
@@ -5,3 +5,5 @@ export * from "./effects.js";
 export * from "./rehydrate.js";
 export * from "./semantic-failures.js";
 export * from "./durable-budget-reducers.js";
+export * from "./task-control-state.js";
+export * from "./task-control.js";

--- a/packages/agent-kernel/src/model-convergence.ts
+++ b/packages/agent-kernel/src/model-convergence.ts
@@ -1,17 +1,25 @@
-import { isCompletionReferenceableEvidence, type JsonValue, type ModelMessage, type ModelToolCall, type RunOutcome, type ToolReceipt } from "agent-protocol";
+import {
+  isCompletionReferenceableEvidence,
+  type JsonValue,
+  type ModelMessage,
+  type ModelToolCall,
+  type RunOutcome,
+  type ToolReceipt
+} from "agent-protocol";
 import type { KernelState } from "./state.js";
+import {
+  protectCompletionCandidate,
+  recordToolPolicyViolation,
+  startActionBatch,
+  taskControlAnswer,
+  taskControlFailureMessage,
+  terminalResolutionObligation
+} from "./task-control.js";
 
 const TERMINAL_PROTOCOL_FAILURE_CODES = new Set([
-  "invalid_completion_proposal",
-  "invalid_blocked_report",
-  "invalid_user_input_request",
-  "internal_tool_denied",
-  "mode_denied",
-  "profile_denied",
-  "terminal_batch_conflict",
-  "tool_arguments_invalid",
-  "tool_unavailable_for_repair",
-  "unknown_tool"
+  "invalid_completion_proposal", "invalid_blocked_report", "invalid_user_input_request",
+  "internal_tool_denied", "mode_denied", "profile_denied", "terminal_batch_conflict",
+  "tool_arguments_invalid", "tool_unavailable_for_repair", "unknown_tool", "model_tool_policy_violation"
 ]);
 
 function propose(state: KernelState, outcome: RunOutcome): KernelState {
@@ -25,28 +33,20 @@ function propose(state: KernelState, outcome: RunOutcome): KernelState {
 }
 
 export function protectedCompletionAnswer(state: KernelState): string | null {
-  return state.completionRepair?.kind === "protected_completion"
-    || state.completionRepair?.kind === "protected_recovery"
-    || state.completionRepair?.kind === "completion_prerequisite"
-    ? state.completionRepair.answer
-    : null;
+  return taskControlAnswer(state.taskControl);
 }
 
 export function hasCompletionRepair(state: KernelState): boolean {
-  return state.completionRepair !== undefined || state.completionRepairAttempts > 0;
+  return Boolean(state.taskControl.obligation || state.taskControl.policyCorrection
+    || state.taskControl.phase !== "normal");
 }
 
 export function completionRepairRequiresTerminalAction(state: KernelState): boolean {
-  if (state.completionRepair?.kind === "evidence_acquisition") return false;
-  if (state.completionRepair?.kind === "protected_recovery") return false;
-  if (state.completionRepair?.kind === "completion_prerequisite") {
-    return state.pendingTools.some((item) => item.request.name === "runtime_finalize");
-  }
-  if (state.completionRepair?.kind === "terminal_action"
-    || state.completionRepair?.kind === "protected_completion") return true;
-  // Compatibility for snapshots written before the explicit repair intent was
-  // introduced. Newly reduced states always carry completionRepair.
-  return state.completionRepairAttempts > 0 && hasCurrentRunEvidence(state);
+  const obligation = state.taskControl.obligation;
+  return state.taskControl.phase === "terminal"
+    || obligation?.kind === "terminal_resolution"
+    || obligation?.kind === "user_decision"
+    || (obligation?.kind === "completion_evidence" && obligation.stage === "terminal");
 }
 
 export function currentRunReferenceableEvidenceCount(state: KernelState): number {
@@ -55,9 +55,7 @@ export function currentRunReferenceableEvidenceCount(state: KernelState): number
 }
 
 export function completionRepairFailureMessage(state: KernelState, detail: string): string {
-  const answer = protectedCompletionAnswer(state);
-  if (!answer || detail.startsWith(answer)) return detail;
-  return `${answer}\n\n[Completion protocol repair failed: ${detail}]`;
+  return taskControlFailureMessage(state.taskControl, detail);
 }
 
 export function completionSummary(receipt: ToolReceipt): string | null {
@@ -71,9 +69,7 @@ export function completionSummary(receipt: ToolReceipt): string | null {
     return warnings.length > 0
       ? `${proposal.summary}\n\nWarnings:\n${warnings.map((item) => `- ${item}`).join("\n")}`
       : proposal.summary;
-  } catch {
-    return null;
-  }
+  } catch { return null; }
 }
 
 export function requestedInput(receipt: ToolReceipt): string | null {
@@ -82,9 +78,7 @@ export function requestedInput(receipt: ToolReceipt): string | null {
     const value = JSON.parse(receipt.output) as unknown;
     return value && typeof value === "object" && typeof (value as { message?: unknown }).message === "string"
       ? (value as { message: string }).message : null;
-  } catch {
-    return null;
-  }
+  } catch { return null; }
 }
 
 export function blockedReport(receipt: ToolReceipt): { code: string; message: string } | null {
@@ -105,78 +99,66 @@ export function failedTerminalRepairState(
   receipt: ToolReceipt,
   remainingTools: number
 ): KernelState | null {
-  if (!repairPending || remainingTools !== 0) return null;
+  if (remainingTools !== 0) return null;
   const protocolCodes = receipt.diagnostics.filter((code) => TERMINAL_PROTOCOL_FAILURE_CODES.has(code));
-  if (protocolCodes.length === 0 && !receipt.ok) {
-    if (!terminalRepairPending) return null;
-    const answer = protectedCompletionAnswer(state);
-    return {
-      ...state,
-      completionRepairAttempts: 0,
-      completionRepair: answer ? { kind: "protected_recovery", answer } : undefined
-    };
-  }
-  if (protocolCodes.length === 0 && !terminalRepairPending) return null;
+  if (protocolCodes.length === 0 && (!repairPending || !terminalRepairPending)) return null;
   const detail = protocolCodes.length > 0 ? protocolCodes.join(", ") : "terminal_action_missing";
-  if (state.completionRepairAttempts < 2) {
+  const batchPolicyRecorded = protocolCodes.some((code) =>
+    code === "model_tool_policy_violation" || code === "tool_unavailable_for_repair");
+  const taskControl = batchPolicyRecorded && state.taskControl.policyCorrection
+    ? state.taskControl
+    : recordToolPolicyViolation(
+        state.taskControl,
+        detail,
+        state.revision
+      );
+  if (taskControl.phase !== "terminal") {
     return {
       ...state,
       phase: "ready_model",
-      completionRepairAttempts: state.completionRepairAttempts + 1,
+      taskControl,
       messages: [...state.messages, {
         role: "developer",
-        content: `The terminal action was invalid (${detail}). Correct the arguments or continue repairing the reported blocker; all normal tools remain available.`
+        content: `The task-control action was rejected (${detail}). Use exactly one currently offered action.`
       }]
     };
   }
-  return propose(state, {
+  return propose({ ...state, taskControl }, {
     kind: "recoverable_failure",
-    code: "convergence_no_progress",
-    message: completionRepairFailureMessage(
-      state,
-      `The terminal action remained invalid after two correction turns (${detail}).`
-    )
+    code: taskControl.obligation?.kind === "terminal_resolution"
+      ? taskControl.obligation.failureCode : "model_tool_policy_violation",
+    message: completionRepairFailureMessage(state, `Task-control correction was rejected twice (${detail}).`)
   });
 }
 
-export function conflictingTerminalBatch(
-  calls: readonly ModelToolCall[],
-  repairPending: boolean
-): boolean {
-  const completionCount = calls.filter((call) => call.name === "runtime_finalize").length;
-  const blockedCount = calls.filter((call) => call.name === "report_blocked").length;
-  const inputRequestCount = calls.filter((call) => call.name === "request_user_input").length;
-  const terminalCount = completionCount + blockedCount + inputRequestCount;
-  if (terminalCount === 0) return false;
-  if (repairPending) return calls.length > 1 || terminalCount > 1;
-  return inputRequestCount > 0 ? calls.length > 1 : terminalCount > 1;
+export function conflictingTerminalBatch(calls: readonly ModelToolCall[], repairPending: boolean): boolean {
+  const terminal = calls.filter((call) => [
+    "runtime_finalize", "report_blocked", "request_user_input"
+  ].includes(call.name)).length;
+  return terminal > 0 && (calls.length > 1 || terminal > 1 || (repairPending && calls.length !== 1));
 }
 
-export function repairConflictingTerminalBatch(
-  state: KernelState,
-  messages: ModelMessage[]
-): KernelState {
-  if (state.completionRepairAttempts >= 1) {
-    return propose({ ...state, messages }, {
-      kind: "recoverable_failure",
-      code: "terminal_batch_conflict",
-      message: completionRepairFailureMessage(
-        state,
-        "The model repeatedly mixed a terminal protocol action with other tool calls."
-      )
-    });
-  }
-  return {
-    ...state,
-    messages: [...messages, {
-      role: "developer",
-      content: "A terminal protocol action must be the only call in its tool batch. Correct the call or continue ordinary repair work; all tools remain available."
-    }],
-    completionRepairAttempts: state.completionRepairAttempts + 1,
-    completionRepair: { kind: "terminal_action" },
-    continuationAttempts: 0,
-    phase: "ready_model"
-  };
+export function repairConflictingTerminalBatch(state: KernelState, messages: ModelMessage[]): KernelState {
+  const taskControl = recordToolPolicyViolation(
+    state.taskControl,
+    "terminal_batch_conflict",
+    state.revision
+  );
+  return taskControl.phase === "terminal"
+    ? propose({ ...state, messages, taskControl }, {
+        kind: "recoverable_failure",
+        code: "terminal_batch_conflict",
+        message: completionRepairFailureMessage(state, "A terminal action was repeatedly mixed with another call.")
+      })
+    : {
+        ...state,
+        messages: [...messages, {
+          role: "developer",
+          content: "A terminal action must be the only call in its batch. Use exactly one currently offered action."
+        }],
+        taskControl,
+        phase: "ready_model"
+      };
 }
 
 function canonicalJson(value: JsonValue): string {
@@ -188,6 +170,7 @@ function canonicalJson(value: JsonValue): string {
   return JSON.stringify(value);
 }
 
+/** Diagnostic identity only; task progress never uses arguments or this signature. */
 export function toolBatchSignature(calls: ModelToolCall[]): string {
   return calls.map((call) => `${call.name}:${canonicalJson(call.arguments)}`).sort().join("\n");
 }
@@ -202,34 +185,62 @@ function earlyFinishReasonState(
   messages: ModelMessage[]
 ): KernelState | null {
   if (payload.finishReason === "length") {
-    if (state.continuationAttempts >= 2) {
+    if (state.taskControl.modelContinuationAttempts >= 2) {
       return propose({ ...state, messages }, {
         kind: "recoverable_failure",
         code: "model_output_limit",
-        message: completionRepairFailureMessage(
-          state,
-          "The model reached its output limit repeatedly without producing a protocol action."
-        )
+        message: completionRepairFailureMessage(state, "The model reached its output limit twice without an action.")
       });
     }
-    return { ...state, messages, continuationAttempts: state.continuationAttempts + 1, phase: "ready_model" };
+    return {
+      ...state,
+      messages,
+      taskControl: {
+        ...state.taskControl,
+        modelContinuationAttempts: state.taskControl.modelContinuationAttempts + 1
+      },
+      phase: "ready_model"
+    };
   }
   if (payload.finishReason === "content_filter") {
     return propose({ ...state, messages }, {
-      kind: "fatal",
-      code: "content_filter",
+      kind: "fatal", code: "content_filter",
       message: completionRepairFailureMessage(state, "Provider blocked the response.")
     });
   }
   if (payload.finishReason !== "protocol_error") return null;
   return propose({ ...state, messages }, {
-    kind: "recoverable_failure",
-    code: "model_protocol_error",
-    message: completionRepairFailureMessage(
-      state,
-      "The provider ended the model response at an invalid protocol boundary."
-    )
+    kind: "recoverable_failure", code: "model_protocol_error",
+    message: completionRepairFailureMessage(state, "The provider ended at an invalid protocol boundary.")
   });
+}
+
+function userDecisionResponseCorrection(
+  state: KernelState,
+  messages: ModelMessage[]
+): KernelState | null {
+  if (state.taskControl.obligation?.kind !== "user_decision") return null;
+  const taskControl = recordToolPolicyViolation(
+    state.taskControl,
+    "user_decision_action_required",
+    state.revision
+  );
+  if (taskControl.obligation?.kind === "terminal_resolution") {
+    return propose({ ...state, messages, taskControl }, {
+      kind: "recoverable_failure",
+      code: "user_decision_action_required",
+      message: "The task requires a concrete user decision, but no valid input request was produced."
+    });
+  }
+  return {
+    ...state,
+    messages: [...messages, {
+      role: "developer",
+      content: "A runtime-authenticated user decision is pending. Use exactly the offered request_user_input action."
+    }],
+    taskControl,
+    phase: "ready_model"
+  };
 }
 
 export function incompleteModelCompletion(
@@ -237,20 +248,28 @@ export function incompleteModelCompletion(
   payload: Record<string, JsonValue>,
   messages: ModelMessage[]
 ): KernelState {
-  const earlyState = earlyFinishReasonState(state, payload, messages);
-  if (earlyState) return earlyState;
+  const early = earlyFinishReasonState(state, payload, messages);
+  if (early) return early;
+  const decisionCorrection = userDecisionResponseCorrection(state, messages);
+  if (decisionCorrection) return decisionCorrection;
   const response = [...messages].reverse().find((message) => message.role === "assistant")?.content.trim() ?? "";
   if (!response) {
-    return propose({ ...state, messages }, {
-      kind: "recoverable_failure",
-      code: hasCompletionRepair(state) ? "terminal_protocol_missing" : "model_no_action",
-      message: completionRepairFailureMessage(
-        state,
-        hasCompletionRepair(state)
-          ? "The model's protocol-repair turn stopped without choosing a terminal action."
-          : "The model stopped without a response or tool call."
-      )
-    });
+    const prior = state.taskControl.obligation;
+    if (prior?.kind === "terminal_resolution" && prior.failureCode === "empty_visible_response") {
+      return propose({ ...state, messages }, {
+        kind: "recoverable_failure", code: "model_no_action",
+        message: "The model stopped twice without a visible response or tool call."
+      });
+    }
+    return {
+      ...state,
+      messages: [...messages, {
+        role: "developer",
+        content: "Your previous turn had no visible response or tool call. Provide one concise visible result or exactly one offered terminal action."
+      }],
+      taskControl: terminalResolutionObligation(state.taskControl, state.revision, "empty_visible_response"),
+      phase: "ready_model"
+    };
   }
   const turnId = typeof payload.turnId === "number" ? payload.turnId : 0;
   const effectRevision = typeof payload.effectRevision === "number" ? payload.effectRevision : state.revision;
@@ -261,16 +280,16 @@ export function incompleteModelCompletion(
   };
   const projectedMessages = messages.map((message, index) => index === messages.length - 1
     && message.role === "assistant" ? { ...message, toolCalls: [call] } : message);
+  const taskControl = startActionBatch(protectCompletionCandidate(state.taskControl, response));
   return {
     ...state,
     messages: projectedMessages,
     pendingTools: [{
       request: { callId: call.id, name: call.name, arguments: call.arguments },
-      modelTurn: { turnId, effectRevision },
-      approval: "not_required",
-      started: false
+      modelTurn: { turnId, effectRevision }, approval: "not_required", started: false
     }],
     toolCallIds: [...state.toolCallIds, call.id],
+    taskControl,
     phase: "tool_pending"
   };
 }

--- a/packages/agent-kernel/src/model-convergence.ts
+++ b/packages/agent-kernel/src/model-convergence.ts
@@ -126,7 +126,7 @@ export function failedTerminalRepairState(
   return propose({ ...state, taskControl }, {
     kind: "recoverable_failure",
     code: taskControl.obligation?.kind === "terminal_resolution"
-      ? taskControl.obligation.failureCode : "model_tool_policy_violation",
+      ? taskControl.obligation.failureCode : "action_convergence_no_progress",
     message: completionRepairFailureMessage(state, `Task-control correction was rejected twice (${detail}).`)
   });
 }
@@ -147,7 +147,8 @@ export function repairConflictingTerminalBatch(state: KernelState, messages: Mod
   return taskControl.phase === "terminal"
     ? propose({ ...state, messages, taskControl }, {
         kind: "recoverable_failure",
-        code: "terminal_batch_conflict",
+        code: taskControl.obligation?.kind === "terminal_resolution"
+          ? taskControl.obligation.failureCode : "action_convergence_no_progress",
         message: completionRepairFailureMessage(state, "A terminal action was repeatedly mixed with another call.")
       })
     : {

--- a/packages/agent-kernel/src/reducer.ts
+++ b/packages/agent-kernel/src/reducer.ts
@@ -3,24 +3,22 @@ import type { ActiveModelTurn, KernelState, PendingTool } from "./state.js";
 import {
   completionRepairFailureMessage,
   completionRepairRequiresTerminalAction,
-  conflictingTerminalBatch,
   hasCompletionRepair,
   incompleteModelCompletion,
-  protectedCompletionAnswer,
-  repairConflictingTerminalBatch
+  protectedCompletionAnswer
 } from "./model-convergence.js";
 import { receiptContent, toolReceipt } from "./receipt-parsing.js";
 import { durableReducers, type KernelEventReducer } from "./durable-reducers.js";
 import { isCurrentModelTurn, modelMessage, modelToolCalls, modelTurn } from "./model-event-parsing.js";
 import { recordSemanticToolResult } from "./semantic-failures.js";
 import { acceptMutationFrontier } from "./mutation-frontier.js";
-import { completedToolBatchProgress, repeatsCompletedToolBatch } from "./tool-batch-progress.js";
+import { completedToolBatchProgress, startedToolBatchProgress } from "./tool-batch-progress.js";
+import { beginGoalEpoch, terminalResolutionObligation, userDecisionObligation } from "./task-control.js";
 import {
   acceptsOutcomeRevision,
   isRecoverySuspension,
   nextPhase,
   pendingForEvent,
-  protectedToolBatchFailure,
   proposedOutcomeState,
   terminalReceiptTransition,
   terminalState
@@ -56,15 +54,7 @@ const runStarted: EventReducer = (state, _event, payload) => ({
   deadlineRemainingMs: undefined,
   activeModelTurn: undefined,
   activeModelSemanticDelta: undefined,
-  completionRepairAttempts: 0,
-  completionRepair: undefined,
-  continuationAttempts: 0,
-  repeatedToolBatchCount: 0,
-  receiptCountAtLastUserInput: state.receipts.length,
-  semanticProgress: { workspaceChanges: 0, durableEvidence: 0, revision: state.revision },
-  semanticFailureCluster: undefined,
-  lastToolBatchSignature: undefined,
-  lastToolBatchOutcomeSignature: undefined,
+  taskControl: state.taskControl,
   outcome: undefined,
   proposedOutcome: undefined
 });
@@ -75,14 +65,7 @@ const userInput: EventReducer = (state, _event, payload) => ({
   activeModelTurn: undefined,
   activeModelSemanticDelta: undefined,
   messages: [...state.messages, { role: "user", content: text(payload.text) }],
-  completionRepairAttempts: 0,
-  completionRepair: undefined,
-  continuationAttempts: 0,
-  repeatedToolBatchCount: 0,
-  receiptCountAtLastUserInput: state.receipts.length,
-  semanticFailureCluster: undefined,
-  lastToolBatchSignature: undefined,
-  lastToolBatchOutcomeSignature: undefined,
+  taskControl: beginGoalEpoch(state.taskControl, state.revision, "submit"),
   outcome: undefined,
   proposedOutcome: undefined
 });
@@ -98,21 +81,23 @@ const steeringInput: EventReducer = (state, _event, payload) => ({
   activeModelTurn: undefined,
   activeModelSemanticDelta: undefined,
   pendingTools: [],
-  completionRepairAttempts: 0,
-  completionRepair: undefined,
-  continuationAttempts: 0,
-  repeatedToolBatchCount: 0,
-  receiptCountAtLastUserInput: state.receipts.length,
-  semanticFailureCluster: undefined,
-  lastToolBatchSignature: undefined,
-  lastToolBatchOutcomeSignature: undefined,
+  taskControl: beginGoalEpoch(state.taskControl, state.revision, "steer"),
   proposedOutcome: undefined,
   outcome: undefined
 });
 
-const followUpInput: EventReducer = (state, event, payload) => payload.status === "queued"
+const followUpInput: EventReducer = (state, _event, payload) => payload.status === "queued"
   ? state
-  : userInput(state, event, payload);
+  : {
+      ...state,
+      phase: "ready_model",
+      activeModelTurn: undefined,
+      activeModelSemanticDelta: undefined,
+      messages: [...state.messages, { role: "user", content: text(payload.text) }],
+      taskControl: beginGoalEpoch(state.taskControl, state.revision, "follow_up"),
+      outcome: undefined,
+      proposedOutcome: undefined
+    };
 
 const modelStarted: EventReducer = (state, _event, payload) => {
   const turn = modelTurn(payload);
@@ -131,16 +116,12 @@ const modelCompleted: EventReducer = (state, _event, payload) => {
   const messages = message ? [...state.messages, message] : state.messages;
   const calls = modelToolCalls(payload.toolCalls);
   const modelTurn = state.activeModelTurn!;
-  const completedState = { ...state, activeModelTurn: undefined, activeModelSemanticDelta: undefined };
+  const completedState = {
+    ...state,
+    activeModelTurn: undefined,
+    activeModelSemanticDelta: undefined
+  };
   if (calls.length === 0) return incompleteModelCompletion(completedState, payload, messages);
-  const protectedFailure = protectedToolBatchFailure(state, calls);
-  if (protectedFailure) {
-    return proposedOutcomeState({ ...completedState, messages }, {
-      kind: "recoverable_failure",
-      code: protectedFailure.code,
-      message: completionRepairFailureMessage(state, protectedFailure.message)
-    });
-  }
   const identifiers = calls.map((call) => call.id);
   const seen = new Set(state.toolCallIds);
   const duplicate = identifiers.find((id, index) => identifiers.indexOf(id) !== index || seen.has(id));
@@ -154,31 +135,17 @@ const modelCompleted: EventReducer = (state, _event, payload) => {
       )
     });
   }
-  if (conflictingTerminalBatch(calls, hasCompletionRepair(state))) {
-    return repairConflictingTerminalBatch({ ...completedState, messages }, messages);
-  }
-  if (repeatsCompletedToolBatch(state, calls)) {
-    return proposedOutcomeState({
-      ...completedState,
-      messages,
-      toolCallIds: [...state.toolCallIds, ...identifiers]
-    }, {
-      kind: "recoverable_failure",
-      code: "convergence_no_progress",
-      message: completionRepairFailureMessage(
-        state,
-        "The same tool batch produced the same completed outcome twice and was proposed again without progress."
-      )
-    });
-  }
   const pendingTools = pendingFromCalls(calls, modelTurn);
+  const taskControl = startedToolBatchProgress({
+    ...completedState,
+    taskControl: { ...completedState.taskControl, modelContinuationAttempts: 0 }
+  }).taskControl;
   return {
     ...completedState,
+    taskControl,
     messages,
     pendingTools,
     toolCallIds: [...state.toolCallIds, ...identifiers],
-    completionRepairAttempts: state.completionRepairAttempts,
-    continuationAttempts: 0,
     phase: "tool_pending"
   };
 };
@@ -226,6 +193,18 @@ const toolStarted: EventReducer = (state, _event, payload) => {
   return { ...state, pendingTools, phase: "tool_in_flight" };
 };
 
+function recoveryDecisionState(state: KernelState, diagnostics: readonly string[]): KernelState {
+  if (!diagnostics.includes("recovery_result_lost_no_replay")) return state;
+  return {
+    ...state,
+    taskControl: userDecisionObligation(
+      state.taskControl,
+      state.revision,
+      "recovery_result_lost_no_replay"
+    )
+  };
+}
+
 const toolFinished: EventReducer = (state, event) => {
   const receipt = toolReceipt(event.payload);
   const pending = pendingForEvent(state, objectPayload(event.payload));
@@ -245,12 +224,14 @@ const toolFinished: EventReducer = (state, event) => {
     // Receipt evidence is untrusted tool output. Only separately emitted,
     // authority-checked evidence.recorded/review events enter the ledger.
     evidence: state.evidence,
-    continuationAttempts: 0,
+    taskControl: { ...state.taskControl, modelContinuationAttempts: 0 },
     phase: nextPhase(pendingTools)
   };
-  const completedBatch = pendingTools.length === 0 ? completedToolBatchProgress(next, receipt.callId) : {};
-  const semantic = recordSemanticToolResult({ ...next, ...completedBatch }, receipt, pending.request.name);
-  const progressed = semantic.state;
+  const semantic = recordSemanticToolResult(next, receipt, pending.request.name);
+  const decisionState = recoveryDecisionState(semantic.state, receipt.diagnostics);
+  const progressed = pendingTools.length === 0
+    ? { ...decisionState, ...completedToolBatchProgress(decisionState) }
+    : decisionState;
   return terminalReceiptTransition({
     state,
     progressed,
@@ -259,7 +240,7 @@ const toolFinished: EventReducer = (state, event) => {
     remainingTools: pendingTools.length,
     repairPending,
     terminalRepairPending,
-    semanticLimitReached: semantic.limitReached
+    semanticLimitReached: progressed.taskControl.phase === "terminal"
   }) ?? progressed;
 };
 
@@ -284,7 +265,7 @@ const runSuspended: EventReducer = (state, _event, payload) => {
     phase: "needs_input",
     activeModelTurn: undefined,
     activeModelSemanticDelta: undefined,
-    ...(!approvalSuspension ? { completionRepairAttempts: 0, completionRepair: undefined } : {}),
+    taskControl: state.taskControl,
     proposedOutcome: undefined,
     outcome: { kind: "needs_input", requestId: text(payload.requestId), message: text(payload.message) }
   };
@@ -328,18 +309,30 @@ const diagnostic: EventReducer = (state, _event, payload) => {
     activeModelSemanticDelta: undefined,
     outcome: undefined
   };
+  if (payload.kind === "tool.batch_settled") {
+    const obligation = state.taskControl.obligation;
+    if (obligation?.kind !== "review_repair" || obligation.stage === "re_review") return state;
+    const diagnosticCodes = Array.isArray(payload.diagnosticCodes)
+      ? payload.diagnosticCodes.filter((item): item is string => typeof item === "string") : [];
+    if (diagnosticCodes.some((code) => code === "model_tool_policy_violation"
+      || code === "tool_unavailable_for_repair")) return state;
+    return {
+      ...state,
+      taskControl: terminalResolutionObligation(
+        state.taskControl,
+        state.revision,
+        obligation.stage === "mutate" ? "review_repair_no_delta" : "validation_evidence_missing"
+      )
+    };
+  }
   if (payload.kind === "child.join_failed") {
     const failures = Array.isArray(payload.failures) ? payload.failures.filter((item): item is string => typeof item === "string") : [];
-    const protectedAnswer = protectedCompletionAnswer(state);
     return {
       ...state,
       phase: "ready_model",
       activeModelTurn: undefined,
       activeModelSemanticDelta: undefined,
-      completionRepairAttempts: 0,
-      completionRepair: protectedAnswer
-        ? { kind: "protected_recovery", answer: protectedAnswer }
-        : undefined,
+      taskControl: state.taskControl,
       proposedOutcome: undefined,
       outcome: undefined,
       messages: [...state.messages, {

--- a/packages/agent-kernel/src/rehydrate.ts
+++ b/packages/agent-kernel/src/rehydrate.ts
@@ -2,14 +2,15 @@ import {
   KERNEL_STATE_VERSION,
   isBudgetLedgerState,
   isCheckpointRef,
-  isCompletionReferenceableEvidence,
   isEvidenceRecord,
   isPlanGraph,
   isUsageRecord,
   type AgentEventEnvelope
 } from "agent-protocol";
 import { evolve } from "./reducer.js";
-import { isSemanticFailureCluster, isSemanticProgressWatermark, type KernelState } from "./state.js";
+import type { KernelState } from "./state.js";
+import { isTaskControlStateV1 } from "./task-control-state.js";
+import { hasPublishedTaskControlLegacyFields } from "./task-control.js";
 
 export function rehydrate(initial: KernelState, events: Iterable<AgentEventEnvelope>): KernelState {
   let state = initial;
@@ -33,27 +34,7 @@ function assertDurableLedgers(state: KernelState): void {
   if (new Set(state.budget.reservations.map((item) => item.reservationId)).size !== state.budget.reservations.length) {
     throw new Error("Duplicate budget reservation IDs.");
   }
-  assertSemanticFailureState(state);
-}
-
-function assertSemanticFailureState(state: KernelState): void {
-  if (!isSemanticProgressWatermark(state.semanticProgress)
-    || (state.semanticFailureCluster && !isSemanticFailureCluster(state.semanticFailureCluster))) {
-    throw new Error("Kernel semantic failure progress state is invalid.");
-  }
-  const clusterProgress = state.semanticFailureCluster?.progress;
-  if (clusterProgress && (clusterProgress.workspaceChanges !== state.semanticProgress.workspaceChanges
-    || clusterProgress.durableEvidence !== state.semanticProgress.durableEvidence
-    || clusterProgress.revision !== state.semanticProgress.revision)) {
-    throw new Error("Kernel semantic failure cluster does not match its progress watermark.");
-  }
-  if (state.semanticProgress.revision > state.revision) {
-    throw new Error("Kernel semantic progress revision exceeds the current revision.");
-  }
-  const cluster = state.semanticFailureCluster;
-  if (cluster && (cluster.firstRevision > cluster.lastRevision || cluster.lastRevision > state.revision)) {
-    throw new Error("Kernel semantic failure revisions are invalid.");
-  }
+  assertTaskControlState(state);
 }
 
 function assertEvidenceLedgers(state: KernelState): void {
@@ -108,55 +89,16 @@ function assertToolLedger(state: KernelState): void {
   }
 }
 
-function assertRepairAttemptState(state: KernelState): void {
-  const repair = state.completionRepair;
-  if (!repair) {
-    if (state.completionRepairAttempts !== 0) {
-      throw new Error("Completion repair attempts require explicit repair state.");
-    }
-    return;
+function assertTaskControlState(state: KernelState): void {
+  if (hasPublishedTaskControlLegacyFields(state)) {
+    throw new Error("Kernel state contains superseded task-control authorities.");
   }
-  if (repair.kind === "protected_recovery") {
-    if (state.completionRepairAttempts !== 0) {
-      throw new Error("Protected completion recovery cannot consume a protocol-repair attempt.");
-    }
-  } else if (state.completionRepairAttempts === 0) {
-    throw new Error("Explicit protocol-repair state requires a repair attempt.");
+  if (!isTaskControlStateV1(state.taskControl)) throw new Error("Kernel task-control state is invalid.");
+  if (state.taskControl.episode.startedRevision > state.revision
+    || state.taskControl.semanticFacts.entries.some((fact) => fact.revision > state.revision)
+    || (state.taskControl.obligation?.openedRevision ?? 0) > state.revision) {
+    throw new Error("Task-control facts or obligation exceed the current kernel revision.");
   }
-}
-
-function assertProtectedInputState(state: KernelState): void {
-  if (state.phase !== "needs_input" && state.outcome?.kind !== "needs_input") return;
-  const requestId = state.outcome?.kind === "needs_input" ? state.outcome.requestId : null;
-  const approval = state.pendingTools.some((item) =>
-    item.approval === "pending" && (requestId === null || item.request.callId === requestId));
-  if (!approval) {
-    throw new Error("A protected completion state can await input only for a pending tool approval.");
-  }
-}
-
-function assertProtectedRepairState(state: KernelState): void {
-  const repair = state.completionRepair;
-  if (!repair) return;
-  const protectedAnswer = repair.kind === "protected_completion" || repair.kind === "protected_recovery";
-  if (!protectedAnswer) return;
-  if (!state.evidence.some((item) =>
-    isCompletionReferenceableEvidence(item, state.sessionId, state.runId))) {
-    throw new Error("A protected completion repair requires current-run referenceable evidence.");
-  }
-  if (repair.kind === "protected_completion" && state.pendingTools.length > 0) {
-    const terminalName = state.pendingTools[0]?.request.name;
-    if (state.pendingTools.length !== 1
-      || (terminalName !== "runtime_finalize" && terminalName !== "request_user_input")) {
-      throw new Error("A protected terminal-intent repair can pend only one runtime completion intent or request_user_input call.");
-    }
-  }
-  assertProtectedInputState(state);
-}
-
-function assertCompletionRepairState(state: KernelState): void {
-  assertRepairAttemptState(state);
-  if (state.completionRepair) assertProtectedRepairState(state);
 }
 
 function assertPhaseState(state: KernelState): void {
@@ -170,7 +112,7 @@ function assertPhaseState(state: KernelState): void {
   if (state.phase !== "terminal" && state.outcome?.kind !== "needs_input") {
     if (state.outcome) throw new Error("Non-terminal kernel state cannot have a terminal outcome.");
   }
-  assertCompletionRepairState(state);
+  assertTaskControlState(state);
 }
 
 export function assertKernelInvariants(state: KernelState): void {

--- a/packages/agent-kernel/src/review-task-control-reducer.ts
+++ b/packages/agent-kernel/src/review-task-control-reducer.ts
@@ -1,0 +1,65 @@
+import type { EvidenceRecord, JsonValue } from "agent-protocol";
+import type { KernelState } from "./state.js";
+import {
+  resolveTaskObligation,
+  reviewRepairObligation,
+  terminalResolutionObligation
+} from "./task-control.js";
+
+function actionableReviewFinding(value: JsonValue): boolean {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return true;
+  const finding = value as Record<string, JsonValue>;
+  return finding.actionable === true && finding.severity === "error";
+}
+
+function reviewFailureTransition(
+  state: KernelState,
+  review: Extract<EvidenceRecord, { kind: "review" }>
+): KernelState {
+  const obligation = state.taskControl.obligation;
+  const sameBasisFailures = state.evidence.filter((item) => item.kind === "review"
+    && item.data.reviewBasisDigest === review.data.reviewBasisDigest
+    && item.data.failureKind === review.data.failureKind).length;
+  const unavailable = obligation?.kind === "review_repair" && obligation.stage === "re_review"
+    && review.data.failureKind === "protocol" && sameBasisFailures >= 2;
+  return unavailable
+    ? { ...state, taskControl: terminalResolutionObligation(state.taskControl, state.revision, "review_unavailable") }
+    : state;
+}
+
+function actionableReviewTransition(
+  state: KernelState,
+  review: Extract<EvidenceRecord, { kind: "review" }>
+): KernelState {
+  const obligation = state.taskControl.obligation;
+  if (obligation?.kind === "review_repair" && obligation.stage === "re_review") {
+    return {
+      ...state,
+      taskControl: terminalResolutionObligation(state.taskControl, state.revision, "review_repair_exhausted")
+    };
+  }
+  return {
+    ...state,
+    taskControl: reviewRepairObligation(
+      state.taskControl,
+      state.revision,
+      review.data.reviewBasisDigest ?? review.data.stateDigest,
+      state.mutationFrontier.changedPaths
+    )
+  };
+}
+
+export function reviewTaskControl(
+  state: KernelState,
+  review: Extract<EvidenceRecord, { kind: "review" }>
+): KernelState {
+  const obligation = state.taskControl.obligation;
+  if (review.data.failureKind) return reviewFailureTransition(state, review);
+  if (review.status === "passed" && review.data.verdict === "approved") {
+    return obligation?.kind === "review_repair" && obligation.stage === "re_review"
+      ? { ...state, taskControl: resolveTaskObligation(state.taskControl) }
+      : state;
+  }
+  if (!review.data.findings.some(actionableReviewFinding)) return state;
+  return actionableReviewTransition(state, review);
+}

--- a/packages/agent-kernel/src/semantic-failures.ts
+++ b/packages/agent-kernel/src/semantic-failures.ts
@@ -1,18 +1,16 @@
-import { createHash } from "node:crypto";
 import {
   INFRASTRUCTURE_FAILURE_LIMIT,
-  classifyInfrastructureFailureCodesV1,
   isCompletionEligibleEvidence,
   type EvidenceRecord,
-  type InfrastructureFailureClassificationV1,
   type ToolReceipt,
   type WorkspaceDelta
 } from "agent-protocol";
-import type {
-  KernelState,
-  SemanticFailureCluster,
-  SemanticProgressWatermark
-} from "./state.js";
+import { createHash } from "node:crypto";
+import type { KernelState } from "./state.js";
+import {
+  recordSemanticFact,
+  taskControlFailureMessage
+} from "./task-control.js";
 
 export const SEMANTIC_INFRASTRUCTURE_FAILURE_LIMIT = INFRASTRUCTURE_FAILURE_LIMIT;
 export const SEMANTIC_INFRASTRUCTURE_FAILURE_CODE = "tool_infrastructure_failure_loop";
@@ -22,135 +20,24 @@ export interface SemanticFailureUpdate {
   limitReached: boolean;
 }
 
-/**
- * Built-in tools whose successful receipt proves that a new process was
- * launched. Other process tools share the process.spawn.readonly effect for
- * policy purposes, but polling, writing to, or terminating an existing handle
- * is not execution-infrastructure recovery.
- */
-const PROCESS_LAUNCH_TOOL_NAMES = new Set(["exec", "shell", "validate", "process_spawn"]);
-
-function isExecutionInfrastructureCluster(cluster: SemanticFailureCluster | undefined): boolean {
-  return cluster?.family.startsWith("execution_") === true;
-}
-
-function isDependencyCluster(cluster: SemanticFailureCluster | undefined): boolean {
-  return cluster?.family === "execution_dependency";
-}
-
-export function semanticInfrastructureFailureMessage(cluster: SemanticFailureCluster): string {
-  const recoveryBoundary = isExecutionInfrastructureCluster(cluster)
-    ? isDependencyCluster(cluster)
-      ? "a bounded dependency recovery"
-      : "a successful process launch"
-    : "workspace or durable evidence progress";
-  return `Infrastructure repeatedly failed without ${recoveryBoundary} (${cluster.family}, ${cluster.attempts} attempts; diagnostics: ${cluster.diagnosticCodes.join(", ")}).`;
-}
-
-function successfulProcessLaunch(receipt: ToolReceipt, toolName: string): boolean {
-  if (!receipt.ok || !PROCESS_LAUNCH_TOOL_NAMES.has(toolName)) return false;
-  // An explicitly empty V3 actual-effects projection is authoritative. Only
-  // legacy receipts that omit it may fall back to the V2 observed projection.
-  const effects = receipt.actualEffects === undefined ? receipt.observedEffects : receipt.actualEffects;
-  return effects.some((effect) => effect === "process.spawn" || effect === "process.spawn.readonly");
-}
-
-function classifyFailure(receipt: ToolReceipt): InfrastructureFailureClassificationV1 | undefined {
-  if (receipt.ok) return undefined;
-  return classifyInfrastructureFailureCodesV1([
-    ...(receipt.outcome?.diagnosticCodes ?? []),
-    ...receipt.diagnostics
-  ]);
-}
-
-function deltaSize(delta: WorkspaceDelta | undefined): number {
-  return (delta?.added.length ?? 0) + (delta?.modified.length ?? 0) + (delta?.deleted.length ?? 0);
-}
-
-function advancedProgress(
-  progress: SemanticProgressWatermark,
-  revision: number,
-  workspaceChanges: number,
-  durableEvidence: number
-): SemanticProgressWatermark {
+function sortedDelta(delta: WorkspaceDelta): WorkspaceDelta {
   return {
-    workspaceChanges: progress.workspaceChanges + workspaceChanges,
-    durableEvidence: progress.durableEvidence + durableEvidence,
-    revision
+    added: [...new Set(delta.added)].sort(),
+    modified: [...new Set(delta.modified)].sort(),
+    deleted: [...new Set(delta.deleted)].sort()
   };
 }
 
-function withoutDiagnosticIdentity(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(withoutDiagnosticIdentity);
-  if (!value || typeof value !== "object") return value;
-  return Object.fromEntries(Object.entries(value as Record<string, unknown>)
-    .filter(([key]) => key !== "callId")
-    .sort(([left], [right]) => left.localeCompare(right))
-    .map(([key, item]) => [key, withoutDiagnosticIdentity(item)]));
+function hasDelta(delta: WorkspaceDelta | undefined): delta is WorkspaceDelta {
+  return Boolean(delta && delta.added.length + delta.modified.length + delta.deleted.length > 0);
 }
 
-function evidenceProgressSignature(evidence: EvidenceRecord): string {
-  const data = evidence.kind === "command"
-    ? {
-        command: evidence.data.command,
-        exitCode: evidence.data.exitCode,
-        ...(evidence.data.signal ? { signal: evidence.data.signal } : {})
-      }
-    : evidence.kind === "diagnostic"
-      ? { source: evidence.data.source, diagnostic: withoutDiagnosticIdentity(evidence.data.diagnostic) }
-      : evidence.data;
-  return createHash("sha256").update(JSON.stringify({
-    kind: evidence.kind,
-    status: evidence.status,
-    summary: evidence.summary,
-    data
-  })).digest("hex");
-}
-
-function progressMatches(left: SemanticProgressWatermark, right: SemanticProgressWatermark): boolean {
-  return left.workspaceChanges === right.workspaceChanges
-    && left.durableEvidence === right.durableEvidence
-    && left.revision === right.revision;
-}
-
-function nextCluster(
-  current: SemanticFailureCluster | undefined,
-  classification: InfrastructureFailureClassificationV1,
-  progress: SemanticProgressWatermark,
-  revision: number
-): SemanticFailureCluster {
-  if (!current || current.family !== classification.family || !progressMatches(current.progress, progress)) {
-    return {
-      family: classification.family,
-      attempts: 1,
-      firstRevision: revision,
-      lastRevision: revision,
-      diagnosticCodes: classification.codes,
-      progress: { ...progress }
-    };
-  }
-  return {
-    ...current,
-    attempts: current.attempts + 1,
-    lastRevision: revision,
-    diagnosticCodes: [...new Set([...current.diagnosticCodes, ...classification.codes])]
-  };
-}
-
-function withWorkspaceProgress(
-  state: KernelState,
-  workspaceChanges: number,
-  preserveExecutionCluster: boolean
-): KernelState {
-  if (workspaceChanges === 0) return state;
-  const semanticProgress = advancedProgress(state.semanticProgress, state.revision, workspaceChanges, 0);
-  return {
-    ...state,
-    semanticProgress,
-    semanticFailureCluster: preserveExecutionCluster && state.semanticFailureCluster
-      ? { ...state.semanticFailureCluster, progress: semanticProgress }
-      : undefined
-  };
+export function semanticInfrastructureFailureMessage(state: KernelState): string {
+  const episode = state.taskControl.episode;
+  return taskControlFailureMessage(
+    state.taskControl,
+    `Actions made no trusted progress for ${episode.noProgressBatches} completed batches in the current episode.`
+  );
 }
 
 export function recordSemanticToolResult(
@@ -158,37 +45,47 @@ export function recordSemanticToolResult(
   receipt: ToolReceipt,
   toolName: string
 ): SemanticFailureUpdate {
-  const workspaceChanges = deltaSize(receipt.workspaceDelta);
-  const executionCluster = isExecutionInfrastructureCluster(state.semanticFailureCluster);
-  if (successfulProcessLaunch(receipt, toolName) && !isDependencyCluster(state.semanticFailureCluster)) {
-    return {
-      state: withWorkspaceProgress({ ...state, semanticFailureCluster: undefined }, workspaceChanges, false),
-      limitReached: false
-    };
+  let taskControl = state.taskControl;
+  if (hasDelta(receipt.workspaceDelta)) {
+    taskControl = recordSemanticFact(
+      taskControl,
+      "workspace_frontier",
+      { delta: sortedDelta(receipt.workspaceDelta) },
+      state.revision
+    ).control;
   }
-  if (workspaceChanges > 0 && !executionCluster) {
-    return { state: withWorkspaceProgress(state, workspaceChanges, false), limitReached: false };
+  const readSubject = receipt.ok ? semanticReadSubject(toolName, receipt) : null;
+  if (readSubject) {
+    taskControl = recordSemanticFact(
+      taskControl,
+      "content",
+      readSubject,
+      state.revision
+    ).control;
   }
-  const progressed = withWorkspaceProgress(state, workspaceChanges, executionCluster);
-  if ((progressed.semanticFailureCluster?.attempts ?? 0) >= SEMANTIC_INFRASTRUCTURE_FAILURE_LIMIT) {
-    return { state: progressed, limitReached: true };
+  const progressed = taskControl === state.taskControl ? state : { ...state, taskControl };
+  return { state: progressed, limitReached: taskControl.phase === "terminal" };
+}
+
+const CONTENT_READ_TOOLS = new Set([
+  "read", "list", "grep", "repository_stats", "git_status", "git_diff", "lsp"
+]);
+
+function object(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown> : null;
+}
+
+function semanticReadSubject(toolName: string, receipt: ToolReceipt): unknown | null {
+  if (!CONTENT_READ_TOOLS.has(toolName)) return null;
+  const result = object(receipt.result);
+  if (toolName === "read" && result?.status === "read"
+    && typeof result.path === "string" && typeof result.sha256 === "string") {
+    return { toolName, path: result.path, contentDigest: result.sha256 };
   }
-  const classification = classifyFailure(receipt);
-  if (!classification) {
-    return {
-      state: progressed,
-      limitReached: (progressed.semanticFailureCluster?.attempts ?? 0) >= SEMANTIC_INFRASTRUCTURE_FAILURE_LIMIT
-    };
-  }
-  const cluster = nextCluster(
-    progressed.semanticFailureCluster,
-    classification,
-    progressed.semanticProgress,
-    progressed.revision
-  );
   return {
-    state: { ...progressed, semanticFailureCluster: cluster },
-    limitReached: cluster.attempts >= SEMANTIC_INFRASTRUCTURE_FAILURE_LIMIT
+    toolName,
+    contentDigest: createHash("sha256").update(receipt.output, "utf8").digest("hex")
   };
 }
 
@@ -197,32 +94,92 @@ export function recordSemanticEvidenceProgress(state: KernelState, evidence: Evi
   const evidenceFromFailedTool = evidence.producer.authority === "tool"
     && state.receipts.some((receipt) => receipt.callId === evidence.producer.id && !receipt.ok);
   if (evidenceFromFailedTool) return state;
-  const signature = evidenceProgressSignature(evidence);
-  if (state.evidence.some((item) => item.evidenceId !== evidence.evidenceId
-    && evidenceProgressSignature(item) === signature)) return state;
-  const executionCluster = isExecutionInfrastructureCluster(state.semanticFailureCluster);
-  const clearsPendingFailure = !executionCluster && state.phase === "outcome_pending"
-    && state.proposedOutcome?.kind === "recoverable_failure"
-    && state.proposedOutcome.code === SEMANTIC_INFRASTRUCTURE_FAILURE_CODE;
-  const semanticProgress = advancedProgress(state.semanticProgress, state.revision, 0, 1);
-  return {
-    ...state,
-    semanticProgress,
-    semanticFailureCluster: executionCluster && state.semanticFailureCluster
-      ? { ...state.semanticFailureCluster, progress: semanticProgress }
-      : undefined,
-    ...(clearsPendingFailure ? { phase: "ready_model" as const, proposedOutcome: undefined } : {})
-  };
+  const semantic = semanticEvidence(evidence);
+  if (!semantic) return state;
+  const fact = recordSemanticFact(state.taskControl, semantic.kind, semantic.subject, state.revision);
+  return fact.trustedProgress ? { ...state, taskControl: fact.control } : state;
+}
+
+type SemanticEvidence = {
+  kind: Parameters<typeof recordSemanticFact>[1]; subject: unknown;
+};
+
+function semanticMutationEvidence(evidence: EvidenceRecord): SemanticEvidence | null {
+  switch (evidence.kind) {
+    case "workspace_delta":
+      return { kind: "workspace_frontier", subject: {
+        delta: evidence.data.delta,
+        reviewContentDigest: evidence.data.reviewDiff
+          ? createHash("sha256").update(evidence.data.reviewDiff, "utf8").digest("hex") : null,
+        opaqueArtifacts: evidence.data.opaqueArtifacts ?? []
+      } };
+    case "repository_delta":
+      return { kind: "repository", subject: {
+        afterStateDigest: evidence.data.afterStateDigest,
+        headAfter: evidence.data.headAfter,
+        refsAfterDigest: evidence.data.refsAfterDigest,
+        indexAfterDigest: evidence.data.indexAfterDigest
+      } };
+    case "validation":
+      return { kind: "validation", subject: {
+        status: evidence.status,
+        frontierRevision: evidence.data.frontierRevision,
+        stateDigest: evidence.data.stateDigest,
+        coveredPaths: evidence.data.coveredPaths,
+        claim: evidence.data.claim ?? null
+      } };
+    case "review":
+      return { kind: "review", subject: {
+        status: evidence.status,
+        verdict: evidence.data.verdict,
+        reviewBasisDigest: evidence.data.reviewBasisDigest ?? null,
+        failureKind: evidence.data.failureKind ?? null,
+        findings: evidence.data.findings
+      } };
+    default:
+      return null;
+  }
+}
+
+function semanticAuxiliaryEvidence(evidence: EvidenceRecord): SemanticEvidence | null {
+  switch (evidence.kind) {
+    case "input_access":
+      return { kind: "content", subject: {
+        path: evidence.data.path,
+        contentDigest: evidence.data.sha256 ?? null,
+        failureCode: evidence.data.failureCode ?? null
+      } };
+    case "child_outcome":
+      return { kind: "plan", subject: {
+        childId: evidence.data.childId,
+        outcome: evidence.data.outcome,
+        planNodeIds: evidence.data.planNodeIds
+      } };
+    case "user_waiver":
+      return { kind: "review", subject: {
+        authority: "user", scope: evidence.data.scope, reason: evidence.data.reason
+      } };
+    case "restoration":
+      return { kind: "restoration", subject: evidence.data };
+    case "command":
+    case "diagnostic":
+    case "checkpoint":
+      return null;
+    default:
+      return null;
+  }
+}
+
+function semanticEvidence(evidence: EvidenceRecord): SemanticEvidence | null {
+  return semanticMutationEvidence(evidence) ?? semanticAuxiliaryEvidence(evidence);
 }
 
 export function recordSemanticWorkspaceRestore(state: KernelState): KernelState {
-  const executionCluster = isExecutionInfrastructureCluster(state.semanticFailureCluster);
-  const semanticProgress = advancedProgress(state.semanticProgress, state.revision, 1, 0);
-  return {
-    ...state,
-    semanticProgress,
-    semanticFailureCluster: executionCluster && state.semanticFailureCluster
-      ? { ...state.semanticFailureCluster, progress: semanticProgress }
-      : undefined
-  };
+  const fact = recordSemanticFact(state.taskControl, "restoration", {
+    frontierRevision: state.mutationFrontier.revision,
+    stateDigest: state.mutationFrontier.currentStateDigest,
+    baselineManifestDigest: state.mutationFrontier.baselineManifestDigest,
+    changedPaths: state.mutationFrontier.changedPaths
+  }, state.revision);
+  return fact.trustedProgress ? { ...state, taskControl: fact.control } : state;
 }

--- a/packages/agent-kernel/src/state.ts
+++ b/packages/agent-kernel/src/state.ts
@@ -5,7 +5,6 @@ import {
   isBudgetLedgerState,
   isCheckpointRef,
   isEvidenceRecord,
-  isJsonValue,
   isMutationFrontier,
   isPlanGraph,
   isUsageRecord,
@@ -24,6 +23,8 @@ import {
   type UsageRecord
 } from "agent-protocol";
 import { emptyMutationFrontier } from "./mutation-frontier.js";
+import { createTaskControlState, hasPublishedTaskControlLegacyFields } from "./task-control.js";
+import { isTaskControlStateV1, type TaskControlStateV1 } from "./task-control-state.js";
 
 export type KernelPhase =
   | "idle"
@@ -46,43 +47,6 @@ export interface PendingTool {
   approval: "not_required" | "pending" | "allowed" | "denied";
   started: boolean;
 }
-
-export interface SemanticProgressWatermark {
-  /** Number of concrete changed paths (plus explicit checkpoint restores) observed in this run. */
-  workspaceChanges: number;
-  /** Number of accepted, non-failed durable evidence records observed in this run. */
-  durableEvidence: number;
-  /** Kernel revision at which either progress dimension last advanced. */
-  revision: number;
-}
-
-export interface SemanticFailureCluster {
-  /** Stable execution diagnostic family; deliberately independent of command text and tool arguments. */
-  family: string;
-  attempts: number;
-  firstRevision: number;
-  lastRevision: number;
-  diagnosticCodes: string[];
-  /** Latest global progress watermark. Execution clusters are rebased across
-   * unrelated evidence or workspace progress. Capability clusters clear after
-   * a successful process launch; dependency clusters retain their retry bound. */
-  progress: SemanticProgressWatermark;
-}
-
-export type CompletionRepairState =
-  | { kind: "evidence_acquisition" }
-  | { kind: "terminal_action" }
-  | { kind: "protected_completion"; answer: string }
-  | { kind: "protected_recovery"; answer: string }
-  | {
-      kind: "completion_prerequisite";
-      answer: string;
-      arguments: ToolRequest["arguments"];
-      originalCallId: string;
-      evidenceCount: number;
-      retryCount: number;
-      modelTurn: ActiveModelTurn;
-    };
 
 export interface KernelState {
   schemaVersion: typeof KERNEL_STATE_VERSION;
@@ -118,20 +82,9 @@ export interface KernelState {
   frozenSkills: FrozenArtifactRef[];
   activeProcessIds: string[];
   childIds: string[];
-  completionRepairAttempts: number;
-  /** Durable reason for a bounded protocol-repair turn. Protected completion
-   * locks the exact evidence-backed natural answer while the model chooses one
-   * typed terminal intent: finalize it or request concrete user input. */
-  completionRepair?: CompletionRepairState;
-  continuationAttempts: number;
-  repeatedToolBatchCount: number;
-  receiptCountAtLastUserInput: number;
-  semanticProgress: SemanticProgressWatermark;
-  semanticFailureCluster?: SemanticFailureCluster;
-  /** Signature of the most recently fully completed tool-call batch. */
-  lastToolBatchSignature?: string;
-  /** Stable receipt semantics for that completed batch; excludes call IDs and timestamps. */
-  lastToolBatchOutcomeSignature?: string;
+  /** The sole authority for task obligations, action convergence, protocol
+   * correction, and completion delivery. Execution lifecycle remains in phase. */
+  taskControl: TaskControlStateV1;
   proposedOutcome?: RunOutcome;
   outcome?: RunOutcome;
 }
@@ -168,11 +121,7 @@ export function createKernelState(options: CreateKernelStateOptions): KernelStat
     frozenSkills: [],
     activeProcessIds: [],
     childIds: [],
-    completionRepairAttempts: 0,
-    continuationAttempts: 0,
-    repeatedToolBatchCount: 0,
-    receiptCountAtLastUserInput: 0,
-    semanticProgress: { workspaceChanges: 0, durableEvidence: 0, revision: 0 }
+    taskControl: createTaskControlState()
   };
 }
 
@@ -185,72 +134,10 @@ function validDeadlineState(state: Record<string, unknown>): boolean {
     || (Number.isSafeInteger(state.deadlineRemainingMs) && Number(state.deadlineRemainingMs) >= 1));
 }
 
-function nonNegativeInteger(value: unknown): boolean {
-  return Number.isSafeInteger(value) && Number(value) >= 0;
-}
-
-function validToolBatchProgressState(state: Record<string, unknown>): boolean {
-  if (state.lastToolBatchSignature !== undefined && typeof state.lastToolBatchSignature !== "string") return false;
-  if (state.lastToolBatchOutcomeSignature === undefined) return true;
-  return typeof state.lastToolBatchSignature === "string" && state.lastToolBatchSignature.length > 0
-    && typeof state.lastToolBatchOutcomeSignature === "string"
-    && /^[a-f0-9]{64}$/u.test(state.lastToolBatchOutcomeSignature)
-    && Number.isSafeInteger(state.repeatedToolBatchCount) && Number(state.repeatedToolBatchCount) >= 1;
-}
-
-export function isSemanticProgressWatermark(value: unknown): value is SemanticProgressWatermark {
-  const progress = record(value);
-  return Boolean(progress && [progress.workspaceChanges, progress.durableEvidence, progress.revision]
-    .every(nonNegativeInteger));
-}
-
-export function isSemanticFailureCluster(value: unknown): value is SemanticFailureCluster {
-  const cluster = record(value);
-  return Boolean(cluster
-    && typeof cluster.family === "string" && cluster.family.length > 0
-    && Number.isSafeInteger(cluster.attempts) && Number(cluster.attempts) >= 1
-    && [cluster.firstRevision, cluster.lastRevision].every(nonNegativeInteger)
-    && Array.isArray(cluster.diagnosticCodes)
-    && cluster.diagnosticCodes.every((item) => typeof item === "string" && item.length > 0)
-    && isSemanticProgressWatermark(cluster.progress));
-}
-
-function isCompletionPrerequisiteRepair(repair: Record<string, unknown>): boolean {
-  const modelTurn = record(repair.modelTurn);
-  if (!modelTurn) return false;
-  const validIdentity = typeof repair.originalCallId === "string" && repair.originalCallId.length > 0;
-  const validCounts = nonNegativeInteger(repair.evidenceCount) && nonNegativeInteger(repair.retryCount);
-  const validTurn = nonNegativeInteger(modelTurn.turnId) && nonNegativeInteger(modelTurn.effectRevision);
-  return typeof repair.answer === "string" && repair.answer.trim().length > 0
-    && validIdentity && isJsonValue(repair.arguments) && validCounts && validTurn;
-}
-
-export function isCompletionRepairState(value: unknown): value is CompletionRepairState {
-  const repair = record(value);
-  if (!repair) return false;
-  if (repair.kind === "evidence_acquisition" || repair.kind === "terminal_action") {
-    return Object.keys(repair).length === 1;
-  }
-  if (repair.kind === "completion_prerequisite") return isCompletionPrerequisiteRepair(repair);
-  return (repair.kind === "protected_completion" || repair.kind === "protected_recovery")
-    && typeof repair.answer === "string"
-    && repair.answer.trim().length > 0
-    && Object.keys(repair).every((key) => key === "kind" || key === "answer");
-}
-
-function validSemanticState(state: Record<string, unknown>): boolean {
-  if (!isSemanticProgressWatermark(state.semanticProgress)) return false;
-  const revision = Number(state.revision);
-  if (state.semanticProgress.revision > revision) return false;
-  if (state.semanticFailureCluster === undefined) return true;
-  if (!isSemanticFailureCluster(state.semanticFailureCluster)) return false;
-  return state.semanticFailureCluster.firstRevision <= state.semanticFailureCluster.lastRevision
-    && state.semanticFailureCluster.lastRevision <= revision;
-}
-
 export function isKernelState(value: unknown): value is KernelState {
   const state = record(value);
-  if (!state || state.schemaVersion !== KERNEL_STATE_VERSION) return false;
+  if (!state || state.schemaVersion !== KERNEL_STATE_VERSION
+    || hasPublishedTaskControlLegacyFields(state)) return false;
   return [
     typeof state.sessionId === "string" && state.sessionId.length > 0,
     typeof state.runId === "string" && state.runId.length > 0,
@@ -275,11 +162,7 @@ export function isKernelState(value: unknown): value is KernelState {
     validFrozenState(state),
     Array.isArray(state.activeProcessIds) && state.activeProcessIds.every((item) => typeof item === "string" && item.length > 0),
     Array.isArray(state.childIds),
-    state.completionRepair === undefined || isCompletionRepairState(state.completionRepair),
-    validSemanticState(state),
-    validToolBatchProgressState(state),
-    [state.completionRepairAttempts, state.continuationAttempts, state.repeatedToolBatchCount,
-      state.receiptCountAtLastUserInput].every((item) => Number.isSafeInteger(item) && Number(item) >= 0)
+    isTaskControlStateV1(state.taskControl)
   ].every(Boolean);
 }
 

--- a/packages/agent-kernel/src/task-control-resolution.ts
+++ b/packages/agent-kernel/src/task-control-resolution.ts
@@ -1,0 +1,20 @@
+import type { TaskControlStateV1 } from "./task-control-state.js";
+
+/** Resolve a repeated policy violation from the runtime-owned obligation,
+ * never from the model-selected tool name or diagnostic wording. */
+export function policyExhaustionCode(control: TaskControlStateV1): string {
+  const obligation = control.obligation;
+  if (obligation?.kind === "terminal_resolution") return obligation.failureCode;
+  if (obligation?.kind === "completion_evidence" && obligation.failureCode) {
+    return obligation.failureCode;
+  }
+  switch (obligation?.kind) {
+    case "review_repair": return "review_repair_exhausted";
+    case "capability_recovery": return "capability_recovery_exhausted";
+    case "repository_recovery": return "repository_recovery_exhausted";
+    case "restoration": return "restoration_incomplete";
+    case "process_settlement": return "process_settlement_failed";
+    case "user_decision": return "user_decision_action_required";
+    default: return "action_convergence_no_progress";
+  }
+}

--- a/packages/agent-kernel/src/task-control-state.ts
+++ b/packages/agent-kernel/src/task-control-state.ts
@@ -1,0 +1,226 @@
+import type { JsonValue } from "agent-protocol";
+
+export type TaskControlPhase = "normal" | "focused" | "repair_only" | "terminal";
+
+export type TaskObligationV1 =
+  | {
+      kind: "completion_evidence";
+      stage: "acquire" | "terminal";
+      basisDigest: string;
+      openedRevision: number;
+      attempts: number;
+      evidenceCount: number;
+      failureCode?: string;
+      originalCallId?: string;
+      arguments?: JsonValue;
+    }
+  | {
+      kind: "review_repair";
+      stage: "mutate" | "validate" | "re_review";
+      basisDigest: string;
+      openedRevision: number;
+      attempts: number;
+      scopePaths: string[];
+    }
+  | {
+      kind: "capability_recovery";
+      stage: "prepare" | "re_probe";
+      basisDigest: string;
+      openedRevision: number;
+      attempts: number;
+      opportunityId: string;
+    }
+  | {
+      kind: "repository_recovery";
+      stage: "inspect" | "select" | "transact" | "validate";
+      basisDigest: string;
+      openedRevision: number;
+      attempts: number;
+      transactionId?: string;
+    }
+  | {
+      kind: "restoration";
+      stage: "quiesce" | "restore" | "confirm";
+      basisDigest: string;
+      openedRevision: number;
+      attempts: number;
+    }
+  | {
+      kind: "process_settlement";
+      stage: "settle";
+      basisDigest: string;
+      openedRevision: number;
+      attempts: number;
+      processIds: string[];
+    }
+  | {
+      kind: "user_decision";
+      stage: "request";
+      basisDigest: string;
+      openedRevision: number;
+      attempts: number;
+      decisionCode: string;
+    }
+  | {
+      kind: "terminal_resolution";
+      stage: "report";
+      basisDigest: string;
+      openedRevision: number;
+      attempts: number;
+      failureCode: string;
+    };
+
+export type SemanticFactKindV1 =
+  | "workspace_frontier"
+  | "content"
+  | "runtime_environment"
+  | "process_lifecycle"
+  | "validation"
+  | "review"
+  | "plan"
+  | "repository"
+  | "restoration";
+
+export interface SemanticFactV1 {
+  kind: SemanticFactKindV1;
+  digest: string;
+  revision: number;
+}
+
+export interface SemanticFactLedgerV1 {
+  entries: SemanticFactV1[];
+}
+
+export interface ActionEpisodeV1 {
+  basisDigest: string;
+  startedRevision: number;
+  noProgressBatches: number;
+  observations: number;
+  factCountAtBatchStart?: number;
+}
+
+export interface ToolPolicyCorrectionStateV1 {
+  basisDigest: string;
+  attempts: number;
+  failureCode: string;
+}
+
+export interface CompletionCandidateV1 {
+  answer: string;
+  digest: string;
+}
+
+export interface TaskControlStateV1 {
+  schemaVersion: 1;
+  goalEpoch: number;
+  goalEpochSource: "initial" | "submit" | "steer" | "follow_up";
+  phase: TaskControlPhase;
+  obligation?: TaskObligationV1;
+  semanticFacts: SemanticFactLedgerV1;
+  episode: ActionEpisodeV1;
+  policyCorrection?: ToolPolicyCorrectionStateV1;
+  completionCandidate?: CompletionCandidateV1;
+  modelContinuationAttempts: number;
+}
+
+const DIGEST = /^[a-f0-9]{64}$/u;
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : null;
+}
+
+function nonNegativeInteger(value: unknown): boolean {
+  return Number.isSafeInteger(value) && Number(value) >= 0;
+}
+
+function nonEmptyStrings(value: unknown): boolean {
+  return Array.isArray(value) && value.every((item) => typeof item === "string" && item.length > 0);
+}
+
+function validObligationHeader(obligation: Record<string, unknown>): boolean {
+  return typeof obligation.kind === "string" && typeof obligation.stage === "string"
+    && typeof obligation.basisDigest === "string" && DIGEST.test(obligation.basisDigest)
+    && nonNegativeInteger(obligation.openedRevision) && nonNegativeInteger(obligation.attempts);
+}
+
+type ObligationValidator = (obligation: Record<string, unknown>) => boolean;
+
+const OBLIGATION_VALIDATORS: Record<TaskObligationV1["kind"], ObligationValidator> = {
+  completion_evidence: (obligation) => ["acquire", "terminal"].includes(String(obligation.stage))
+    && nonNegativeInteger(obligation.evidenceCount)
+    && (obligation.failureCode === undefined
+      || typeof obligation.failureCode === "string" && obligation.failureCode.length > 0),
+  review_repair: (obligation) => ["mutate", "validate", "re_review"].includes(String(obligation.stage))
+    && nonEmptyStrings(obligation.scopePaths),
+  capability_recovery: (obligation) => ["prepare", "re_probe"].includes(String(obligation.stage))
+    && typeof obligation.opportunityId === "string" && obligation.opportunityId.length > 0,
+  repository_recovery: (obligation) => ["inspect", "select", "transact", "validate"].includes(String(obligation.stage)),
+  restoration: (obligation) => ["quiesce", "restore", "confirm"].includes(String(obligation.stage)),
+  process_settlement: (obligation) => obligation.stage === "settle" && nonEmptyStrings(obligation.processIds),
+  user_decision: (obligation) => obligation.stage === "request"
+    && typeof obligation.decisionCode === "string" && obligation.decisionCode.length > 0,
+  terminal_resolution: (obligation) => obligation.stage === "report"
+    && typeof obligation.failureCode === "string" && obligation.failureCode.length > 0
+};
+
+function validObligation(value: unknown): value is TaskObligationV1 {
+  const obligation = record(value);
+  if (!obligation || !validObligationHeader(obligation)) return false;
+  const validator = OBLIGATION_VALIDATORS[obligation.kind as TaskObligationV1["kind"]];
+  return validator?.(obligation) ?? false;
+}
+
+function validFact(value: unknown): value is SemanticFactV1 {
+  const fact = record(value);
+  return Boolean(fact && [
+    "workspace_frontier", "content", "runtime_environment", "process_lifecycle",
+    "validation", "review", "plan", "repository", "restoration"
+  ].includes(String(fact.kind)) && typeof fact.digest === "string" && DIGEST.test(fact.digest)
+    && nonNegativeInteger(fact.revision));
+}
+
+export function isTaskControlStateV1(value: unknown): value is TaskControlStateV1 {
+  const state = record(value);
+  if (!validTaskControlHeader(state)) return false;
+  const facts = record(state.semanticFacts);
+  const episode = record(state.episode);
+  const correction = state.policyCorrection === undefined ? null : record(state.policyCorrection);
+  const candidate = state.completionCandidate === undefined ? null : record(state.completionCandidate);
+  return validOptionalObligation(state.obligation)
+    && validFactLedger(facts)
+    && validEpisode(episode)
+    && validCorrection(correction)
+    && validCandidate(candidate)
+    && nonNegativeInteger(state.modelContinuationAttempts);
+}
+
+function validTaskControlHeader(state: Record<string, unknown> | null): state is Record<string, unknown> {
+  return Boolean(state && state.schemaVersion === 1 && nonNegativeInteger(state.goalEpoch)
+    && ["initial", "submit", "steer", "follow_up"].includes(String(state.goalEpochSource))
+    && ["normal", "focused", "repair_only", "terminal"].includes(String(state.phase)));
+}
+
+function validOptionalObligation(value: unknown): boolean {
+  return value === undefined || validObligation(value);
+}
+
+function validFactLedger(facts: Record<string, unknown> | null): boolean {
+  if (!facts || !Array.isArray(facts.entries) || !facts.entries.every(validFact)) return false;
+  return new Set(facts.entries.map((item) => item.digest)).size === facts.entries.length;
+}
+
+function validEpisode(episode: Record<string, unknown> | null): boolean {
+  return Boolean(episode && typeof episode.basisDigest === "string" && DIGEST.test(episode.basisDigest)
+    && [episode.startedRevision, episode.noProgressBatches, episode.observations].every(nonNegativeInteger)
+    && (episode.factCountAtBatchStart === undefined || nonNegativeInteger(episode.factCountAtBatchStart)));
+}
+
+function validCorrection(correction: Record<string, unknown> | null): boolean {
+  return correction === null || Boolean(typeof correction.basisDigest === "string" && DIGEST.test(correction.basisDigest)
+    && nonNegativeInteger(correction.attempts) && typeof correction.failureCode === "string");
+}
+
+function validCandidate(candidate: Record<string, unknown> | null): boolean {
+  return candidate === null || Boolean(typeof candidate.answer === "string" && candidate.answer.trim().length > 0
+    && typeof candidate.digest === "string" && DIGEST.test(candidate.digest));
+}

--- a/packages/agent-kernel/src/task-control.ts
+++ b/packages/agent-kernel/src/task-control.ts
@@ -1,0 +1,399 @@
+import { createHash } from "node:crypto";
+import type { JsonValue } from "agent-protocol";
+import type {
+  SemanticFactKindV1,
+  TaskControlStateV1,
+  TaskObligationV1
+} from "./task-control-state.js";
+import { isTaskControlStateV1 } from "./task-control-state.js";
+
+const EMPTY_BASIS = createHash("sha256").update("sigma-task-control-v1").digest("hex");
+
+/** Task-control authorities written by the published V5 state before
+ * TaskControlStateV1. They may only be consumed by the explicit snapshot
+ * migration path and must never coexist with the new reducer-owned state. */
+export const PUBLISHED_TASK_CONTROL_LEGACY_KEYS = [
+  "completionRepairAttempts",
+  "completionRepair",
+  "continuationAttempts",
+  "repeatedToolBatchCount",
+  "receiptCountAtLastUserInput",
+  "semanticProgress",
+  "semanticFailureCluster",
+  "lastToolBatchSignature",
+  "lastToolBatchOutcomeSignature"
+] as const;
+
+export function hasPublishedTaskControlLegacyFields(value: unknown): boolean {
+  const stored = record(value);
+  return Boolean(stored && PUBLISHED_TASK_CONTROL_LEGACY_KEYS.some((key) => key in stored));
+}
+
+function digest(value: unknown): string {
+  return createHash("sha256").update(JSON.stringify(value)).digest("hex");
+}
+
+export function createTaskControlState(revision = 0, goalEpoch = 0): TaskControlStateV1 {
+  return {
+    schemaVersion: 1,
+    goalEpoch,
+    goalEpochSource: "initial",
+    phase: "normal",
+    semanticFacts: { entries: [] },
+    episode: {
+      basisDigest: digest({ seed: EMPTY_BASIS, goalEpoch }),
+      startedRevision: revision,
+      noProgressBatches: 0,
+      observations: 0
+    },
+    modelContinuationAttempts: 0
+  };
+}
+
+export function beginGoalEpoch(
+  control: TaskControlStateV1,
+  revision: number,
+  source: Exclude<TaskControlStateV1["goalEpochSource"], "initial">
+): TaskControlStateV1 {
+  return { ...createTaskControlState(revision, control.goalEpoch + 1), goalEpochSource: source };
+}
+
+export function protectCompletionCandidate(control: TaskControlStateV1, answer: string): TaskControlStateV1 {
+  const normalized = answer.trim();
+  return normalized ? {
+    ...control,
+    completionCandidate: { answer: normalized, digest: digest({ answer: normalized }) }
+  } : control;
+}
+
+export function taskControlAnswer(control: TaskControlStateV1): string | null {
+  return control.completionCandidate?.answer ?? null;
+}
+
+export function openTaskObligation(
+  control: TaskControlStateV1,
+  obligation: TaskObligationV1,
+  phase: TaskControlStateV1["phase"] = "repair_only"
+): TaskControlStateV1 {
+  return {
+    ...control,
+    phase,
+    obligation,
+    policyCorrection: undefined,
+    episode: {
+      basisDigest: obligation.basisDigest,
+      startedRevision: obligation.openedRevision,
+      noProgressBatches: 0,
+      observations: 0
+    }
+  };
+}
+
+export function completionEvidenceObligation(
+  control: TaskControlStateV1,
+  revision: number,
+  stage: "acquire" | "terminal",
+  evidenceCount: number,
+  options: { failureCode?: string; originalCallId?: string; arguments?: JsonValue } = {}
+): TaskControlStateV1 {
+  const basisDigest = digest({
+    kind: "completion_evidence", goalEpoch: control.goalEpoch, stage,
+    candidate: control.completionCandidate?.digest, evidenceCount,
+    failureCode: options.failureCode,
+    originalCallId: options.originalCallId
+  });
+  return openTaskObligation(control, {
+    kind: "completion_evidence",
+    stage,
+    basisDigest,
+    openedRevision: revision,
+    attempts: 0,
+    evidenceCount,
+    ...options
+  });
+}
+
+export function terminalResolutionObligation(
+  control: TaskControlStateV1,
+  revision: number,
+  failureCode: string
+): TaskControlStateV1 {
+  const basisDigest = digest({
+    kind: "terminal_resolution", goalEpoch: control.goalEpoch, failureCode,
+    candidate: control.completionCandidate?.digest
+  });
+  return {
+    ...control,
+    phase: "terminal",
+    obligation: {
+      kind: "terminal_resolution",
+      stage: "report",
+      basisDigest,
+      openedRevision: revision,
+      attempts: 0,
+      failureCode
+    },
+    policyCorrection: undefined
+  };
+}
+
+export function reviewRepairObligation(
+  control: TaskControlStateV1,
+  revision: number,
+  reviewBasisDigest: string,
+  scopePaths: string[]
+): TaskControlStateV1 {
+  return openTaskObligation(control, {
+    kind: "review_repair",
+    stage: "mutate",
+    basisDigest: reviewBasisDigest,
+    openedRevision: revision,
+    attempts: 0,
+    scopePaths: [...new Set(scopePaths)].sort()
+  });
+}
+
+export function userDecisionObligation(
+  control: TaskControlStateV1,
+  revision: number,
+  decisionCode: string
+): TaskControlStateV1 {
+  return openTaskObligation(control, {
+    kind: "user_decision",
+    stage: "request",
+    basisDigest: digest({ kind: "user_decision", goalEpoch: control.goalEpoch, decisionCode }),
+    openedRevision: revision,
+    attempts: 0,
+    decisionCode
+  }, "terminal");
+}
+
+export function advanceReviewRepair(
+  control: TaskControlStateV1,
+  stage: "mutate" | "validate" | "re_review",
+  revision: number
+): TaskControlStateV1 {
+  const obligation = control.obligation;
+  if (obligation?.kind !== "review_repair") return control;
+  const basisDigest = digest({
+    priorBasis: obligation.basisDigest,
+    stage,
+    attempts: obligation.attempts + 1,
+    goalEpoch: control.goalEpoch
+  });
+  return openTaskObligation(control, {
+    ...obligation,
+    stage,
+    basisDigest,
+    openedRevision: revision,
+    attempts: obligation.attempts + 1
+  });
+}
+
+export function resolveTaskObligation(control: TaskControlStateV1): TaskControlStateV1 {
+  return {
+    ...control,
+    phase: "normal",
+    obligation: undefined,
+    policyCorrection: undefined,
+    episode: {
+      ...control.episode,
+      noProgressBatches: 0,
+      observations: 0,
+      factCountAtBatchStart: undefined
+    }
+  };
+}
+
+export function recordSemanticFact(
+  control: TaskControlStateV1,
+  kind: SemanticFactKindV1,
+  subject: unknown,
+  revision: number
+): { control: TaskControlStateV1; trustedProgress: boolean } {
+  const factDigest = digest({ kind, subject });
+  if (control.semanticFacts.entries.some((item) => item.digest === factDigest)) {
+    return { control, trustedProgress: false };
+  }
+  const entries = [...control.semanticFacts.entries, { kind, digest: factDigest, revision }];
+  return {
+    trustedProgress: true,
+    control: {
+      ...control,
+      phase: control.obligation ? control.phase : "normal",
+      semanticFacts: { entries },
+      policyCorrection: undefined,
+      episode: {
+        basisDigest: factDigest,
+        startedRevision: revision,
+        noProgressBatches: 0,
+        observations: control.phase === "focused" ? control.episode.observations + 1 : 0,
+        factCountAtBatchStart: control.episode.factCountAtBatchStart
+      }
+    }
+  };
+}
+
+export function startActionBatch(control: TaskControlStateV1): TaskControlStateV1 {
+  return {
+    ...control,
+    episode: { ...control.episode, factCountAtBatchStart: control.semanticFacts.entries.length }
+  };
+}
+
+export function completeActionBatch(control: TaskControlStateV1, revision: number): TaskControlStateV1 {
+  const before = control.episode.factCountAtBatchStart;
+  if (before === undefined) return control;
+  const progressed = control.semanticFacts.entries.length > before;
+  if (progressed) {
+    return {
+      ...control,
+      phase: control.obligation ? control.phase : "normal",
+      episode: { ...control.episode, noProgressBatches: 0, factCountAtBatchStart: undefined }
+    };
+  }
+  const noProgressBatches = control.episode.noProgressBatches + 1;
+  const convergenceTerminal = noProgressBatches >= 7;
+  const phase = convergenceTerminal ? "terminal"
+    : noProgressBatches >= 6 ? "repair_only"
+      : noProgressBatches >= 2 ? "focused" : control.phase;
+  const next = {
+    ...control,
+    phase,
+    episode: { ...control.episode, noProgressBatches, factCountAtBatchStart: undefined }
+  };
+  return convergenceTerminal && control.obligation?.kind !== "terminal_resolution"
+    ? terminalResolutionObligation(next, revision, "action_convergence_no_progress") : next;
+}
+
+export function recordToolPolicyViolation(
+  control: TaskControlStateV1,
+  failureCode: string,
+  revision: number
+): TaskControlStateV1 {
+  const obligation = control.obligation;
+  const basisDigest = digest({
+    goalEpoch: control.goalEpoch,
+    episodeBasisDigest: control.episode.basisDigest,
+    obligation: obligation ? {
+      kind: obligation.kind,
+      stage: obligation.stage,
+      basisDigest: obligation.basisDigest
+    } : null
+  });
+  const attempts = control.policyCorrection?.basisDigest === basisDigest
+    ? control.policyCorrection.attempts + 1 : 1;
+  const updated: TaskControlStateV1 = {
+    ...control,
+    phase: control.obligation || control.phase !== "normal" ? control.phase : "focused",
+    policyCorrection: { basisDigest, attempts, failureCode }
+  };
+  const resolutionCode = obligation?.kind === "completion_evidence" && obligation.failureCode
+    ? obligation.failureCode : failureCode;
+  return attempts >= 2 ? terminalResolutionObligation(updated, revision, resolutionCode) : updated;
+}
+
+export function taskControlFailureMessage(control: TaskControlStateV1, detail: string): string {
+  const answer = taskControlAnswer(control);
+  if (!answer || detail.startsWith(answer)) return detail;
+  return `${answer}\n\n[Task control resolution failed: ${detail}]`;
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : null;
+}
+
+function legacyCount(value: unknown): number {
+  return Number.isSafeInteger(value) && Number(value) >= 0 ? Number(value) : 0;
+}
+
+const PUBLISHED_V5_REQUIRED_KEYS = [
+  "completionRepairAttempts", "continuationAttempts", "repeatedToolBatchCount",
+  "receiptCountAtLastUserInput", "semanticProgress"
+] as const;
+
+const PUBLISHED_V5_REPAIR_KINDS = new Set([
+  "evidence_acquisition", "terminal_action", "protected_completion",
+  "completion_prerequisite", "protected_recovery"
+]);
+
+function validPublishedLegacyShape(stored: Record<string, unknown>): boolean {
+  return PUBLISHED_V5_REQUIRED_KEYS.every((key) => key in stored);
+}
+
+function validLegacyRepair(
+  stored: Record<string, unknown>,
+  repair: Record<string, unknown> | null,
+  repairAttempts: number
+): boolean {
+  if (stored.completionRepair !== undefined && !repair) return false;
+  if (repairAttempts > 0 && !repair) return false;
+  return !repair || typeof repair.kind === "string" && PUBLISHED_V5_REPAIR_KINDS.has(repair.kind);
+}
+
+function migrateLegacyRepair(
+  control: TaskControlStateV1,
+  repair: Record<string, unknown> | null,
+  revision: number
+): TaskControlStateV1 {
+  const answer = typeof repair?.answer === "string" ? repair.answer.trim() : "";
+  const protectedControl = answer ? protectCompletionCandidate(control, answer) : control;
+  if (repair?.kind === "evidence_acquisition") {
+    return completionEvidenceObligation(protectedControl, revision, "acquire", 0);
+  }
+  if (repair?.kind === "terminal_action" || repair?.kind === "protected_completion") {
+    return completionEvidenceObligation(protectedControl, revision, "terminal", 0);
+  }
+  if (repair?.kind !== "completion_prerequisite") return protectedControl;
+  return completionEvidenceObligation(
+    protectedControl,
+    revision,
+    "acquire",
+    legacyCount(repair.evidenceCount),
+    {
+      ...(typeof repair.originalCallId === "string" ? { originalCallId: repair.originalCallId } : {}),
+      ...(repair.arguments === undefined ? {} : { arguments: repair.arguments as JsonValue })
+    }
+  );
+}
+
+function phaseForLegacyDebt(
+  current: TaskControlStateV1["phase"],
+  noProgressBatches: number
+): TaskControlStateV1["phase"] {
+  if (noProgressBatches >= 7) return "terminal";
+  if (noProgressBatches >= 6) return "repair_only";
+  if (noProgressBatches >= 2) return "focused";
+  return current;
+}
+
+/** Migrate only fields written by published V5 main. Experimental #55 state
+ * carries separate versioned markers and is deliberately rejected by restore. */
+export function migratePublishedTaskControlState(value: unknown, revision: number): TaskControlStateV1 | null {
+  const stored = record(value);
+  if (!stored) return null;
+  if (isTaskControlStateV1(stored.taskControl)) {
+    return hasPublishedTaskControlLegacyFields(stored) ? null : stored.taskControl;
+  }
+  if (!validPublishedLegacyShape(stored)) return null;
+  const repair = stored.completionRepair === undefined ? null : record(stored.completionRepair);
+  const repairAttempts = legacyCount(stored.completionRepairAttempts);
+  if (!validLegacyRepair(stored, repair, repairAttempts)) return null;
+  const control = migrateLegacyRepair(createTaskControlState(revision), repair, revision);
+  const cluster = record(stored.semanticFailureCluster);
+  const noProgressBatches = Math.max(
+    legacyCount(stored.repeatedToolBatchCount),
+    legacyCount(cluster?.attempts)
+  );
+  const phase = phaseForLegacyDebt(control.phase, noProgressBatches);
+  const obligation = control.obligation && repairAttempts > 0
+    ? { ...control.obligation, attempts: repairAttempts }
+    : control.obligation;
+  return {
+    ...control,
+    phase,
+    ...(obligation ? { obligation } : {}),
+    modelContinuationAttempts: legacyCount(stored.continuationAttempts),
+    episode: { ...control.episode, noProgressBatches }
+  };
+}

--- a/packages/agent-kernel/src/task-control.ts
+++ b/packages/agent-kernel/src/task-control.ts
@@ -6,6 +6,7 @@ import type {
   TaskObligationV1
 } from "./task-control-state.js";
 import { isTaskControlStateV1 } from "./task-control-state.js";
+import { policyExhaustionCode } from "./task-control-resolution.js";
 
 const EMPTY_BASIS = createHash("sha256").update("sigma-task-control-v1").digest("hex");
 
@@ -288,8 +289,7 @@ export function recordToolPolicyViolation(
     phase: control.obligation || control.phase !== "normal" ? control.phase : "focused",
     policyCorrection: { basisDigest, attempts, failureCode }
   };
-  const resolutionCode = obligation?.kind === "completion_evidence" && obligation.failureCode
-    ? obligation.failureCode : failureCode;
+  const resolutionCode = policyExhaustionCode(control);
   return attempts >= 2 ? terminalResolutionObligation(updated, revision, resolutionCode) : updated;
 }
 

--- a/packages/agent-kernel/src/terminal-reducer-helpers.ts
+++ b/packages/agent-kernel/src/terminal-reducer-helpers.ts
@@ -9,11 +9,15 @@ import {
   requestedInput
 } from "./model-convergence.js";
 import {
-  semanticInfrastructureFailureMessage,
-  SEMANTIC_INFRASTRUCTURE_FAILURE_CODE
+  semanticInfrastructureFailureMessage
 } from "./semantic-failures.js";
 import { isCurrentModelTurn, modelTurn } from "./model-event-parsing.js";
 import type { KernelState, PendingTool } from "./state.js";
+import {
+  completionEvidenceObligation,
+  protectCompletionCandidate,
+  recordToolPolicyViolation
+} from "./task-control.js";
 
 export function nextPhase(pending: readonly PendingTool[]): KernelState["phase"] {
   if (pending.some((item) => item.approval === "pending")) return "needs_input";
@@ -60,8 +64,11 @@ export function terminalState(state: KernelState, outcome: RunOutcome): KernelSt
     activeModelTurn: undefined,
     activeModelSemanticDelta: undefined,
     pendingTools: [],
-    completionRepairAttempts: 0,
-    completionRepair: undefined,
+    taskControl: {
+      ...state.taskControl,
+      phase: "terminal",
+      policyCorrection: undefined
+    },
     proposedOutcome: undefined,
     outcome
   };
@@ -81,7 +88,7 @@ export function protectedToolBatchFailure(
   state: KernelState,
   calls: readonly ModelToolCall[]
 ): { code: "terminal_batch_conflict" | "terminal_protocol_invalid"; message: string } | null {
-  if (state.completionRepair?.kind !== "protected_completion") return null;
+  if (!state.taskControl.completionCandidate || state.taskControl.phase !== "terminal") return null;
   const terminal = calls[0]?.name === "runtime_finalize" || calls[0]?.name === "report_blocked"
     || calls[0]?.name === "request_user_input";
   if (calls.length === 1 && terminal) return null;
@@ -157,18 +164,22 @@ function hasCurrentFailedValidation(state: KernelState): boolean {
 
 function invalidBlockedReportState(state: KernelState, progressed: KernelState): KernelState | null {
   if (hasCurrentFailedValidation(progressed)) return null;
-  if (state.completionRepairAttempts >= 2) {
-    return proposedOutcomeState(progressed, {
+  const taskControl = recordToolPolicyViolation(
+    progressed.taskControl,
+    "invalid_blocked_report",
+    progressed.revision
+  );
+  if (taskControl.phase === "terminal") {
+    return proposedOutcomeState({ ...progressed, taskControl }, {
       kind: "recoverable_failure",
-      code: "convergence_no_progress",
+      code: "invalid_blocked_report",
       message: "report_blocked was repeated without a failed validation on the current workspace state."
     });
   }
   return {
     ...progressed,
     phase: "ready_model",
-    completionRepairAttempts: state.completionRepairAttempts + 1,
-    completionRepair: { kind: "terminal_action" },
+    taskControl,
     messages: [...progressed.messages, {
       role: "developer",
       content: "report_blocked requires a failed semantic validation on the current workspace state. Continue repair or validation, complete if the frontier is ready, or request user input only for a genuine user decision."
@@ -187,41 +198,83 @@ function isCompletionPrerequisiteFailure(input: TerminalReceiptTransition): bool
   return input.receipt.diagnostics.some((code) => COMPLETION_PREREQUISITE_CODES.has(code));
 }
 
+function completionPrerequisiteCode(input: TerminalReceiptTransition): string {
+  return input.receipt.diagnostics.find((code) => COMPLETION_PREREQUISITE_CODES.has(code))
+    ?? "completion_prerequisite_unresolved";
+}
+
+function completionPrerequisiteExhausted(input: TerminalReceiptTransition, retryCount: number): KernelState | null {
+  if (retryCount < 2) return null;
+  const failureCode = completionPrerequisiteCode(input);
+  return proposedOutcomeState(input.progressed, {
+    kind: "recoverable_failure",
+    code: failureCode,
+    message: completionRepairFailureMessage(
+      input.state,
+      `Completion prerequisite ${failureCode} remained unresolved after two correction turns.`
+    )
+  });
+}
+
+function completionCandidateForReceipt(input: TerminalReceiptTransition, summary: string): string {
+  return protectedCompletionAnswer(input.state)
+    || assistantBodyForToolCall(input.state, input.receipt.callId)
+    || summary;
+}
+
+function withCompletionRepairAttempts(
+  taskControl: KernelState["taskControl"],
+  attempts: number
+): KernelState["taskControl"] {
+  return taskControl.obligation?.kind === "completion_evidence"
+    ? { ...taskControl, obligation: { ...taskControl.obligation, attempts } }
+    : taskControl;
+}
+
+function pendingCompletionTool(input: TerminalReceiptTransition): PendingTool | undefined {
+  return input.state.pendingTools.find((item) => item.request.callId === input.receipt.callId);
+}
+
+function completionRepairSummary(pending: PendingTool): string {
+  const raw = pending.request.arguments;
+  if (raw && typeof raw === "object" && !Array.isArray(raw) && typeof raw.summary === "string") {
+    return raw.summary;
+  }
+  return "Task completion is awaiting required evidence.";
+}
+
 function completionPrerequisiteRepair(input: TerminalReceiptTransition): KernelState | null {
   if (!isCompletionPrerequisiteFailure(input)) return null;
-  const pending = input.state.pendingTools.find((item) => item.request.callId === input.receipt.callId);
-  if (!pending) return null;
-  const previous = input.state.completionRepair?.kind === "completion_prerequisite"
-    ? input.state.completionRepair : undefined;
-  const retryCount = previous ? previous.retryCount + 1 : 0;
-  if (retryCount >= 2) {
-    return proposedOutcomeState(input.progressed, {
-      kind: "recoverable_failure",
-      code: "convergence_no_progress",
-      message: completionRepairFailureMessage(
-        input.state,
-        "Completion prerequisites remained unresolved after two correction turns."
-      )
-    });
+  if (input.progressed.taskControl.obligation?.kind === "review_repair") {
+    return { ...input.progressed, phase: "ready_model" };
   }
-  const raw = pending.request.arguments;
-  const summary = raw && typeof raw === "object" && !Array.isArray(raw)
-    && typeof raw.summary === "string" ? raw.summary : "Task completion is awaiting required evidence.";
+  const pending = pendingCompletionTool(input);
+  if (!pending) return null;
+  const previous = input.state.taskControl.obligation?.kind === "completion_evidence"
+    ? input.state.taskControl.obligation : undefined;
+  const retryCount = previous ? previous.attempts + 1 : 0;
+  const exhausted = completionPrerequisiteExhausted(input, retryCount);
+  if (exhausted) return exhausted;
+  const summary = completionRepairSummary(pending);
+  const protectedControl = protectCompletionCandidate(
+    input.progressed.taskControl,
+    completionCandidateForReceipt(input, summary)
+  );
+  const taskControl = completionEvidenceObligation(
+    protectedControl,
+    input.progressed.revision,
+    "acquire",
+    currentRunReferenceableEvidenceCount(input.progressed),
+    {
+      failureCode: previous?.failureCode ?? completionPrerequisiteCode(input),
+      originalCallId: previous?.originalCallId ?? input.receipt.callId,
+      arguments: pending.request.arguments
+    }
+  );
   return {
     ...input.progressed,
     phase: "ready_model",
-    completionRepairAttempts: Math.max(1, input.state.completionRepairAttempts),
-    completionRepair: {
-      kind: "completion_prerequisite",
-      answer: protectedCompletionAnswer(input.state)
-        || assistantBodyForToolCall(input.state, input.receipt.callId)
-        || summary,
-      arguments: pending.request.arguments,
-      originalCallId: previous?.originalCallId ?? input.receipt.callId,
-      evidenceCount: currentRunReferenceableEvidenceCount(input.progressed),
-      retryCount,
-      modelTurn: pending.modelTurn
-    }
+    taskControl: withCompletionRepairAttempts(taskControl, retryCount)
   };
 }
 
@@ -236,45 +289,64 @@ export interface TerminalReceiptTransition {
   semanticLimitReached: boolean;
 }
 
-export function terminalReceiptTransition(input: TerminalReceiptTransition): KernelState | null {
-  const inputMessage = requestedInput(input.receipt);
-  if (inputMessage) {
-    const failure = terminalReceiptFailure(input.state, input.progressed, input.toolName, "request_input");
-    if (failure) return failure;
-    return proposedOutcomeState(input.progressed, {
+function explicitTerminalFailure(input: TerminalReceiptTransition): KernelState | null {
+  if (input.toolName !== "runtime_finalize" || input.receipt.ok || input.remainingTools !== 0) return null;
+  const failureCode = input.receipt.diagnostics.find((code) =>
+    code === "validation_failed" || code === "review_unavailable");
+  if (!failureCode) return null;
+  return proposedOutcomeState(input.progressed, {
+    kind: "recoverable_failure",
+    code: failureCode,
+    message: completionRepairFailureMessage(input.state, input.receipt.output)
+  });
+}
+
+function requestedInputTransition(input: TerminalReceiptTransition): KernelState | null {
+  const message = requestedInput(input.receipt);
+  if (!message) return null;
+  return terminalReceiptFailure(input.state, input.progressed, input.toolName, "request_input")
+    ?? proposedOutcomeState(input.progressed, {
       kind: "needs_input",
       requestId: input.receipt.callId,
-      message: inputMessage
+      message
     });
-  }
-  const blocked = blockedReport(input.receipt);
-  if (blocked) {
-    const failure = terminalReceiptFailure(input.state, input.progressed, input.toolName, "report_blocked");
-    if (failure) return failure;
-    const invalid = invalidBlockedReportState(input.state, input.progressed);
-    if (invalid) return invalid;
-    return proposedOutcomeState(input.progressed, {
+}
+
+function blockedReportTransition(input: TerminalReceiptTransition): KernelState | null {
+  const report = blockedReport(input.receipt);
+  if (!report) return null;
+  return terminalReceiptFailure(input.state, input.progressed, input.toolName, "report_blocked")
+    ?? invalidBlockedReportState(input.state, input.progressed)
+    ?? proposedOutcomeState(input.progressed, {
       kind: "recoverable_failure",
-      code: blocked.code,
-      message: blocked.message
+      code: report.code,
+      message: report.message
     });
-  }
+}
+
+function completionTransition(input: TerminalReceiptTransition): KernelState | null {
   const summary = completionSummary(input.receipt);
-  if (summary) {
-    const failure = terminalReceiptFailure(input.state, input.progressed, input.toolName, "complete");
-    if (failure) return failure;
-    const sameTurnAnswer = assistantBodyForToolCall(input.state, input.receipt.callId);
-    return proposedOutcomeState(input.progressed, {
-      kind: "completed",
-      // A protected substantive answer is intentionally immutable during its
-      // terminal repair. On an ordinary completion, retain both handoff
-      // surfaces so a generic same-turn status cannot hide
-      // the structured completion summary.
-      message: `${protectedCompletionAnswer(input.state)
-        || ordinaryCompletionMessage(sameTurnAnswer, summary)}${advisoryReviewWarnings(input.progressed)}`,
-      evidence: input.progressed.evidence
-    });
-  }
+  if (!summary) return null;
+  const failure = terminalReceiptFailure(input.state, input.progressed, input.toolName, "complete");
+  if (failure) return failure;
+  const sameTurnAnswer = assistantBodyForToolCall(input.state, input.receipt.callId);
+  return proposedOutcomeState(input.progressed, {
+    kind: "completed",
+    message: `${ordinaryCompletionMessage(
+      protectedCompletionAnswer(input.state) || sameTurnAnswer,
+      summary
+    )}${advisoryReviewWarnings(input.progressed)}`,
+    evidence: input.progressed.evidence
+  });
+}
+
+export function terminalReceiptTransition(input: TerminalReceiptTransition): KernelState | null {
+  const terminalOutcome = requestedInputTransition(input)
+    ?? blockedReportTransition(input)
+    ?? completionTransition(input);
+  if (terminalOutcome) return terminalOutcome;
+  const explicitFailure = explicitTerminalFailure(input);
+  if (explicitFailure) return explicitFailure;
   const prerequisiteRepair = completionPrerequisiteRepair(input);
   if (prerequisiteRepair) return prerequisiteRepair;
   const failedRepair = failedTerminalRepairState(
@@ -285,11 +357,13 @@ export function terminalReceiptTransition(input: TerminalReceiptTransition): Ker
     input.remainingTools
   );
   if (failedRepair) return failedRepair;
-  if (input.semanticLimitReached && input.remainingTools === 0 && input.progressed.semanticFailureCluster) {
+  const terminalResolution = input.progressed.taskControl.obligation;
+  if (input.semanticLimitReached && input.remainingTools === 0
+    && terminalResolution?.kind === "terminal_resolution") {
     return proposedOutcomeState(input.progressed, {
       kind: "recoverable_failure",
-      code: SEMANTIC_INFRASTRUCTURE_FAILURE_CODE,
-      message: semanticInfrastructureFailureMessage(input.progressed.semanticFailureCluster)
+      code: terminalResolution.failureCode,
+      message: semanticInfrastructureFailureMessage(input.progressed)
     });
   }
   return null;

--- a/packages/agent-kernel/src/tool-batch-progress.ts
+++ b/packages/agent-kernel/src/tool-batch-progress.ts
@@ -1,108 +1,31 @@
-import { createHash } from "node:crypto";
-import type { JsonValue, ModelToolCall, ToolReceipt } from "agent-protocol";
-import { toolBatchSignature } from "./model-convergence.js";
 import type { KernelState } from "./state.js";
+import {
+  completeActionBatch,
+  recordToolPolicyViolation,
+  startActionBatch
+} from "./task-control.js";
 
-type ToolBatchProgress = Pick<
-  KernelState,
-  "lastToolBatchSignature" | "lastToolBatchOutcomeSignature" | "repeatedToolBatchCount"
->;
-
-function uniqueSorted(values: readonly string[]): string[] {
-  return [...new Set(values)].sort();
+export function startedToolBatchProgress(state: KernelState): Pick<KernelState, "taskControl"> {
+  return { taskControl: startActionBatch(state.taskControl) };
 }
 
-function canonicalJson(value: JsonValue): string {
-  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
-  if (value && typeof value === "object") {
-    return `{${Object.entries(value).sort(([left], [right]) => left.localeCompare(right))
-      .map(([key, item]) => `${JSON.stringify(key)}:${canonicalJson(item)}`).join(",")}}`;
-  }
-  return JSON.stringify(value);
-}
-
-function contentIdentity(value: JsonValue): JsonValue {
-  const serialized = typeof value === "string" ? value : canonicalJson(value);
-  return {
-    characters: serialized.length,
-    sha256: createHash("sha256").update(serialized, "utf8").digest("hex")
-  };
-}
-
-function receiptSemantics(receipt: ToolReceipt): JsonValue {
-  const outcome = receipt.outcome ?? {
-    status: receipt.ok ? "succeeded" as const : "failed" as const,
-    output: contentIdentity(receipt.output),
-    diagnosticCodes: receipt.diagnostics
-  };
-  const artifactRefs = (receipt.artifactRefs ?? []).map((artifact) => ({
-    name: artifact.name,
-    digest: artifact.digest,
-    ...(artifact.mediaType === undefined ? {} : { mediaType: artifact.mediaType }),
-    ...(artifact.sizeBytes === undefined ? {} : { sizeBytes: artifact.sizeBytes })
-  }));
-  return {
-    ok: receipt.ok,
-    output: receipt.output,
-    outcome: {
-      status: outcome.status,
-      output: contentIdentity(outcome.output),
-      diagnosticCodes: uniqueSorted(outcome.diagnosticCodes)
-    },
-    diagnostics: uniqueSorted(receipt.diagnostics),
-    observedEffects: uniqueSorted(receipt.observedEffects),
-    actualEffects: uniqueSorted(receipt.actualEffects ?? receipt.observedEffects),
-    workspaceDelta: {
-      added: uniqueSorted(receipt.workspaceDelta?.added ?? []),
-      modified: uniqueSorted(receipt.workspaceDelta?.modified ?? []),
-      deleted: uniqueSorted(receipt.workspaceDelta?.deleted ?? [])
-    },
-    artifacts: artifactRefs.length > 0
-      ? artifactRefs.sort((left, right) => canonicalJson(left).localeCompare(canonicalJson(right)))
-      : uniqueSorted(receipt.artifacts)
-  };
-}
-
-function completedOutcomeSignature(calls: ModelToolCall[], receipts: Map<string, ToolReceipt>): string | null {
-  const entries = calls.flatMap((call): string[] => {
-    const receipt = receipts.get(call.id);
-    return receipt ? [canonicalJson({
-      call: { name: call.name, arguments: call.arguments },
-      receipt: receiptSemantics(receipt)
-    })] : [];
-  });
-  if (entries.length !== calls.length) return null;
-  return createHash("sha256").update(canonicalJson(entries.sort())).digest("hex");
-}
-
-function resetProgress(): ToolBatchProgress {
-  return {
-    lastToolBatchSignature: undefined,
-    lastToolBatchOutcomeSignature: undefined,
-    repeatedToolBatchCount: 0
-  };
-}
-
-export function repeatsCompletedToolBatch(state: KernelState, calls: ModelToolCall[]): boolean {
-  return state.repeatedToolBatchCount >= 2
-    && typeof state.lastToolBatchOutcomeSignature === "string"
-    && toolBatchSignature(calls) === state.lastToolBatchSignature;
-}
-
-export function completedToolBatchProgress(state: KernelState, completedCallId: string): ToolBatchProgress {
+export function completedToolBatchProgress(state: KernelState): Pick<KernelState, "taskControl"> {
+  let taskControl = completeActionBatch(state.taskControl, state.revision);
   const calls = [...state.messages].reverse().find((message) => message.role === "assistant"
-    && message.toolCalls?.some((call) => call.id === completedCallId))?.toolCalls;
-  if (!calls?.length) return resetProgress();
+    && message.toolCalls?.some((call) => state.receipts.some((receipt) => receipt.callId === call.id)))?.toolCalls ?? [];
   const receipts = new Map(state.receipts.map((receipt) => [receipt.callId, receipt]));
-  const outcomeSignature = completedOutcomeSignature(calls, receipts);
-  if (!outcomeSignature) return resetProgress();
-  const callSignature = toolBatchSignature(calls);
-  const repeatedToolBatchCount = callSignature === state.lastToolBatchSignature
-    && outcomeSignature === state.lastToolBatchOutcomeSignature
-    ? state.repeatedToolBatchCount + 1 : 1;
-  return {
-    lastToolBatchSignature: callSignature,
-    lastToolBatchOutcomeSignature: outcomeSignature,
-    repeatedToolBatchCount
-  };
+  const policyFailures = calls.flatMap((call) => {
+    const receipt = receipts.get(call.id);
+    const codes = receipt ? [...new Set([...(receipt.outcome?.diagnosticCodes ?? []), ...receipt.diagnostics])] : [];
+    return codes.some((code) => code === "model_tool_policy_violation" || code === "tool_unavailable_for_repair")
+      ? [call.name] : [];
+  });
+  if (policyFailures.length > 0) {
+    taskControl = recordToolPolicyViolation(
+      taskControl,
+      "model_tool_policy_violation",
+      state.revision
+    );
+  }
+  return { taskControl };
 }

--- a/packages/agent-protocol/src/domain-schema-primitives.ts
+++ b/packages/agent-protocol/src/domain-schema-primitives.ts
@@ -1,0 +1,49 @@
+import { z } from "zod";
+import type { JsonValue } from "./json.js";
+
+export const jsonValueSchema: z.ZodType<JsonValue> = z.lazy(() => z.union([
+  z.null(),
+  z.boolean(),
+  z.number(),
+  z.string(),
+  z.array(jsonValueSchema),
+  z.record(z.string(), jsonValueSchema)
+]));
+
+export const nonEmptyStringSchema = z.string().min(1);
+export const dateTimeSchema = z.string().refine(
+  (value) => Number.isFinite(Date.parse(value)),
+  "Expected an ISO-compatible date-time string"
+);
+export const nonNegativeIntegerSchema = z.number().int().nonnegative();
+export const digestSchema = z.string().regex(/^[a-f0-9]{64}$/u);
+
+export const evidenceKindSchema = z.enum([
+  "workspace_delta", "repository_delta", "command", "validation", "diagnostic",
+  "input_access", "review", "checkpoint", "child_outcome", "user_waiver", "restoration"
+]);
+export const evidenceStatusSchema = z.enum(["passed", "failed", "warning", "informational"]);
+export const evidenceClaimSchema = z.enum([
+  "acceptance_met", "validation_executed", "validation_passed"
+]);
+export const evidenceAuthoritySchema = z.enum(["system", "developer", "user", "project", "runtime", "tool"]);
+export const evidenceProducerSchema = z.object({
+  authority: evidenceAuthoritySchema,
+  id: z.string().optional()
+}).strict();
+
+export const checkpointDeltaSchema = z.object({
+  added: z.array(z.string()),
+  modified: z.array(z.string()),
+  deleted: z.array(z.string())
+}).strict();
+
+export const evidenceBaseShape = {
+  evidenceId: nonEmptyStringSchema,
+  sessionId: nonEmptyStringSchema,
+  runId: nonEmptyStringSchema,
+  status: evidenceStatusSchema,
+  createdAt: dateTimeSchema,
+  producer: evidenceProducerSchema,
+  summary: nonEmptyStringSchema
+};

--- a/packages/agent-protocol/src/domain-schemas.ts
+++ b/packages/agent-protocol/src/domain-schemas.ts
@@ -1,41 +1,27 @@
 import { z } from "zod";
-import type { JsonValue } from "./json.js";
-
-export const jsonValueSchema: z.ZodType<JsonValue> = z.lazy(() => z.union([
-  z.null(),
-  z.boolean(),
-  z.number(),
-  z.string(),
-  z.array(jsonValueSchema),
-  z.record(z.string(), jsonValueSchema)
-]));
-
-export const nonEmptyStringSchema = z.string().min(1);
-export const dateTimeSchema = z.string().refine(
-  (value) => Number.isFinite(Date.parse(value)),
-  "Expected an ISO-compatible date-time string"
-);
-export const nonNegativeIntegerSchema = z.number().int().nonnegative();
-
-export const evidenceKindSchema = z.enum([
-  "workspace_delta", "repository_delta", "command", "validation", "diagnostic",
-  "input_access", "review", "checkpoint", "child_outcome", "user_waiver"
-]);
-export const evidenceStatusSchema = z.enum(["passed", "failed", "warning", "informational"]);
-export const evidenceClaimSchema = z.enum([
-  "acceptance_met", "validation_executed", "validation_passed"
-]);
-export const evidenceAuthoritySchema = z.enum(["system", "developer", "user", "project", "runtime", "tool"]);
-export const evidenceProducerSchema = z.object({
-  authority: evidenceAuthoritySchema,
-  id: z.string().optional()
-}).strict();
-
-export const checkpointDeltaSchema = z.object({
-  added: z.array(z.string()),
-  modified: z.array(z.string()),
-  deleted: z.array(z.string())
-}).strict();
+import {
+  checkpointDeltaSchema,
+  dateTimeSchema,
+  digestSchema,
+  evidenceBaseShape,
+  evidenceClaimSchema,
+  evidenceKindSchema,
+  jsonValueSchema,
+  nonEmptyStringSchema,
+  nonNegativeIntegerSchema
+} from "./domain-schema-primitives.js";
+export {
+  checkpointDeltaSchema,
+  dateTimeSchema,
+  evidenceAuthoritySchema,
+  evidenceClaimSchema,
+  evidenceKindSchema,
+  evidenceProducerSchema,
+  evidenceStatusSchema,
+  jsonValueSchema,
+  nonEmptyStringSchema,
+  nonNegativeIntegerSchema
+} from "./domain-schema-primitives.js";
 
 const opaqueArtifactIdentitySchema = z.object({
   digest: z.string().regex(/^[a-f0-9]{64}$/u),
@@ -51,16 +37,6 @@ export const opaqueArtifactEvidenceSchema = z.object({
   (value) => value.before !== undefined || value.after !== undefined,
   "Opaque artifact evidence must contain a before or after identity"
 );
-
-const evidenceBaseShape = {
-  evidenceId: nonEmptyStringSchema,
-  sessionId: nonEmptyStringSchema,
-  runId: nonEmptyStringSchema,
-  status: evidenceStatusSchema,
-  createdAt: dateTimeSchema,
-  producer: evidenceProducerSchema,
-  summary: nonEmptyStringSchema
-};
 
 export const workspaceDeltaEvidenceSchema = z.object({
   ...evidenceBaseShape,
@@ -80,8 +56,6 @@ export const workspaceDeltaEvidenceSchema = z.object({
     }).strict().optional()
   }).strict()
 }).strict();
-
-const digestSchema = z.string().regex(/^[a-f0-9]{64}$/u);
 
 export const mutationFrontierSchema = z.object({
   revision: nonNegativeIntegerSchema,
@@ -193,8 +167,10 @@ export const reviewEvidenceSchema = z.object({
     stateDigest: digestSchema,
     reviewBasisDigest: digestSchema.optional(),
     validationEvidenceIds: z.array(z.string()).optional(),
-    failureKind: z.enum(["infrastructure", "interrupted"]).optional(),
-    failureCode: z.literal("review_scope_too_large").optional(),
+    failureKind: z.enum(["infrastructure", "interrupted", "protocol"]).optional(),
+    failureCode: z.enum([
+      "review_scope_too_large", "review_protocol_invalid", "review_unavailable"
+    ]).optional(),
     checkpointId: z.string().optional()
   }).strict()
 }).strict();
@@ -233,6 +209,31 @@ export const userWaiverEvidenceSchema = z.object({
   }).strict()
 }).strict();
 
+export const workspaceRestorationEvidenceV1Schema = z.object({
+  ...evidenceBaseShape,
+  kind: z.literal("restoration"),
+  data: z.object({
+    schemaVersion: z.literal(1),
+    goalEpoch: nonNegativeIntegerSchema,
+    frontierRevision: nonNegativeIntegerSchema,
+    frontierStateDigest: digestSchema,
+    baselineManifestDigest: digestSchema,
+    currentManifestDigest: digestSchema,
+    restoredCheckpointIds: z.array(nonEmptyStringSchema),
+    quiescence: z.object({
+      supersededExecutionStopped: z.literal(true),
+      noPendingMutations: z.literal(true),
+      noProcesses: z.literal(true),
+      noChildren: z.literal(true),
+      noOpenCheckpoint: z.literal(true)
+    }).strict(),
+    repository: z.object({
+      status: z.enum(["unchanged", "restored"]),
+      stateDigest: digestSchema.optional()
+    }).strict()
+  }).strict()
+}).strict();
+
 export const evidenceRecordSchema = z.discriminatedUnion("kind", [
   workspaceDeltaEvidenceSchema,
   repositoryDeltaEvidenceSchema,
@@ -243,7 +244,8 @@ export const evidenceRecordSchema = z.discriminatedUnion("kind", [
   reviewEvidenceSchema,
   checkpointEvidenceSchema,
   childOutcomeEvidenceSchema,
-  userWaiverEvidenceSchema
+  userWaiverEvidenceSchema,
+  workspaceRestorationEvidenceV1Schema
 ]);
 
 export const modelExecutionRoleSchema = z.enum([

--- a/packages/agent-protocol/src/domain-types.ts
+++ b/packages/agent-protocol/src/domain-types.ts
@@ -28,6 +28,7 @@ import type {
   repositoryDeltaEvidenceSchema,
   usageRecordSchema,
   userWaiverEvidenceSchema,
+  workspaceRestorationEvidenceV1Schema,
   validationEvidenceSchema,
   workspaceDeltaEvidenceSchema
 } from "./domain-schemas.js";
@@ -65,6 +66,7 @@ export type ReviewEvidence = z.infer<typeof reviewEvidenceSchema>;
 export type CheckpointEvidence = z.infer<typeof checkpointEvidenceSchema>;
 export type ChildOutcomeEvidence = z.infer<typeof childOutcomeEvidenceSchema>;
 export type UserWaiverEvidence = z.infer<typeof userWaiverEvidenceSchema>;
+export type WorkspaceRestorationEvidenceV1 = z.infer<typeof workspaceRestorationEvidenceV1Schema>;
 export type EvidenceRecord = z.infer<typeof evidenceRecordSchema>;
 export type EvidenceRef = z.infer<typeof evidenceRefSchema>;
 

--- a/packages/agent-protocol/src/event-payload-schemas-core.ts
+++ b/packages/agent-protocol/src/event-payload-schemas-core.ts
@@ -103,6 +103,13 @@ const diagnosticSchema = z.discriminatedUnion("kind", [
   }).strict(),
   z.object({ kind: z.literal("recovery.retry_model"), message: nonEmptyStringSchema }).strict(),
   z.object({
+    kind: z.literal("tool.batch_settled"),
+    callId: nonEmptyStringSchema,
+    ok: z.boolean(),
+    evidenceIds: z.array(nonEmptyStringSchema),
+    diagnosticCodes: z.array(nonEmptyStringSchema)
+  }).strict(),
+  z.object({
     kind: z.literal("deadline.stage"),
     stage: z.enum(["normal", "converge", "stop"]),
     budgetStage: z.enum(["normal", "converge", "terminal"]).optional(),

--- a/packages/agent-protocol/src/tools.ts
+++ b/packages/agent-protocol/src/tools.ts
@@ -6,7 +6,8 @@ import type {
   EvidenceRecord,
   BudgetAmounts,
   BudgetLimits,
-  PlanGraph
+  PlanGraph,
+  WorkspaceRestorationEvidenceV1
 } from "./domain.js";
 import type { RunMode } from "./outcomes.js";
 import type { ExecutionIntentV1, ResolvedExecutionCapabilityV1 } from "./execution-v5.js";
@@ -129,6 +130,8 @@ export interface RuntimeControlPort {
   listCheckpoints(): Promise<CheckpointRef[]>;
   createCheckpoint(scopePaths: string[]): Promise<CheckpointRef>;
   restoreRunCheckpoint(checkpointId: string): Promise<CheckpointRef>;
+  restoreRunChanges(callId: string): Promise<WorkspaceRestorationEvidenceV1["data"]>;
+  confirmRunRestored(callId: string): Promise<WorkspaceRestorationEvidenceV1["data"]>;
   requestReview(): Promise<ReviewRequestResult>;
   loadSkill(qualifiedName: string): Promise<{ content: string; evidence: EvidenceRecord }>;
   resolveLoadedSkillResource(input: {
@@ -143,7 +146,8 @@ export interface RuntimeControlPort {
 }
 
 export interface ReviewRequestResult {
-  status: "review_requested" | "validation_required" | "changes_required" | "not_required";
+  status: "review_requested" | "approved" | "validation_required" | "changes_required"
+    | "review_unavailable" | "not_required";
   reviewState: "none" | "current" | "stale";
   reviewBasisDigest: string;
   frontierRevision: number;

--- a/packages/agent-runtime/src/capability-failure-convergence.ts
+++ b/packages/agent-runtime/src/capability-failure-convergence.ts
@@ -3,27 +3,8 @@ import { failed } from "./effect-helpers.js";
 import { failureCode } from "./tool-transaction-support.js";
 import type { RuntimeSession } from "./types.js";
 
-const CAPABILITY_FAILURE_CODES = new Set([
-  "filesystem_acl_unsupported", "external_read_required", "write_scope_invalid",
-  "network_capability_unavailable", "network_unavailable", "toolchain_unavailable",
-  "container_unavailable", "sandbox_recovery_required", "sandbox_unavailable",
-  "sandbox_recovery_failed"
-]);
-
-function canonical(value: unknown): string {
-  if (value === null || typeof value !== "object") return JSON.stringify(value);
-  if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`;
-  return `{${Object.entries(value as Record<string, unknown>)
-    .sort(([left], [right]) => left.localeCompare(right))
-    .map(([key, item]) => `${JSON.stringify(key)}:${canonical(item)}`).join(",")}}`;
-}
-
-function capabilityFailureKey(code: string, call: ModelToolCall): string {
-  return `${code}:${call.name}:${canonical(call.arguments)}`;
-}
-
 export function convergedToolFailure(
-  session: RuntimeSession,
+  _session: RuntimeSession,
   call: ModelToolCall,
   startedAt: string,
   error: unknown,
@@ -31,18 +12,8 @@ export function convergedToolFailure(
 ): ToolReceipt {
   if ((error as { code?: unknown })?.code === "approval_needs_input") throw error;
   const code = failureCode(error, signal);
-  if (CAPABILITY_FAILURE_CODES.has(code)) {
-    const key = capabilityFailureKey(code, call);
-    const attempts = (session.interaction.capabilityFailures.get(key) ?? 0) + 1;
-    session.interaction.capabilityFailures.set(key, attempts);
-    if (attempts >= 2) {
-      return failed(
-        call,
-        startedAt,
-        `Execution capability '${code}' failed twice. Runtime retries are exhausted; a weaker validation is not an acceptable substitute.`,
-        "capability_retry_exhausted"
-      );
-    }
-  }
+  // Retry/convergence authority belongs exclusively to TaskControlStateV1.
+  // This adapter only turns the concrete operation failure into a durable
+  // receipt; it must not maintain a second, argument-sensitive retry ledger.
   return failed(call, startedAt, error instanceof Error ? error.message : String(error), code);
 }

--- a/packages/agent-runtime/src/completion-evidence-gate.ts
+++ b/packages/agent-runtime/src/completion-evidence-gate.ts
@@ -172,8 +172,24 @@ function requiredReviewFailure(
 ): ToolReceipt | null {
   if (reviewMode(session) !== "required" && assuranceRequirement(session).review !== "required") return null;
   const frontier = session.durable.state.mutationFrontier;
-  const review = currentFrontierReview(session);
+  const candidateDigest = session.durable.state.taskControl.completionCandidate?.digest;
+  const review = currentFrontierReview(session, candidateDigest);
   if (review?.status === "passed" && review.data.verdict === "approved") return null;
+  if (review?.data.failureKind === "protocol") {
+    const attempts = session.durable.state.evidence.filter((item) => item.kind === "review"
+      && item.data.reviewBasisDigest === review.data.reviewBasisDigest).length;
+    if (attempts >= 2) {
+      return failed(call, startedAt,
+        "Required independent review returned invalid protocol output twice for the same basis.",
+        "review_unavailable",
+        {
+          status: "rejected", code: "review_unavailable",
+          frontierRevision: frontier.revision, stateDigest: frontier.currentStateDigest,
+          nextActions: [{ tool: "report_blocked" }]
+        }
+      );
+    }
+  }
   if (review?.data.failureCode === "review_scope_too_large") {
     return failed(call, startedAt,
       `${review.data.findings.slice(0, 20).map(findingText).join("; ")}.`,
@@ -187,7 +203,7 @@ function requiredReviewFailure(
     );
   }
   return failed(call, startedAt,
-    review
+    review && !review.data.failureKind
       ? `Strict review requested changes: ${review.data.findings.slice(0, 20).map(findingText).join("; ")}.`
       : "Strict profile requires an approved review of the validated current state.",
     "review_evidence_required",

--- a/packages/agent-runtime/src/effect-runner.ts
+++ b/packages/agent-runtime/src/effect-runner.ts
@@ -1,21 +1,9 @@
-import type {
-  ModelToolCall,
-  RunOutcome,
-  ToolDescriptor,
-  ToolOutcome,
-  ToolReceipt
-} from "agent-protocol";
-import { decide, type ActiveModelTurn, type KernelEffect } from "agent-kernel";
-import { loadNestedInstructions } from "agent-context";
-import {
-  failed, requestTargets, requiresInstructionReplan, steeringRestart
-} from "./effect-helpers.js";
+import type { RunOutcome } from "agent-protocol";
+import { decide, type KernelEffect } from "agent-kernel";
 import {
   attemptFromEffect,
   childOutcomeEvidence,
-  turnPayload,
-  type ExecuteToolEffect,
-  type ToolAttempt
+  type ExecuteToolEffect
 } from "./effect-runner-helpers.js";
 import { ModelEffectRunner } from "./model-effect-runner.js";
 import { convergenceAdmissionFailure } from "./convergence-policy.js";
@@ -29,6 +17,7 @@ import { ToolExecutionMonitor } from "./tool-execution-monitor.js";
 import { ToolTransactionRunner } from "./tool-transaction-runner.js";
 import type { RuntimeEventEmitter } from "./runtime-event-emitter.js";
 import type { RunSuspensionContext } from "./runtime-session-finish.js";
+import { ToolBatchCoordinator } from "./tool-batch-coordinator.js";
 
 export interface EffectRunnerOptions {
   runtime: RuntimeOptions;
@@ -50,44 +39,12 @@ export interface EffectRunnerOptions {
   hooks: RuntimeHookCoordinator;
 }
 
-type DurableToolReceipt = ToolReceipt & { outcome: ToolOutcome };
-
-function durableToolReceipt(receipt: ToolReceipt): DurableToolReceipt {
-  const diagnosticCodes = [...new Set([
-    ...(receipt.outcome?.diagnosticCodes ?? []),
-    ...receipt.diagnostics
-  ])];
-  return {
-    ...receipt,
-    outcome: {
-      status: receipt.ok ? "succeeded" : "failed",
-      output: receipt.output,
-      diagnosticCodes
-    }
-  };
-}
-
-function receiptToolName(
-  session: RuntimeSession,
-  receipt: ToolReceipt,
-  modelTurn: ActiveModelTurn
-): string {
-  return session.durable.state.pendingTools.find((item) => item.request.callId === receipt.callId
-    && item.modelTurn.turnId === modelTurn.turnId
-    && item.modelTurn.effectRevision === modelTurn.effectRevision)?.request.name ?? "tool";
-}
-
-function shouldReviewReceipt(name: string, reviewMode: "off" | "advisory" | "required"): boolean {
-  if (name === "request_review") return true;
-  if (name === "runtime_finalize") return reviewMode !== "off";
-  return reviewMode === "required" && name === "validate";
-}
-
 export class EffectRunner {
   private readonly models: ModelEffectRunner;
   private readonly reviews: ReviewCoordinator;
   private readonly execution: ToolExecutionMonitor;
   private readonly transactions: ToolTransactionRunner;
+  private readonly toolBatches: ToolBatchCoordinator;
 
   constructor(private readonly options: EffectRunnerOptions) {
     this.models = new ModelEffectRunner(options);
@@ -98,6 +55,7 @@ export class EffectRunner {
     );
     this.execution = new ToolExecutionMonitor(options);
     this.transactions = new ToolTransactionRunner(options, this.execution);
+    this.toolBatches = new ToolBatchCoordinator(options, this.reviews, this.transactions);
   }
 
   async waitForQuiescence(sessionId: string, signal?: AbortSignal): Promise<void> {
@@ -136,7 +94,7 @@ export class EffectRunner {
       kind: "tool", count: effects.length, terminalOnly
     });
     if (failure) return await this.options.finish(session, failure);
-    await this.executeTools(session, effects.map(attemptFromEffect), signal);
+    await this.toolBatches.execute(session, effects.map(attemptFromEffect), signal);
     return false;
   }
 
@@ -146,25 +104,8 @@ export class EffectRunner {
       const effects = decide(session.durable.state);
       const terminal = effects.find((effect): effect is Extract<KernelEffect, { type: "finish_run" }> => effect.type === "finish_run");
       if (terminal) {
-        let outcome = terminal.outcome;
-        let outcomeRevision = terminal.revision;
-        if (outcome.kind === "completed" && this.options.runtime.joinChildren) {
-          const children = await this.options.runtime.joinChildren(session.identity.sessionId, signal);
-          if (children.failures.length > 0) {
-            await this.options.emit(session, "diagnostic", "runtime", {
-              kind: "child.join_failed",
-              failures: children.failures,
-              evidence: children.evidence
-            });
-            continue;
-          }
-          for (const [index, value] of children.evidence.entries()) {
-            await this.options.emit(session, "evidence.recorded", "runtime", childOutcomeEvidence(session, value, index));
-          }
-          outcome = { ...outcome, evidence: [...session.durable.state.evidence] };
-          outcomeRevision = session.durable.state.revision;
-        }
-        if (await this.options.finish(session, outcome, outcomeRevision)) return;
+        const finished = await this.finishTerminalEffect(session, terminal, signal);
+        if (finished) return;
         continue;
       }
       if (effects.some((effect) => effect.type === "publish_outcome")) return;
@@ -181,6 +122,32 @@ export class EffectRunner {
       return;
     }
     throw signal.reason ?? new Error("Run cancelled.");
+  }
+
+  private async finishTerminalEffect(
+    session: RuntimeSession,
+    terminal: Extract<KernelEffect, { type: "finish_run" }>,
+    signal: AbortSignal
+  ): Promise<boolean> {
+    let outcome = terminal.outcome;
+    let outcomeRevision = terminal.revision;
+    if (outcome.kind === "completed" && this.options.runtime.joinChildren) {
+      const children = await this.options.runtime.joinChildren(session.identity.sessionId, signal);
+      if (children.failures.length > 0) {
+        await this.options.emit(session, "diagnostic", "runtime", {
+          kind: "child.join_failed",
+          failures: children.failures,
+          evidence: children.evidence
+        });
+        return false;
+      }
+      for (const [index, value] of children.evidence.entries()) {
+        await this.options.emit(session, "evidence.recorded", "runtime", childOutcomeEvidence(session, value, index));
+      }
+      outcome = { ...outcome, evidence: [...session.durable.state.evidence] };
+      outcomeRevision = session.durable.state.revision;
+    }
+    return await this.options.finish(session, outcome, outcomeRevision);
   }
 
   private async suspendForLostProcesses(session: RuntimeSession): Promise<boolean> {
@@ -201,146 +168,4 @@ export class EffectRunner {
       message: "A background process was lost when the execution broker ended. It was not replayed; review its durable output before continuing."
     }, undefined, { processIds: lost.map((handle) => handle.id) });
   }
-
-  private async executeTools(session: RuntimeSession, attempts: ToolAttempt[], signal: AbortSignal): Promise<void> {
-    const turnController = session.execution.turnController ?? new AbortController();
-    session.execution.turnController = turnController;
-    const turnSignal = AbortSignal.any([signal, turnController.signal]);
-    if (steeringRestart(turnSignal)) return;
-    try {
-      let loadedInstructions = false;
-      const instructionFailures = new Set<string>();
-      for (const { call } of attempts) {
-        const descriptor = this.options.runtime.tools.descriptors().find((item) => item.name === call.name);
-        if (!descriptor) continue;
-        const instructionResult = await this.loadInstructions(session, call, descriptor);
-        if (instructionResult.failure) {
-          instructionFailures.add(call.id);
-          await this.emitReceipt(session, instructionResult.failure, attempts.find((item) => item.call.id === call.id)!.modelTurn);
-        } else if (instructionResult.loaded) {
-          loadedInstructions = true;
-        }
-      }
-      const isCompletion = ({ call }: ToolAttempt): boolean => Boolean(
-        this.options.runtime.tools.descriptors().find((item) => item.name === call.name)
-          ?.possibleEffects.includes("outcome.propose")
-      );
-      const pending = attempts.filter((attempt) => !isCompletion(attempt));
-      const completions = attempts.filter(isCompletion);
-      const executeAttempt = async (attempt: ToolAttempt): Promise<void> => {
-        const { call, modelTurn } = attempt;
-        if (instructionFailures.has(call.id)) return;
-        const descriptor = this.options.runtime.tools.descriptors().find((item) => item.name === call.name);
-        if (loadedInstructions && descriptor && requiresInstructionReplan(descriptor)) {
-          const startedAt = new Date().toISOString();
-          await this.options.emit(session, "tool.requested", "runtime", {
-            callId: call.id, name: call.name, arguments: call.arguments, ...turnPayload(modelTurn)
-          });
-          await this.emitReceipt(session, failed(
-            call,
-            startedAt,
-            "New nested project instructions were loaded. Re-evaluate the request and propose a new tool call that follows them.",
-            "nested_instructions_require_replan"
-          ), modelTurn);
-          return;
-        }
-        const receipt = await this.transactions.execute(session, attempt, turnSignal);
-        await this.emitReceipt(session, receipt, modelTurn);
-      };
-      while (pending.length > 0) {
-        if (steeringRestart(turnSignal)) return;
-        const batch = pending.splice(0, this.options.maxParallelTools);
-        await Promise.all(batch.map(executeAttempt));
-        if (await this.suspendForCheckpointRecovery(session)) return;
-      }
-      for (const completion of completions) {
-        if (steeringRestart(turnSignal)) return;
-        await executeAttempt(completion);
-      }
-    } finally {
-      if (session.execution.turnController === turnController) session.execution.turnController = null;
-    }
-  }
-
-  private async suspendForCheckpointRecovery(session: RuntimeSession): Promise<boolean> {
-    const recovery = session.recovery.openCheckpointRecovery;
-    if (!recovery) return false;
-    return await this.options.finish(session, {
-      kind: "needs_input",
-      requestId: `checkpoint:${recovery.checkpointId}`,
-      message: `Mutation checkpoint '${recovery.checkpointId}' contains an interrupted delta. Choose safe restore or keep before continuing.`
-    }, undefined, { checkpointId: recovery.checkpointId, choices: ["restore", "keep"] });
-  }
-
-  private async loadInstructions(
-    session: RuntimeSession,
-    call: ModelToolCall,
-    descriptor: ToolDescriptor
-  ): Promise<{ loaded: boolean; failure?: ToolReceipt }> {
-    let discovered;
-    try {
-      discovered = await Promise.all(requestTargets(call, descriptor).map(async (targetPath) =>
-        await loadNestedInstructions({ workspacePath: session.identity.workspacePath, targetPath })));
-    } catch (error) {
-      if ((error as { code?: unknown })?.code !== "path_escape") throw error;
-      return {
-        loaded: false,
-        failure: failed(
-          call,
-          new Date().toISOString(),
-          error instanceof Error ? error.message : String(error),
-          "path_escape"
-        )
-      };
-    }
-    const unseen = discovered.flat().filter((item) => !session.interaction.loadedContextIds.has(item.id));
-    for (const item of unseen) {
-      session.interaction.loadedContextIds.add(item.id);
-      session.interaction.contextItems.push(item);
-    }
-    if (unseen.length === 0) return { loaded: false };
-    await this.options.emit(session, "diagnostic", "runtime", {
-      kind: "nested_instructions_loaded",
-      callId: call.id,
-      provenance: unseen.map((item) => item.provenance),
-      items: unseen,
-      affectsMutation: descriptor.possibleEffects.includes("filesystem.write")
-    });
-    return { loaded: true };
-  }
-
-  private async emitReceipt(session: RuntimeSession, receipt: ToolReceipt, modelTurn: ActiveModelTurn): Promise<void> {
-    const name = receiptToolName(session, receipt, modelTurn);
-    const durableReceipt = durableToolReceipt(receipt);
-    await this.options.emit(session, receipt.ok ? "tool.completed" : "tool.failed", "tool", {
-      ...durableReceipt, name, ...turnPayload(modelTurn)
-    });
-    for (const evidence of receipt.evidence ?? []) {
-      await this.options.emit(session, "evidence.recorded", "tool", evidence);
-    }
-    try {
-      await this.options.hooks.dispatch(session, "post_tool", {
-        sessionId: session.identity.sessionId,
-        runId: session.durable.runId,
-        callId: receipt.callId,
-        toolName: name,
-        ok: receipt.ok,
-        diagnostics: receipt.diagnostics,
-        actualEffects: receipt.actualEffects ?? receipt.observedEffects,
-        evidenceIds: (receipt.evidence ?? []).map((item) => item.evidenceId),
-        artifactRefs: receipt.artifactRefs ?? []
-      }, session.execution.controller?.signal ?? new AbortController().signal);
-      const reviewMode = session.services.profile?.profile.mutationPolicy.reviewMode ?? "advisory";
-      if (shouldReviewReceipt(name, reviewMode)) {
-        await this.reviews.maybeReview(
-          session,
-          session.execution.controller?.signal ?? new AbortController().signal,
-          name === "request_review"
-        );
-      }
-    } finally {
-      await this.transactions.settleBudgetsAfterReceipt(session);
-    }
-  }
-
 }

--- a/packages/agent-runtime/src/model-budget-convergence.ts
+++ b/packages/agent-runtime/src/model-budget-convergence.ts
@@ -51,7 +51,7 @@ export interface TurnPreparationInput {
 
 function actionPolicy(input: TurnPreparationInput): ActionPolicy {
   const { session, forecast, turnId, defaultOutputReserveTokens, budgetStage } = input;
-  const lengthRecovery = session.durable.state.continuationAttempts > 0;
+  const lengthRecovery = session.durable.state.taskControl.modelContinuationAttempts > 0;
   const required = lengthRecovery || forecast.stage === "converge" || budgetStage !== "normal";
   const outputReserveTokens = required ? Math.min(2_048, defaultOutputReserveTokens) : defaultOutputReserveTokens;
   if (!required) return { required, outputReserveTokens, context: [] };

--- a/packages/agent-runtime/src/model-effect-runner.ts
+++ b/packages/agent-runtime/src/model-effect-runner.ts
@@ -194,7 +194,7 @@ export class ModelEffectRunner {
     // from silently switching modes between the repair call and its recovery.
     const repairPending = repairPhase !== "none";
     const ledger = evidenceLedger(session);
-    const descriptors = descriptorsAllowedForRepair(availableDescriptors, repairPhase);
+    const descriptors = descriptorsAllowedForRepair(session, availableDescriptors, repairPhase);
     const query = [...session.durable.state.messages].reverse().find((message) => message.role === "user")?.content ?? "";
     const dynamic = await this.repositoryContext.collect(session.identity.workspacePath, query, signal);
     const forecast = deadlineForecast(session);

--- a/packages/agent-runtime/src/mutation-evidence.ts
+++ b/packages/agent-runtime/src/mutation-evidence.ts
@@ -82,14 +82,16 @@ function validationSemanticSignature(validation: ValidationEvidence): string {
 
 export function reviewBasisDigest(
   session: RuntimeSession,
-  validations = frontierValidationReadiness(session).validations
+  validations = frontierValidationReadiness(session).validations,
+  completionCandidateDigest?: string
 ): string {
   const frontier = session.durable.state.mutationFrontier;
   const signatures = [...new Set(validations.map(validationSemanticSignature))].sort();
   return createHash("sha256").update(JSON.stringify({
     frontierRevision: frontier.revision,
     stateDigest: frontier.currentStateDigest,
-    validations: signatures
+    validations: signatures,
+    ...(completionCandidateDigest ? { completionCandidateDigest } : {})
   })).digest("hex");
 }
 
@@ -100,8 +102,11 @@ export function latestFrontierReview(session: RuntimeSession): ReviewEvidence | 
     && item.data.stateDigest === frontier.currentStateDigest).at(-1);
 }
 
-export function currentFrontierReview(session: RuntimeSession): ReviewEvidence | undefined {
-  const basisDigest = reviewBasisDigest(session);
+export function currentFrontierReview(
+  session: RuntimeSession,
+  completionCandidateDigest?: string
+): ReviewEvidence | undefined {
+  const basisDigest = reviewBasisDigest(session, undefined, completionCandidateDigest);
   return sessionMutationEvidence(session).filter((item): item is ReviewEvidence => item.kind === "review"
     && item.data.frontierRevision === session.durable.state.mutationFrontier.revision
     && item.data.stateDigest === session.durable.state.mutationFrontier.currentStateDigest

--- a/packages/agent-runtime/src/new-runtime-session.ts
+++ b/packages/agent-runtime/src/new-runtime-session.ts
@@ -55,7 +55,6 @@ export async function newRuntimeSession(
     approvals: new Map(),
     callApprovals: new Map(),
     alwaysAllowedEffects: new Set(),
-    capabilityFailures: new Map(),
     processHandles: new Map(),
     steeringPending: 0,
     followUps: [],

--- a/packages/agent-runtime/src/restore-session.ts
+++ b/packages/agent-runtime/src/restore-session.ts
@@ -18,10 +18,9 @@ import {
   assertKernelInvariants,
   createKernelState,
   evolve,
-  isCompletionRepairState,
   isKernelState,
-  isSemanticFailureCluster,
-  isSemanticProgressWatermark,
+  migratePublishedTaskControlState,
+  PUBLISHED_TASK_CONTROL_LEGACY_KEYS,
   type KernelState
 } from "agent-kernel";
 import { jsonValue } from "./json.js";
@@ -213,53 +212,28 @@ function validSnapshotShape(state: KernelState, sessionId: string): boolean {
   return isKernelState(state) && state.sessionId === sessionId;
 }
 
-function restoredSemanticState(stored: Partial<KernelState>): Pick<
-  KernelState,
-  "semanticProgress" | "semanticFailureCluster"
-> {
-  return {
-    semanticProgress: isSemanticProgressWatermark(stored.semanticProgress)
-      ? stored.semanticProgress
-      : { workspaceChanges: 0, durableEvidence: 0, revision: 0 },
-    semanticFailureCluster: isSemanticFailureCluster(stored.semanticFailureCluster)
-      ? stored.semanticFailureCluster : undefined
-  };
-}
-
-function restoredCompletionRepairState(stored: Partial<KernelState>): Pick<
-  KernelState,
-  "completionRepairAttempts" | "completionRepair"
-> | null {
-  const completionRepairAttempts = Number.isInteger(stored.completionRepairAttempts)
-    ? Number(stored.completionRepairAttempts)
-    : 0;
-  const repair = stored.completionRepair;
-  if (repair !== undefined && !isCompletionRepairState(repair)) return null;
-  if (completionRepairAttempts > 0 && !isCompletionRepairState(repair)) return null;
-  return {
-    completionRepairAttempts,
-    completionRepair: isCompletionRepairState(repair) ? repair : undefined
-  };
-}
-
 function snapshotState(snapshot: Awaited<ReturnType<RunStore["latestSnapshot"]>>, sessionId: string): KernelState | undefined {
   if (!snapshot?.state || typeof snapshot.state !== "object" || Array.isArray(snapshot.state)) return undefined;
-  const stored = snapshot.state as unknown as Partial<KernelState>;
-  const completionRepair = restoredCompletionRepairState(stored);
-  if (!completionRepair) return undefined;
+  const raw = snapshot.state as unknown as Record<string, unknown>;
+  if (["actionConvergenceState", "convergenceStageHighWater", "semanticFactLedgerV2",
+    "taskControlStateV2", "taskControlStateV3", "taskControlStateV4"].some((key) => key in raw)) {
+    throw Object.assign(new Error("Experimental PR #55 session schemas are not supported."), {
+      code: "unsupported_experimental_session_schema"
+    });
+  }
+  const stored = raw as unknown as Partial<KernelState>;
+  const taskControl = migratePublishedTaskControlState(raw, Number(stored.revision ?? 0));
+  if (!taskControl) return undefined;
+  const migrated = { ...raw };
+  for (const key of PUBLISHED_TASK_CONTROL_LEGACY_KEYS) delete migrated[key];
   const state = {
-    ...stored,
+    ...migrated,
     toolCallIds: Array.isArray(stored.toolCallIds)
       ? stored.toolCallIds
       : [...new Set([...(stored.receipts ?? []).map((receipt) => receipt.callId),
         ...(stored.pendingTools ?? []).map((pending) => pending.request.callId)])],
     activeProcessIds: Array.isArray(stored.activeProcessIds) ? stored.activeProcessIds : [],
-    ...restoredSemanticState(stored),
-    ...completionRepair,
-    continuationAttempts: Number.isInteger(stored.continuationAttempts) ? stored.continuationAttempts : 0,
-    repeatedToolBatchCount: Number.isInteger(stored.repeatedToolBatchCount) ? stored.repeatedToolBatchCount : 0,
-    receiptCountAtLastUserInput: Number.isInteger(stored.receiptCountAtLastUserInput)
-      ? stored.receiptCountAtLastUserInput : 0
+    taskControl
   } as KernelState;
   if (!validSnapshotShape(state, sessionId)) return undefined;
   try {

--- a/packages/agent-runtime/src/review-coordinator.ts
+++ b/packages/agent-runtime/src/review-coordinator.ts
@@ -37,7 +37,9 @@ function profileReviewMode(session: RuntimeSession): "off" | "advisory" | "requi
 function normalizeReview(session: RuntimeSession, raw: ReviewEvidence, basisDigest: string): ReviewEvidence {
   const frontier = session.durable.state.mutationFrontier;
   const findings = [...raw.data.findings];
-  const verdict = findings.some(isActionableErrorFinding) ? "changes_requested" : "approved";
+  const protocolOrInfrastructureFailure = raw.data.failureKind !== undefined;
+  const verdict = protocolOrInfrastructureFailure || findings.some(isActionableErrorFinding)
+    ? "changes_requested" : "approved";
   return {
     evidenceId: randomUUID(),
     sessionId: session.identity.sessionId,
@@ -46,7 +48,8 @@ function normalizeReview(session: RuntimeSession, raw: ReviewEvidence, basisDige
     status: verdict === "approved" ? "passed" : "failed",
     createdAt: new Date().toISOString(),
     producer: { authority: "runtime", id: raw.data.reviewerId },
-    summary: verdict === "approved" ? raw.summary : "Independent reviewer requested changes.",
+    summary: protocolOrInfrastructureFailure ? raw.summary
+      : verdict === "approved" ? raw.summary : "Independent reviewer requested changes.",
     data: {
       reviewerId: raw.data.reviewerId,
       verdict,
@@ -105,7 +108,12 @@ export function reviewReadiness(session: RuntimeSession): ReviewReadiness {
   };
 }
 
-function requestIdentity(session: RuntimeSession, reviewerId: string, attempt: number): string {
+function requestIdentity(
+  session: RuntimeSession,
+  reviewerId: string,
+  basisDigest: string,
+  attempt: number
+): string {
   const frontier = session.durable.state.mutationFrontier;
   return `review:${createHash("sha256").update(JSON.stringify({
     sessionId: session.identity.sessionId,
@@ -113,7 +121,7 @@ function requestIdentity(session: RuntimeSession, reviewerId: string, attempt: n
     reviewerId,
     revision: frontier.revision,
     stateDigest: frontier.currentStateDigest,
-    reviewBasisDigest: reviewBasisDigest(session),
+    reviewBasisDigest: basisDigest,
     attempt
   })).digest("hex")}`;
 }
@@ -125,6 +133,68 @@ function stableUsage(usage: UsageRecord, requestId: string): UsageRecord {
 function activeReservation(session: RuntimeSession, ownerId: string): BudgetReservation | undefined {
   return [...session.durable.state.budget.reservations].reverse().find((item) =>
     item.ownerId === ownerId && item.status !== "released");
+}
+
+interface ReviewAttempt {
+  eligible: WorkspaceDeltaEvidence[];
+  relevantValidations: ValidationEvidence[];
+  basisDigest: string;
+  basisAttempts: number;
+  candidate?: { answer: string; digest: string };
+}
+
+function reviewAttemptAllowed(
+  existing: ReviewEvidence | undefined,
+  explicitlyRequested: boolean,
+  attemptCount: number
+): boolean {
+  if (existing?.status === "passed") return false;
+  if (existing?.status === "failed" && !existing.data.failureKind) return false;
+  if (existing?.data.failureKind !== "protocol" && existing && !explicitlyRequested) return false;
+  const attemptLimit = existing?.data.failureKind === "protocol" ? 2 : 3;
+  return attemptCount < attemptLimit;
+}
+
+function eligibleReviewAttempt(
+  session: RuntimeSession,
+  explicitlyRequested: boolean,
+  reviewMode: ReviewerInput["reviewMode"]
+): ReviewAttempt | null {
+  const { eligible, relevantValidations } = reviewReadiness(session);
+  if (eligible.length === 0) return null;
+  const candidate = reviewMode === "completion" ? session.durable.state.taskControl.completionCandidate : undefined;
+  const basisDigest = reviewBasisDigest(session, relevantValidations, candidate?.digest);
+  const reviews = session.durable.state.evidence.filter((item): item is ReviewEvidence => item.kind === "review"
+    && item.sessionId === session.identity.sessionId && item.runId === session.durable.runId
+    && item.data.reviewBasisDigest === basisDigest);
+  const existing = reviews.at(-1);
+  if (!reviewAttemptAllowed(existing, explicitlyRequested, reviews.length)) return null;
+  return { eligible, relevantValidations, basisDigest, basisAttempts: reviews.length, ...(candidate ? { candidate } : {}) };
+}
+
+function reviewerInput(
+  session: RuntimeSession,
+  reviewMode: ReviewerInput["reviewMode"],
+  attempt: ReviewAttempt
+): ReviewerInput {
+  const frontier = session.durable.state.mutationFrontier;
+  return {
+    sessionId: session.identity.sessionId,
+    runId: session.durable.runId,
+    goal: session.durable.state.plan.goal,
+    frontierRevision: frontier.revision,
+    stateDigest: frontier.currentStateDigest,
+    reviewBasisDigest: attempt.basisDigest,
+    reviewMode,
+    ...(attempt.candidate ? {
+      completionCandidate: attempt.candidate.answer,
+      completionCandidateDigest: attempt.candidate.digest
+    } : {}),
+    workspaceDeltas: attempt.eligible,
+    validations: attempt.relevantValidations,
+    inputAccesses: session.durable.state.evidence.filter((item): item is InputAccessEvidence =>
+      item.kind === "input_access" && item.runId === session.durable.runId)
+  };
 }
 
 export class ReviewCoordinator {
@@ -139,81 +209,90 @@ export class ReviewCoordinator {
     this.reviewerForSession = typeof reviewer === "function" ? reviewer : () => reviewer;
   }
 
-  async maybeReview(session: RuntimeSession, signal: AbortSignal, explicitlyRequested = false): Promise<void> {
+  async maybeReview(
+    session: RuntimeSession,
+    signal: AbortSignal,
+    explicitlyRequested = false,
+    reviewMode: ReviewerInput["reviewMode"] = "workspace"
+  ): Promise<void> {
     if (profileReviewMode(session) === "off") return;
     if (deadlineForecast(session).stage === "stop") return;
     const existing = this.active.get(session.identity.sessionId);
     if (existing) return await existing;
-    const task = this.reviewEligibleChange(session, signal, explicitlyRequested);
+    const task = this.reviewEligibleChange(session, signal, explicitlyRequested, reviewMode);
     this.active.set(session.identity.sessionId, task);
     try { await task; } finally {
       if (this.active.get(session.identity.sessionId) === task) this.active.delete(session.identity.sessionId);
     }
   }
 
-  private async reviewEligibleChange(session: RuntimeSession, signal: AbortSignal, explicitlyRequested: boolean): Promise<void> {
-    const { eligible, relevantValidations, retryableReview } = reviewReadiness(session);
-    if (eligible.length === 0) return;
-    const existing = currentFrontierReview(session);
-    let basisAttempts = 0;
-    if (existing) {
-      if (!(explicitlyRequested && retryableReview)) return;
-      basisAttempts = session.durable.state.evidence.filter((item) => item.kind === "review"
-        && item.sessionId === session.identity.sessionId
-        && item.runId === session.durable.runId
-        && item.data.reviewBasisDigest === existing.data.reviewBasisDigest).length;
-      if (basisAttempts >= 3) return;
-    }
+  private async reviewEligibleChange(
+    session: RuntimeSession,
+    signal: AbortSignal,
+    explicitlyRequested: boolean,
+    reviewMode: ReviewerInput["reviewMode"]
+  ): Promise<void> {
+    const attempt = eligibleReviewAttempt(session, explicitlyRequested, reviewMode);
+    if (!attempt) return;
     const reviewer = this.reviewerForSession(session);
     const reviewerId = reviewer.reviewerId ?? "builtin-reviewer";
-    const frontier = session.durable.state.mutationFrontier;
-    const basisDigest = reviewBasisDigest(session, relevantValidations);
-    const input: ReviewerInput = {
-      sessionId: session.identity.sessionId,
-      runId: session.durable.runId,
-      goal: session.durable.state.plan.goal,
-      frontierRevision: frontier.revision,
-      stateDigest: frontier.currentStateDigest,
-      reviewBasisDigest: basisDigest,
-      workspaceDeltas: eligible,
-      validations: relevantValidations,
-      inputAccesses: session.durable.state.evidence.filter((item): item is InputAccessEvidence =>
-        item.kind === "input_access" && item.runId === session.durable.runId)
-    };
-    const requestId = requestIdentity(session, reviewerId, basisAttempts + 1);
-    if (this.budgets && isAccountableReviewer(reviewer)) {
-      const prior = activeReservation(session, `reviewer:${requestId}`);
-      if (prior) {
-        await this.recoverInterruptedReview(session, reviewer, reviewerId, input, requestId, prior);
-        return;
-      }
-    }
+    const input = reviewerInput(session, reviewMode, attempt);
+    const requestId = requestIdentity(session, reviewerId, attempt.basisDigest, attempt.basisAttempts + 1);
+    if (await this.recoverActiveReview(session, reviewer, reviewerId, input, requestId)) return;
     const inputProblem = reviewInputFailure(input);
     if (inputProblem) {
       await this.emit(session, "review.completed", "runtime", normalizeReview(
-        session, reviewInputFailureEvidence(input, reviewerId, inputProblem), basisDigest
+        session, reviewInputFailureEvidence(input, reviewerId, inputProblem), attempt.basisDigest
       ));
       return;
     }
-    if (this.budgets && isAccountableReviewer(reviewer)) {
-      await this.reviewAccounted(session, reviewer, reviewerId, input, requestId, signal);
-      return;
+    const normalized = this.budgets && isAccountableReviewer(reviewer)
+      ? await this.reviewAccounted(session, reviewer, reviewerId, input, requestId, signal)
+      : await this.reviewUnaccounted(session, reviewer, reviewerId, input, requestId, signal);
+    if (normalized.data.failureKind === "protocol" && attempt.basisAttempts + 1 < 2) {
+      await this.reviewEligibleChange(session, signal, true, reviewMode);
     }
+  }
+
+  private async recoverActiveReview(
+    session: RuntimeSession,
+    reviewer: ReviewerPort,
+    reviewerId: string,
+    input: ReviewerInput,
+    requestId: string
+  ): Promise<boolean> {
+    if (!this.budgets || !isAccountableReviewer(reviewer)) return false;
+    const prior = activeReservation(session, `reviewer:${requestId}`);
+    if (!prior) return false;
+    await this.recoverInterruptedReview(session, reviewer, reviewerId, input, requestId, prior);
+    return true;
+  }
+
+  private async reviewUnaccounted(
+    session: RuntimeSession,
+    reviewer: ReviewerPort,
+    reviewerId: string,
+    input: ReviewerInput,
+    requestId: string,
+    signal: AbortSignal
+  ): Promise<ReviewEvidence> {
     await this.emit(session, "review.started", "runtime", {
       reviewerId, requestId,
-      workspaceDeltaEvidenceIds: eligible.map((item) => item.evidenceId),
-      validationEvidenceIds: relevantValidations.map((item) => item.evidenceId)
+      workspaceDeltaEvidenceIds: input.workspaceDeltas.map((item) => item.evidenceId),
+      validationEvidenceIds: input.validations.map((item) => item.evidenceId)
     });
     let raw: ReviewEvidence;
     try { raw = await reviewer.review(input, signal); } catch (error) {
       raw = failedReview(input, reviewerId,
         `Independent reviewer failed: ${error instanceof Error ? error.message : String(error)}`, "infrastructure");
     }
-    await this.emit(session, "review.completed", "runtime", normalizeReview(session, raw, basisDigest));
+    const normalized = normalizeReview(session, raw, input.reviewBasisDigest);
+    await this.emit(session, "review.completed", "runtime", normalized);
+    return normalized;
   }
 
   private async reviewAccounted(session: RuntimeSession, reviewer: AccountableReviewerPort,
-    reviewerId: string, input: ReviewerInput, requestId: string, signal: AbortSignal): Promise<void> {
+    reviewerId: string, input: ReviewerInput, requestId: string, signal: AbortSignal): Promise<ReviewEvidence> {
     const remaining = Math.max(0, session.durable.state.budget.limits.costMicroUsd
       - session.durable.state.budget.consumed.costMicroUsd
       - session.durable.state.budget.reserved.costMicroUsd);
@@ -233,17 +312,20 @@ export class ReviewCoordinator {
       const usage = stableUsage(reviewer.failedUsage(input, requestId, prepared, performance.now() - startedAt, error), requestId);
       await this.budgets!.commit(session, reservationId, consumedBudget(usage, prepared.budget));
       await this.emit(session, "usage.recorded", "runtime", usage);
-      await this.emit(session, "review.completed", "runtime", normalizeReview(session, failedReview(
+      const normalized = normalizeReview(session, failedReview(
         input, reviewerId, `Independent reviewer failed: ${error instanceof Error ? error.message : String(error)}`, "infrastructure"
-      ), input.reviewBasisDigest));
-      return;
+      ), input.reviewBasisDigest);
+      await this.emit(session, "review.completed", "runtime", normalized);
+      return normalized;
     }
     const usage = stableUsage(result.usage, requestId);
     await this.budgets!.commitMeasured(session, reservationId, consumedBudget(usage, prepared.budget));
     await this.emit(session, "usage.recorded", "runtime", usage);
-    await this.emit(session, "review.completed", "runtime", normalizeReview(
+    const normalized = normalizeReview(
       session, result.evidence, input.reviewBasisDigest
-    ));
+    );
+    await this.emit(session, "review.completed", "runtime", normalized);
+    return normalized;
   }
 
   private async recoverInterruptedReview(session: RuntimeSession, reviewer: AccountableReviewerPort,

--- a/packages/agent-runtime/src/reviewer.ts
+++ b/packages/agent-runtime/src/reviewer.ts
@@ -30,6 +30,9 @@ export interface ReviewerInput {
   frontierRevision: number;
   stateDigest: string;
   reviewBasisDigest: string;
+  reviewMode: "workspace" | "completion";
+  completionCandidate?: string;
+  completionCandidateDigest?: string;
   workspaceDeltas: WorkspaceDeltaEvidence[];
   validations: ValidationEvidence[];
   inputAccesses?: InputAccessEvidence[];
@@ -228,6 +231,13 @@ function reviewMessages(input: ReviewerInput): ModelMessage[] {
       frontierRevision: input.frontierRevision,
       stateDigest: input.stateDigest,
       reviewBasisDigest: input.reviewBasisDigest,
+      reviewMode: input.reviewMode,
+      ...(input.reviewMode === "completion" && input.completionCandidate
+        ? {
+            completionCandidate: input.completionCandidate,
+            completionCandidateDigest: input.completionCandidateDigest
+          }
+        : {}),
       inputAccesses: input.inputAccesses ?? [],
       workspaceDeltas: input.workspaceDeltas.map((item) => ({
         evidenceId: item.evidenceId,
@@ -254,20 +264,33 @@ export function isActionableErrorFinding(finding: JsonValue): boolean {
   return true;
 }
 
+interface ParsedReviewResult {
+  findings: JsonValue[];
+  protocolFailure: boolean;
+  verdict: "approved" | "changes_requested";
+}
+
+function parsedReviewResult(input: ReviewerInput, response: ModelResponse): ParsedReviewResult {
+  const parsed = responseObject(response.message.content);
+  const inputProblem = reviewInputFailure(input);
+  const rawFindings = Array.isArray(parsed?.findings) ? parsed.findings : undefined;
+  const validVerdict = parsed?.verdict === "approved" || parsed?.verdict === "changes_requested";
+  const protocolFailure = !inputProblem && (!parsed || !validVerdict || rawFindings === undefined);
+  const findings = inputProblem ? [inputProblem] : rawFindings
+    ? rawFindings.filter((item): item is JsonValue => item === null
+      || ["string", "number", "boolean", "object"].includes(typeof item))
+    : [];
+  const verdict = !inputProblem && !protocolFailure && !findings.some(isActionableErrorFinding)
+    ? "approved" : "changes_requested";
+  return { findings, protocolFailure, verdict };
+}
+
 function reviewEvidence(
   input: ReviewerInput,
   reviewerId: string,
   response: ModelResponse
 ): ReviewEvidence {
-    const parsed = responseObject(response.message.content);
-    const inputProblem = reviewInputFailure(input);
-    const rawFindings = Array.isArray(parsed?.findings) ? parsed.findings : undefined;
-    const validFindings = rawFindings !== undefined;
-    const findings = inputProblem ? [inputProblem] : validFindings
-      ? rawFindings.filter((item): item is JsonValue => item === null || ["string", "number", "boolean", "object"].includes(typeof item))
-      : [parsed ? "Reviewer response omitted findings." : "Reviewer returned invalid JSON."];
-    const verdict = !inputProblem && validFindings && !findings.some(isActionableErrorFinding)
-      ? "approved" : "changes_requested";
+    const { findings, protocolFailure, verdict } = parsedReviewResult(input, response);
     return {
       evidenceId: randomUUID(),
       sessionId: input.sessionId,
@@ -276,7 +299,9 @@ function reviewEvidence(
       status: verdict === "approved" ? "passed" : "failed",
       createdAt: new Date().toISOString(),
       producer: { authority: "runtime", id: reviewerId },
-      summary: verdict === "approved" ? "Independent reviewer approved the change." : "Independent reviewer requested changes.",
+      summary: protocolFailure ? "Independent reviewer returned an invalid protocol response."
+        : verdict === "approved" ? "Independent reviewer approved the change."
+          : "Independent reviewer requested changes.",
       data: {
         reviewerId,
         verdict,
@@ -285,6 +310,9 @@ function reviewEvidence(
         stateDigest: input.stateDigest,
         reviewBasisDigest: input.reviewBasisDigest,
         validationEvidenceIds: input.validations.map((item) => item.evidenceId),
+        ...(protocolFailure
+          ? { failureKind: "protocol" as const, failureCode: "review_protocol_invalid" as const }
+          : {}),
         ...(input.workspaceDeltas.some((item) => item.data.reviewProblem?.code === "review_scope_too_large")
           ? { failureCode: "review_scope_too_large" as const } : {})
       }

--- a/packages/agent-runtime/src/runtime-checkpoint-control.ts
+++ b/packages/agent-runtime/src/runtime-checkpoint-control.ts
@@ -1,4 +1,8 @@
-import { CheckpointConflictError, type CheckpointRecord } from "agent-checkpoint";
+import {
+  CheckpointConflictError,
+  type CheckpointRecord,
+  type RunRestorationInspection
+} from "agent-checkpoint";
 import type { CheckpointRef } from "agent-protocol";
 import { CheckpointEvidenceRecorder } from "./checkpoint-evidence-recorder.js";
 import { checkpointRef, type OpenCheckpointRecoveryResult, type RuntimeControlServiceOptions } from "./runtime-control-contracts.js";
@@ -53,6 +57,34 @@ export class RuntimeCheckpointControl {
       });
     }
     return await this.undoLatest(session);
+  }
+
+  async restoreRunChanges(session: RuntimeSession): Promise<RunRestorationInspection> {
+    if (session.recovery.openCheckpointRecovery) {
+      throw Object.assign(new Error("Resolve the interrupted open checkpoint before restoring sealed run changes."), {
+        code: "checkpoint_recovery_required"
+      });
+    }
+    const restored = await this.options.checkpoints.restoreRunChanges(
+      session.identity.sessionId,
+      session.durable.runId
+    );
+    for (const checkpoint of restored.checkpoints) {
+      await this.options.emit(session, "checkpoint.restored", "runtime", checkpointRef(checkpoint));
+    }
+    return restored;
+  }
+
+  async inspectRunRestoration(session: RuntimeSession): Promise<RunRestorationInspection> {
+    if (session.recovery.openCheckpointRecovery) {
+      throw Object.assign(new Error("Resolve the interrupted open checkpoint before confirming restoration."), {
+        code: "checkpoint_recovery_required"
+      });
+    }
+    return await this.options.checkpoints.inspectRunRestoration(
+      session.identity.sessionId,
+      session.durable.runId
+    );
   }
 
   async seal(session: RuntimeSession, checkpointId: string): Promise<CheckpointRef> {

--- a/packages/agent-runtime/src/runtime-client.ts
+++ b/packages/agent-runtime/src/runtime-client.ts
@@ -84,6 +84,7 @@ export class InProcessRuntimeClient implements RuntimeClient {
       emit: async (session, type, authority, value) => await this.emit(session, type, authority, value),
       createArtifact: async (sessionId, content) => await this.artifacts.put(sessionId, content),
       readArtifact: async (sessionId, artifactId) => (await this.artifacts.get(sessionId, artifactId)).toString("utf8"),
+      hasActiveChildren: options.hasActiveChildren,
       skillMaterializer: new FrozenSkillMaterializer(options.storeRootDir, this.artifacts),
       planChanged: async (session, previousRevision, plan) => {
         await this.hooks.dispatch(session, "plan_changed", {

--- a/packages/agent-runtime/src/runtime-control-contracts.ts
+++ b/packages/agent-runtime/src/runtime-control-contracts.ts
@@ -17,6 +17,7 @@ export interface RuntimeControlServiceOptions {
   };
   planChanged?(session: RuntimeSession, previousRevision: number, plan: PlanGraph): Promise<void>;
   budgets: BudgetController;
+  hasActiveChildren?(parentSessionId: string): Promise<boolean> | boolean;
 }
 export type OpenCheckpointRecoveryResult =
   | { kind: "clean" }

--- a/packages/agent-runtime/src/runtime-control.ts
+++ b/packages/agent-runtime/src/runtime-control.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import {
   isCompletionEligibleEvidence,
   type BudgetAmounts,
@@ -5,7 +6,8 @@ import {
   type CheckpointRef,
   type PlanGraph,
   type ReviewRequestResult,
-  type RuntimeControlPort
+  type RuntimeControlPort,
+  type WorkspaceRestorationEvidenceV1
 } from "agent-protocol";
 import type { ChildCheckpointRecovery, RuntimeSession } from "./types.js";
 import { ChildBudgetControl } from "./child-budget-control.js";
@@ -30,6 +32,41 @@ export { DEFAULT_CHILD_BUDGET } from "./child-budget-control.js";
 
 export type { OpenCheckpointRecoveryResult, RuntimeControlServiceOptions } from "./runtime-control-contracts.js";
 
+function restorationFailure(message: string, code: string): never {
+  throw Object.assign(new Error(message), { code });
+}
+
+function assertIsolatedRestorationCall(session: RuntimeSession, callId: string): void {
+  const pending = session.durable.state.pendingTools;
+  if (pending.length !== 1 || pending[0]?.request.callId !== callId || !pending[0].started
+    || session.durable.state.activeModelTurn) {
+    restorationFailure("Restoration requires one isolated runtime-control call.", "restoration_not_quiescent");
+  }
+}
+
+function assertLocalRestorationState(
+  session: RuntimeSession,
+  callId: string,
+  manualConfirmation: boolean
+): void {
+  assertIsolatedRestorationCall(session, callId);
+  if (session.durable.state.activeProcessIds.length > 0) {
+    restorationFailure("Restoration requires all processes to be settled.", "checkpoint_processes_active");
+  }
+  if (session.recovery.openCheckpointRecovery || session.durable.state.checkpointHead?.status === "open") {
+    restorationFailure("Restoration requires the open checkpoint to be resolved.", "checkpoint_recovery_required");
+  }
+  if (session.durable.state.mutationFrontier.revision === 0) {
+    restorationFailure("The current run has no mutation frontier to restore.", "restoration_mutation_missing");
+  }
+  if (session.durable.state.mutationFrontier.repositoryStateDigest) {
+    restorationFailure("Repository metadata must be restored and verified separately.", "repository_restoration_required");
+  }
+  if (manualConfirmation && session.durable.state.taskControl.goalEpochSource !== "steer") {
+    restorationFailure("Manual restoration confirmation requires a current user steer.", "restoration_steer_required");
+  }
+}
+
 export class RuntimeControlService {
   private readonly planQueues = new Map<string, Promise<void>>();
   private readonly checkpoints: RuntimeCheckpointControl;
@@ -50,6 +87,8 @@ export class RuntimeControlService {
       listCheckpoints: async () => (await this.options.checkpoints.list(session.identity.sessionId)).map(checkpointRef),
       createCheckpoint: async (scopePaths) => await this.createCheckpoint(session, scopePaths),
       restoreRunCheckpoint: async (checkpointId) => await this.restoreRunCheckpoint(session, checkpointId),
+      restoreRunChanges: async (callId) => await this.restoreRunChanges(session, callId),
+      confirmRunRestored: async (callId) => await this.confirmRunRestored(session, callId),
       requestReview: async () => this.requestReview(session),
       loadSkill: async (qualifiedName) => await this.skillControl.loadSkill(session, qualifiedName),
       resolveLoadedSkillResource: async (input) => await this.skillControl.resolveLoadedSkillResource(session, input),
@@ -191,6 +230,86 @@ export class RuntimeControlService {
 
   async restoreRunCheckpoint(session: RuntimeSession, checkpointId: string): Promise<CheckpointRef> {
     return await this.checkpoints.restoreRun(session, checkpointId);
+  }
+
+  async restoreRunChanges(
+    session: RuntimeSession,
+    callId: string
+  ): Promise<WorkspaceRestorationEvidenceV1["data"]> {
+    await this.assertRestorationQuiescence(session, callId, false);
+    if (session.durable.state.mutationFrontier.repositoryStateDigest) {
+      throw Object.assign(new Error("Workspace checkpoint restore cannot restore repository metadata."), {
+        code: "repository_restoration_required"
+      });
+    }
+    const inspection = await this.checkpoints.restoreRunChanges(session);
+    return await this.recordRestorationEvidence(session, inspection, true);
+  }
+
+  async confirmRunRestored(
+    session: RuntimeSession,
+    callId: string
+  ): Promise<WorkspaceRestorationEvidenceV1["data"]> {
+    await this.assertRestorationQuiescence(session, callId, true);
+    const inspection = await this.checkpoints.inspectRunRestoration(session);
+    if (!inspection.restored) {
+      throw Object.assign(new Error("Workspace does not match the run baseline."), {
+        code: "workspace_not_restored"
+      });
+    }
+    return await this.recordRestorationEvidence(session, inspection, false);
+  }
+
+  private async assertRestorationQuiescence(
+    session: RuntimeSession,
+    callId: string,
+    manualConfirmation: boolean
+  ): Promise<void> {
+    assertLocalRestorationState(session, callId, manualConfirmation);
+    if (await this.options.hasActiveChildren?.(session.identity.sessionId)) {
+      restorationFailure("Restoration requires all child agents to be settled.", "checkpoint_children_active");
+    }
+  }
+
+  private async recordRestorationEvidence(
+    session: RuntimeSession,
+    inspection: import("agent-checkpoint").RunRestorationInspection,
+    explicitRestore: boolean
+  ): Promise<WorkspaceRestorationEvidenceV1["data"]> {
+    const frontier = session.durable.state.mutationFrontier;
+    const data: WorkspaceRestorationEvidenceV1["data"] = {
+      schemaVersion: 1,
+      goalEpoch: session.durable.state.taskControl.goalEpoch,
+      frontierRevision: frontier.revision,
+      frontierStateDigest: frontier.currentStateDigest,
+      baselineManifestDigest: inspection.baselineManifestDigest,
+      currentManifestDigest: inspection.currentManifestDigest,
+      restoredCheckpointIds: explicitRestore
+        ? inspection.checkpoints.map((item) => item.checkpointId) : [],
+      quiescence: {
+        supersededExecutionStopped: true,
+        noPendingMutations: true,
+        noProcesses: true,
+        noChildren: true,
+        noOpenCheckpoint: true
+      },
+      repository: { status: "unchanged" }
+    };
+    const evidence: WorkspaceRestorationEvidenceV1 = {
+      evidenceId: randomUUID(),
+      sessionId: session.identity.sessionId,
+      runId: session.durable.runId,
+      kind: "restoration",
+      status: inspection.restored ? "passed" : "failed",
+      createdAt: new Date().toISOString(),
+      producer: { authority: "runtime", id: "workspace-restoration-v1" },
+      summary: inspection.restored
+        ? "The current goal epoch is quiescent and the workspace matches its run baseline."
+        : "The workspace does not match its run baseline.",
+      data
+    };
+    await this.options.emit(session, "evidence.recorded", "runtime", evidence);
+    return data;
   }
 
   async sealCheckpoint(session: RuntimeSession, checkpointId: string): Promise<CheckpointRef> {

--- a/packages/agent-runtime/src/runtime-session-restore.ts
+++ b/packages/agent-runtime/src/runtime-session-restore.ts
@@ -54,7 +54,6 @@ export async function hydrateRuntimeSession(
     }])),
     callApprovals: new Map(),
     alwaysAllowedEffects: new Set(),
-    capabilityFailures: new Map(),
     processHandles: new Map(),
     steeringPending: 0,
     followUps,

--- a/packages/agent-runtime/src/runtime-session-state.ts
+++ b/packages/agent-runtime/src/runtime-session-state.ts
@@ -50,7 +50,6 @@ export function createRuntimeSessionAggregate(seed: RuntimeSessionSeed): Runtime
     approvals: seed.approvals,
     callApprovals: seed.callApprovals,
     alwaysAllowedEffects: seed.alwaysAllowedEffects,
-    capabilityFailures: seed.capabilityFailures,
     steeringPending: seed.steeringPending,
     followUps: seed.followUps,
     contextItems: seed.contextItems,

--- a/packages/agent-runtime/src/tool-batch-coordinator.ts
+++ b/packages/agent-runtime/src/tool-batch-coordinator.ts
@@ -1,0 +1,374 @@
+import type { ModelToolCall, ToolDescriptor, ToolOutcome, ToolReceipt } from "agent-protocol";
+import type { ActiveModelTurn } from "agent-kernel";
+import { loadNestedInstructions } from "agent-context";
+import { isToolAllowed } from "agent-tools";
+import { failed, requestTargets, requiresInstructionReplan, steeringRestart } from "./effect-helpers.js";
+import { turnPayload, type ToolAttempt } from "./effect-runner-helpers.js";
+import type { EffectRunnerOptions } from "./effect-runner.js";
+import { currentFrontierReview, reviewBasisDigest } from "./mutation-evidence.js";
+import { profileAllowsTool } from "./profile-policy.js";
+import type { ReviewCoordinator } from "./review-coordinator.js";
+import {
+  completionRepairPhase,
+  descriptorAllowedForRepair,
+  maximumTaskControlCalls,
+  type CompletionRepairPhase
+} from "./tool-turn-policy.js";
+import type { ToolTransactionRunner } from "./tool-transaction-runner.js";
+import type { RuntimeSession } from "./types.js";
+
+type DurableToolReceipt = ToolReceipt & { outcome: ToolOutcome };
+
+function durableToolReceipt(receipt: ToolReceipt): DurableToolReceipt {
+  const diagnosticCodes = [...new Set([
+    ...(receipt.outcome?.diagnosticCodes ?? []),
+    ...receipt.diagnostics
+  ])];
+  return {
+    ...receipt,
+    outcome: {
+      status: receipt.ok ? "succeeded" : "failed",
+      output: receipt.output,
+      diagnosticCodes
+    }
+  };
+}
+
+function receiptToolName(
+  session: RuntimeSession,
+  receipt: ToolReceipt,
+  modelTurn: ActiveModelTurn
+): string {
+  return session.durable.state.pendingTools.find((item) => item.request.callId === receipt.callId
+    && item.modelTurn.turnId === modelTurn.turnId
+    && item.modelTurn.effectRevision === modelTurn.effectRevision)?.request.name ?? "tool";
+}
+
+function shouldReviewReceipt(name: string, reviewMode: "off" | "advisory" | "required"): boolean {
+  if (name === "runtime_finalize") return reviewMode !== "off";
+  return reviewMode === "required" && name === "validate";
+}
+
+function settledReviewRequestReceipt(session: RuntimeSession, receipt: ToolReceipt): ToolReceipt {
+  const review = currentFrontierReview(session);
+  const basis = reviewBasisDigest(session);
+  if (review?.status === "passed" && review.data.verdict === "approved") {
+    return {
+      ...receipt,
+      ok: true,
+      output: JSON.stringify({
+        status: "approved", reviewState: "current", reviewBasisDigest: basis,
+        frontierRevision: review.data.frontierRevision, stateDigest: review.data.stateDigest
+      }),
+      diagnostics: []
+    };
+  }
+  if (review?.data.failureKind === "protocol") {
+    return {
+      ...receipt,
+      ok: false,
+      output: JSON.stringify({ status: "review_unavailable", reviewState: "current", reviewBasisDigest: basis }),
+      diagnostics: ["review_unavailable"]
+    };
+  }
+  if (review?.status === "failed") {
+    return {
+      ...receipt,
+      ok: false,
+      output: JSON.stringify({
+        status: "changes_required", reviewState: "current", reviewBasisDigest: basis,
+        findings: review.data.findings
+      }),
+      diagnostics: ["review_changes_required"]
+    };
+  }
+  return receipt;
+}
+
+function projectedToolNames(
+  session: RuntimeSession,
+  descriptors: readonly ToolDescriptor[],
+  phase: CompletionRepairPhase
+): Set<string> {
+  return new Set(descriptors.filter((descriptor) => isToolAllowed(descriptor, session.durable.mode)
+    && profileAllowsTool(session, descriptor)
+    && descriptorAllowedForRepair(session, descriptor, phase)).map((descriptor) => descriptor.name));
+}
+
+function internalCompletion(attempt: ToolAttempt): boolean {
+  return attempt.call.name === "runtime_finalize" && attempt.call.id.startsWith("runtime_completion_intent_");
+}
+
+const TERMINAL_TOOL_NAMES = new Set(["runtime_finalize", "report_blocked", "request_user_input"]);
+
+function violatesToolProjection(
+  session: RuntimeSession,
+  attempts: readonly ToolAttempt[],
+  offeredNames: ReadonlySet<string>,
+  phase: CompletionRepairPhase
+): boolean {
+  const terminalCount = attempts.filter(({ call }) => TERMINAL_TOOL_NAMES.has(call.name)).length;
+  const conflictingTerminalBatch = attempts.length > 1 && terminalCount > 0;
+  // An ordinary turn may pair work with one terminal intent. The coordinator
+  // executes ordinary work first and checks checkpoint recovery before the
+  // terminal intent is allowed to run. Multiple terminal intents remain an
+  // unambiguous protocol conflict. Single-call task control is otherwise
+  // imposed only after an obligation has been opened.
+  if (phase === "none") return terminalCount > 1;
+  return conflictingTerminalBatch || attempts.length > maximumTaskControlCalls(session)
+    || attempts.some((attempt) => !internalCompletion(attempt) && !offeredNames.has(attempt.call.name));
+}
+
+function terminalAttempt(attempt: ToolAttempt): boolean {
+  return TERMINAL_TOOL_NAMES.has(attempt.call.name);
+}
+
+interface InstructionPreparation {
+  loaded: boolean;
+  failures: Set<string>;
+}
+
+export class ToolBatchCoordinator {
+  constructor(
+    private readonly options: EffectRunnerOptions,
+    private readonly reviews: ReviewCoordinator,
+    private readonly transactions: ToolTransactionRunner
+  ) {}
+
+  async execute(session: RuntimeSession, attempts: ToolAttempt[], signal: AbortSignal): Promise<void> {
+    const turnController = session.execution.turnController ?? new AbortController();
+    session.execution.turnController = turnController;
+    const turnSignal = AbortSignal.any([signal, turnController.signal]);
+    if (steeringRestart(turnSignal)) return;
+    try {
+      const phase = completionRepairPhase(session);
+      const descriptors = new Map(this.options.runtime.tools.descriptors().map((item) => [item.name, item]));
+      const modelDescriptors = this.options.runtime.tools.modelDescriptors?.() ?? [...descriptors.values()];
+      if (violatesToolProjection(
+        session,
+        attempts,
+        projectedToolNames(session, modelDescriptors, phase),
+        phase
+      )) {
+        await this.rejectProjection(session, attempts, phase);
+        return;
+      }
+      const instructions = await this.prepareInstructions(session, attempts, descriptors);
+      const pending = attempts.filter((attempt) => !terminalAttempt(attempt));
+      const completions = attempts.filter(terminalAttempt);
+      if (await this.executePending(session, pending, completions, descriptors, instructions, turnSignal)) return;
+      for (const completion of completions) {
+        if (steeringRestart(turnSignal)) return;
+        await this.executeAttempt(session, completion, descriptors, instructions, turnSignal);
+      }
+    } finally {
+      if (session.execution.turnController === turnController) session.execution.turnController = null;
+    }
+  }
+
+  private async rejectProjection(
+    session: RuntimeSession,
+    attempts: readonly ToolAttempt[],
+    phase: CompletionRepairPhase
+  ): Promise<void> {
+    for (const { call, modelTurn } of attempts) {
+      await this.emitReceipt(session, failed(
+        call,
+        new Date().toISOString(),
+        `Tool batch is outside the active task-control projection (${phase}). Use one currently offered action.`,
+        "model_tool_policy_violation"
+      ), modelTurn);
+    }
+  }
+
+  private async prepareInstructions(
+    session: RuntimeSession,
+    attempts: readonly ToolAttempt[],
+    descriptors: ReadonlyMap<string, ToolDescriptor>
+  ): Promise<InstructionPreparation> {
+    let loaded = false;
+    const failures = new Set<string>();
+    for (const attempt of attempts) {
+      const descriptor = descriptors.get(attempt.call.name);
+      if (!descriptor) continue;
+      const result = await this.loadInstructions(session, attempt.call, descriptor);
+      if (result.failure) {
+        failures.add(attempt.call.id);
+        await this.emitReceipt(session, result.failure, attempt.modelTurn);
+      } else if (result.loaded) {
+        loaded = true;
+      }
+    }
+    return { loaded, failures };
+  }
+
+  private async executePending(
+    session: RuntimeSession,
+    pending: ToolAttempt[],
+    deferredTerminal: readonly ToolAttempt[],
+    descriptors: ReadonlyMap<string, ToolDescriptor>,
+    instructions: InstructionPreparation,
+    signal: AbortSignal
+  ): Promise<boolean> {
+    while (pending.length > 0) {
+      if (steeringRestart(signal)) return true;
+      const batch = pending.splice(0, this.options.maxParallelTools);
+      await Promise.all(batch.map(async (attempt) =>
+        await this.executeAttempt(session, attempt, descriptors, instructions, signal)));
+      if (session.recovery.openCheckpointRecovery) {
+        await this.rejectDeferredForCheckpoint(session, deferredTerminal);
+        return await this.suspendForCheckpointRecovery(session);
+      }
+    }
+    return false;
+  }
+
+  private async rejectDeferredForCheckpoint(
+    session: RuntimeSession,
+    deferred: readonly ToolAttempt[]
+  ): Promise<void> {
+    for (const { call, modelTurn } of deferred) {
+      await this.emitReceipt(session, failed(
+        call,
+        new Date().toISOString(),
+        "The terminal action was not executed because an open mutation checkpoint requires recovery.",
+        "checkpoint_recovery_required"
+      ), modelTurn);
+    }
+  }
+
+  private async executeAttempt(
+    session: RuntimeSession,
+    attempt: ToolAttempt,
+    descriptors: ReadonlyMap<string, ToolDescriptor>,
+    instructions: InstructionPreparation,
+    signal: AbortSignal
+  ): Promise<void> {
+    const { call, modelTurn } = attempt;
+    if (instructions.failures.has(call.id)) return;
+    const descriptor = descriptors.get(call.name);
+    if (instructions.loaded && descriptor && requiresInstructionReplan(descriptor)) {
+      const startedAt = new Date().toISOString();
+      await this.options.emit(session, "tool.requested", "runtime", {
+        callId: call.id, name: call.name, arguments: call.arguments, ...turnPayload(modelTurn)
+      });
+      await this.emitReceipt(session, failed(
+        call,
+        startedAt,
+        "New nested project instructions were loaded. Re-evaluate the request and propose a new tool call that follows them.",
+        "nested_instructions_require_replan"
+      ), modelTurn);
+      return;
+    }
+    let receipt = await this.transactions.execute(session, attempt, signal);
+    if (call.name === "request_review" && receipt.ok) {
+      await this.reviews.maybeReview(session, signal, true, "workspace");
+      receipt = settledReviewRequestReceipt(session, receipt);
+    }
+    await this.emitReceipt(session, receipt, modelTurn);
+  }
+
+  private async loadInstructions(
+    session: RuntimeSession,
+    call: ModelToolCall,
+    descriptor: ToolDescriptor
+  ): Promise<{ loaded: boolean; failure?: ToolReceipt }> {
+    let discovered;
+    try {
+      discovered = await Promise.all(requestTargets(call, descriptor).map(async (targetPath) =>
+        await loadNestedInstructions({ workspacePath: session.identity.workspacePath, targetPath })));
+    } catch (error) {
+      if ((error as { code?: unknown })?.code !== "path_escape") throw error;
+      return {
+        loaded: false,
+        failure: failed(call, new Date().toISOString(), error instanceof Error ? error.message : String(error), "path_escape")
+      };
+    }
+    const unseen = discovered.flat().filter((item) => !session.interaction.loadedContextIds.has(item.id));
+    for (const item of unseen) {
+      session.interaction.loadedContextIds.add(item.id);
+      session.interaction.contextItems.push(item);
+    }
+    if (unseen.length === 0) return { loaded: false };
+    await this.options.emit(session, "diagnostic", "runtime", {
+      kind: "nested_instructions_loaded",
+      callId: call.id,
+      provenance: unseen.map((item) => item.provenance),
+      items: unseen,
+      affectsMutation: descriptor.possibleEffects.includes("filesystem.write")
+    });
+    return { loaded: true };
+  }
+
+  private async suspendForCheckpointRecovery(session: RuntimeSession): Promise<boolean> {
+    const recovery = session.recovery.openCheckpointRecovery;
+    if (!recovery) return false;
+    return await this.options.finish(session, {
+      kind: "needs_input",
+      requestId: `checkpoint:${recovery.checkpointId}`,
+      message: `Mutation checkpoint '${recovery.checkpointId}' contains an interrupted delta. Choose safe restore or keep before continuing.`
+    }, undefined, { checkpointId: recovery.checkpointId, choices: ["restore", "keep"] });
+  }
+
+  private async emitReceipt(
+    session: RuntimeSession,
+    receipt: ToolReceipt,
+    modelTurn: ActiveModelTurn
+  ): Promise<void> {
+    const name = receiptToolName(session, receipt, modelTurn);
+    await this.emitDurableReceipt(session, receipt, modelTurn, name);
+    try {
+      await this.dispatchPostTool(session, receipt, name);
+      await this.reviewAfterReceipt(session, name);
+    } finally {
+      await this.transactions.settleBudgetsAfterReceipt(session);
+    }
+  }
+
+  private async emitDurableReceipt(
+    session: RuntimeSession,
+    receipt: ToolReceipt,
+    modelTurn: ActiveModelTurn,
+    name: string
+  ): Promise<void> {
+    await this.options.emit(session, receipt.ok ? "tool.completed" : "tool.failed", "tool", {
+      ...durableToolReceipt(receipt), name, ...turnPayload(modelTurn)
+    });
+    for (const evidence of receipt.evidence ?? []) {
+      await this.options.emit(session, "evidence.recorded", "tool", evidence);
+    }
+    await this.options.emit(session, "diagnostic", "runtime", {
+      kind: "tool.batch_settled",
+      callId: receipt.callId,
+      ok: receipt.ok,
+      evidenceIds: (receipt.evidence ?? []).map((item) => item.evidenceId),
+      diagnosticCodes: [...new Set([...receipt.diagnostics, ...(receipt.outcome?.diagnosticCodes ?? [])])]
+    });
+  }
+
+  private async dispatchPostTool(session: RuntimeSession, receipt: ToolReceipt, name: string): Promise<void> {
+    await this.options.hooks.dispatch(session, "post_tool", {
+      sessionId: session.identity.sessionId,
+      runId: session.durable.runId,
+      callId: receipt.callId,
+      toolName: name,
+      ok: receipt.ok,
+      diagnostics: receipt.diagnostics,
+      actualEffects: receipt.actualEffects ?? receipt.observedEffects,
+      evidenceIds: (receipt.evidence ?? []).map((item) => item.evidenceId),
+      artifactRefs: receipt.artifactRefs ?? []
+    }, session.execution.controller?.signal ?? new AbortController().signal);
+  }
+
+  private async reviewAfterReceipt(session: RuntimeSession, name: string): Promise<void> {
+    if (session.recovery.openCheckpointRecovery) return;
+    const reviewMode = session.services.profile?.profile.mutationPolicy.reviewMode ?? "advisory";
+    if (!shouldReviewReceipt(name, reviewMode)) return;
+    await this.reviews.maybeReview(
+      session,
+      session.execution.controller?.signal ?? new AbortController().signal,
+      name === "request_review",
+      name === "runtime_finalize" ? "completion" : "workspace"
+    );
+  }
+}

--- a/packages/agent-runtime/src/tool-plan-enforcement.ts
+++ b/packages/agent-runtime/src/tool-plan-enforcement.ts
@@ -175,6 +175,41 @@ async function canonicalWrittenObjectPath(
   return parent ? path.join(parent, path.basename(lexical)) : null;
 }
 
+/** Keep a review-directed mutation inside the runtime-authenticated finding
+ * scope. The model may narrow the prepared write plan, but it cannot widen
+ * the obligation by changing arguments, checkpoint roots, or call IDs. */
+export async function assertTaskControlPlanAllowed(
+  session: RuntimeSession,
+  plan: ToolCallPlan
+): Promise<void> {
+  const obligation = session.durable.state.taskControl.obligation;
+  if (obligation?.kind !== "review_repair" || obligation.stage !== "mutate") return;
+  if (!plan.exactEffects.includes("filesystem.write")) {
+    throw Object.assign(new Error(
+      "The active review repair requires one scoped workspace mutation."
+    ), { code: "tool_unavailable_for_repair" });
+  }
+  const requested = plan.writePaths.length > 0 ? plan.writePaths : plan.checkpointScope;
+  if (requested.length === 0) {
+    throw Object.assign(new Error(
+      "The review repair mutation did not declare any exact write path."
+    ), { code: "tool_unavailable_for_repair" });
+  }
+  const allowed = (await Promise.all(obligation.scopePaths.map(async (item) =>
+    await canonicalWrittenObjectPath(session.identity.workspacePath, item))))
+    .filter((item): item is string => Boolean(item));
+  const targets = await Promise.all(requested.map(async (item) => ({
+    item,
+    canonical: await canonicalWrittenObjectPath(session.identity.workspacePath, item)
+  })));
+  const outside = targets.filter(({ canonical }) => !canonical
+    || !allowed.some((scope) => isInside(scope, canonical))).map(({ item }) => item);
+  if (allowed.length === obligation.scopePaths.length && outside.length === 0) return;
+  throw Object.assign(new Error(
+    `Review repair write plan is outside the authenticated finding scope: ${outside.join(", ") || "invalid scope"}.`
+  ), { code: "tool_unavailable_for_repair" });
+}
+
 /** Freeze validation authority at preparation time. Coverage comes only from
  * a semantic command adapter and its selected project/files. Filesystem grants
  * and cwd traversal authority are deliberately irrelevant. */

--- a/packages/agent-runtime/src/tool-transaction-runner.ts
+++ b/packages/agent-runtime/src/tool-transaction-runner.ts
@@ -105,7 +105,7 @@ export class ToolTransactionRunner {
       return failed(call, startedAt, `Tool '${call.name}' is denied by the frozen Agent Profile.`, "profile_denied");
     }
     const repairPhase = completionRepairPhase(session);
-    if (!descriptorAllowedForRepair(descriptor, repairPhase)) {
+    if (!descriptorAllowedForRepair(session, descriptor, repairPhase)) {
       return failed(
         call,
         startedAt,
@@ -125,7 +125,7 @@ export class ToolTransactionRunner {
         callId: call.id, name: call.name, arguments: call.arguments
       }, context)
       : await prepareToolCallPlan(descriptor, call.arguments, context);
-    if (!effectsAllowedForRepair(plan.exactEffects, repairPhase)) {
+    if (!effectsAllowedForRepair(session, plan.exactEffects, repairPhase)) {
       return failed(
         call,
         startedAt,

--- a/packages/agent-runtime/src/tool-transaction-runner.ts
+++ b/packages/agent-runtime/src/tool-transaction-runner.ts
@@ -87,15 +87,6 @@ export class ToolTransactionRunner {
     const { call, modelTurn } = attempt;
     const descriptor = this.options.runtime.tools.descriptors().find((item) => item.name === call.name);
     if (!descriptor) return failed(call, startedAt, `Unknown tool '${call.name}'.`, "unknown_tool");
-    if (descriptor.possibleEffects.some((effect) => effect === "process.spawn" || effect === "process.spawn.readonly")
-      && [...session.interaction.capabilityFailures.values()].some((count) => count >= 2)) {
-      return failed(
-        call,
-        startedAt,
-        "Execution is blocked after the same sandbox capability failed twice. Do not substitute a weaker probe; report the typed environment blocker.",
-        "capability_retry_exhausted"
-      );
-    }
     await this.options.emit(session, "tool.requested", "runtime", {
       callId: call.id, name: call.name, arguments: call.arguments, ...turnPayload(modelTurn)
     });

--- a/packages/agent-runtime/src/tool-transaction-runner.ts
+++ b/packages/agent-runtime/src/tool-transaction-runner.ts
@@ -18,6 +18,7 @@ import { profileAllowsTool } from "./profile-policy.js";
 import { assertToolReceiptIdentity, normalizeReceiptEvidence } from "./tool-evidence.js";
 import {
   assertCheckpointActionAllowed,
+  assertTaskControlPlanAllowed,
   assertReceiptWithinPlan,
   validationScope
 } from "./tool-plan-enforcement.js";
@@ -168,6 +169,7 @@ export class ToolTransactionRunner {
         "plan_required"
       );
     }
+    await assertTaskControlPlanAllowed(session, plan);
     const scopeError = await writeScopeFailure(session, call, descriptor, startedAt, plan);
     if (scopeError) return scopeError;
     const completionError = completionFailure(session, call, descriptor, startedAt);

--- a/packages/agent-runtime/src/tool-turn-policy.ts
+++ b/packages/agent-runtime/src/tool-turn-policy.ts
@@ -1,93 +1,99 @@
-import {
-  evidenceSupportsClaim,
-  isCompletionReferenceableEvidence,
-  type ToolDescriptor,
-  type ToolEffect
-} from "agent-protocol";
+import type { ToolDescriptor, ToolEffect } from "agent-protocol";
 import type { RuntimeSession } from "./types.js";
 
 export type CompletionRepairPhase =
   | "none"
-  | "evidence"
-  | "terminal"
-  | "failed_validation_terminal"
-  | "protected_completion"
-  | "protected_recovery";
+  | "focused"
+  | "generic_repair"
+  | "completion_evidence"
+  | "review_mutate"
+  | "review_validate"
+  | "review_review"
+  | "terminal";
 
-function hasExitedFailedValidation(session: RuntimeSession): boolean {
-  return session.durable.state.evidence.some((item) => item.sessionId === session.identity.sessionId
-    && item.runId === session.durable.runId
-    && item.kind === "validation"
-    && item.status === "failed"
-    && evidenceSupportsClaim(item, "validation_executed"));
-}
+const REVIEW_REPAIR_PHASES = {
+  mutate: "review_mutate",
+  validate: "review_validate",
+  re_review: "review_review"
+} as const;
 
-function prerequisiteRepairPhase(
-  session: RuntimeSession,
-  evidenceCount: number
-): CompletionRepairPhase {
-  const referenceableEvidence = session.durable.state.evidence.filter((item) =>
-    isCompletionReferenceableEvidence(item, session.identity.sessionId, session.durable.runId)).length;
-  return referenceableEvidence > evidenceCount ? "protected_completion" : "evidence";
-}
-
-function explicitRepairPhase(session: RuntimeSession): CompletionRepairPhase | null {
-  const repair = session.durable.state.completionRepair;
-  if (repair?.kind === "evidence_acquisition") {
-    // A failed validation is still referenceable for the narrow
-    // validation_executed claim. Once it is durable, asking for another
-    // evidence tool would make an honest failure look like an unfinished
-    // validation obligation. Restrict the next turn to terminal actions so
-    // the agent can report exactly what happened.
-    const hasReferenceableEvidence = session.durable.state.evidence.some((item) =>
-      isCompletionReferenceableEvidence(item, session.identity.sessionId, session.durable.runId));
-    return hasReferenceableEvidence
-      ? hasExitedFailedValidation(session) ? "failed_validation_terminal" : "terminal"
-      : "evidence";
+function obligationRepairPhase(session: RuntimeSession): CompletionRepairPhase | null {
+  const obligation = session.durable.state.taskControl.obligation;
+  if (obligation?.kind === "review_repair") return REVIEW_REPAIR_PHASES[obligation.stage];
+  if (obligation?.kind === "completion_evidence") {
+    return obligation.stage === "acquire" ? "completion_evidence" : "terminal";
   }
-  if (repair?.kind === "terminal_action") {
-    return hasExitedFailedValidation(session) ? "failed_validation_terminal" : "terminal";
-  }
-  if (repair?.kind === "protected_completion") {
-    return hasExitedFailedValidation(session) ? "failed_validation_terminal" : "protected_completion";
-  }
-  if (repair?.kind === "protected_recovery") return "protected_recovery";
-  if (repair?.kind === "completion_prerequisite") return prerequisiteRepairPhase(session, repair.evidenceCount);
+  if (obligation?.kind === "terminal_resolution" || obligation?.kind === "user_decision") return "terminal";
   return null;
 }
 
 export function completionRepairPhase(session: RuntimeSession): CompletionRepairPhase {
-  const explicit = explicitRepairPhase(session);
-  if (explicit) return explicit;
-  if (session.durable.state.completionRepairAttempts === 0) return "none";
-  // Compatibility for snapshots created before repair intent was durable.
-  const hasEvidence = session.durable.state.evidence.some((item) =>
-    isCompletionReferenceableEvidence(item, session.identity.sessionId, session.durable.runId));
-  return hasEvidence ? "terminal" : "evidence";
+  const control = session.durable.state.taskControl;
+  const obligationPhase = obligationRepairPhase(session);
+  if (obligationPhase) return obligationPhase;
+  if (control.phase === "terminal") return "terminal";
+  if (control.phase === "repair_only") return "generic_repair";
+  return control.phase === "focused" ? "focused" : "none";
+}
+
+function terminalEffect(effect: ToolEffect): boolean {
+  return effect === "outcome.propose" || effect === "outcome.report_blocked" || effect === "outcome.request_input";
+}
+
+function userInputAllowed(session: RuntimeSession): boolean {
+  return session.durable.state.taskControl.obligation?.kind === "user_decision";
 }
 
 export function descriptorAllowedForRepair(
+  session: RuntimeSession,
   descriptor: ToolDescriptor,
-  phase: CompletionRepairPhase
+  phase = completionRepairPhase(session)
 ): boolean {
-  void phase;
-  void descriptor;
-  return true;
+  switch (phase) {
+    case "none":
+    case "focused": return true;
+    case "generic_repair": return descriptor.possibleEffects.some((effect) =>
+      effect === "filesystem.write" || effect === "validation" || terminalEffect(effect));
+    case "completion_evidence":
+      return descriptor.name === "validate" || descriptor.name === "request_review"
+        || descriptor.possibleEffects.includes("filesystem.read");
+    case "review_mutate": return descriptor.possibleEffects.includes("filesystem.write");
+    case "review_validate": return descriptor.possibleEffects.includes("validation");
+    case "review_review": return descriptor.name === "request_review";
+    case "terminal":
+      if (descriptor.name === "request_user_input") return userInputAllowed(session);
+      return descriptor.possibleEffects.length > 0 && descriptor.possibleEffects.every(terminalEffect);
+  }
 }
 
 export function effectsAllowedForRepair(
+  session: RuntimeSession,
   effects: readonly ToolEffect[],
-  phase: CompletionRepairPhase
+  phase = completionRepairPhase(session)
 ): boolean {
-  void effects;
-  void phase;
-  return true;
+  switch (phase) {
+    case "none":
+    case "focused": return true;
+    case "generic_repair": return effects.some((effect) =>
+      effect === "filesystem.write" || effect === "validation" || terminalEffect(effect));
+    case "completion_evidence":
+      return effects.includes("validation") || effects.includes("filesystem.read")
+        || effects.includes("runtime.control");
+    case "review_mutate": return effects.includes("filesystem.write");
+    case "review_validate": return effects.includes("validation");
+    case "review_review": return effects.length === 1 && effects[0] === "runtime.control";
+    case "terminal": return effects.length > 0 && effects.every(terminalEffect);
+  }
 }
 
 export function descriptorsAllowedForRepair(
+  session: RuntimeSession,
   descriptors: readonly ToolDescriptor[],
-  phase: CompletionRepairPhase
+  phase = completionRepairPhase(session)
 ): ToolDescriptor[] {
-  void phase;
-  return [...descriptors];
+  return descriptors.filter((descriptor) => descriptorAllowedForRepair(session, descriptor, phase));
+}
+
+export function maximumTaskControlCalls(session: RuntimeSession): number {
+  return completionRepairPhase(session) === "none" ? Number.MAX_SAFE_INTEGER : 1;
 }

--- a/packages/agent-runtime/src/types.ts
+++ b/packages/agent-runtime/src/types.ts
@@ -161,9 +161,6 @@ export interface RuntimeSessionInteractionState {
   /** One-shot grants, bound to a call and intentionally not restored. */
   callApprovals: Map<string, CallApprovalGrant>;
   alwaysAllowedEffects: Set<string>;
-  /** Runtime-local convergence guard; infrastructure failures are summarized
-   * instead of being replayed through durable model history. */
-  capabilityFailures: Map<string, number>;
   steeringPending: number;
   followUps: QueuedFollowUp[];
   contextItems: ContextItem[];

--- a/packages/agent-tools/src/control-tools.ts
+++ b/packages/agent-tools/src/control-tools.ts
@@ -125,11 +125,12 @@ function requestReviewTool(): RegisteredEffectTool {
       const startedAt = new Date().toISOString();
       const result = await requiredControl(context).requestReview();
       const base = receipt(request, startedAt, result, ["runtime.control"]);
-      return result.status === "validation_required" || result.status === "changes_required" ? {
+      return result.status === "validation_required" || result.status === "changes_required"
+        || result.status === "review_unavailable" ? {
         ...base,
         ok: false,
-        diagnostics: [result.status === "validation_required"
-          ? "review_validation_required" : "review_changes_required"]
+        diagnostics: [result.status === "validation_required" ? "review_validation_required"
+          : result.status === "changes_required" ? "review_changes_required" : "review_unavailable"]
       } : base;
     }
   };
@@ -143,7 +144,7 @@ function restoreRunChangesTool(): RegisteredEffectTool {
     descriptor: {
       ...descriptor(
         "restore_run_changes",
-        "Restore the latest sealed mutation checkpoint created by this run. The runtime freezes the target, checks LIFO safety, and does not create a nested checkpoint.",
+        "Atomically restore every sealed mutation checkpoint created by this run. The runtime verifies the complete LIFO postimage chain and does not create a nested checkpoint.",
         {},
         [],
         effects
@@ -151,18 +152,22 @@ function restoreRunChangesTool(): RegisteredEffectTool {
       availableModes: ["change"],
       prepare: async (_argumentsValue, context): Promise<ToolCallPlan> => {
         const checkpoints = await requiredControl(context).listCheckpoints();
-        const latest = [...checkpoints].reverse().find((item) => item.status !== "restored");
+        const unresolved = checkpoints.filter((item) => item.status !== "restored");
+        const latest = unresolved.at(-1);
         if (!latest) throw controlError("The current session has no checkpoint to restore.", "checkpoint_missing");
         if (latest.status !== "sealed") {
           throw controlError("Resolve the open checkpoint before restoring run changes.", "checkpoint_recovery_required");
         }
-        if (latest.runId !== context.runId) {
-          throw controlError("The latest checkpoint was not created by the current run.", "checkpoint_run_mismatch");
+        const first = unresolved.findIndex((item) => item.runId === context.runId);
+        if (first < 0 || unresolved.slice(first).some((item) => item.runId !== context.runId)) {
+          throw controlError("The current run is not the latest restorable checkpoint group.", "checkpoint_run_mismatch");
         }
-        const delta = latest.delta;
-        const paths = delta
-          ? [...new Set([...delta.added, ...delta.modified, ...delta.deleted])]
-          : [];
+        const targets = unresolved.slice(first);
+        if (targets.some((item) => item.status !== "sealed" || !item.delta)) {
+          throw controlError("All current-run checkpoints must be sealed before restoration.", "checkpoint_not_sealed");
+        }
+        const paths = [...new Set(targets.flatMap((item) => item.delta
+          ? [...item.delta.added, ...item.delta.modified, ...item.delta.deleted] : []))].sort();
         if (paths.length === 0) {
           throw controlError("The latest checkpoint contains no workspace changes.", "checkpoint_delta_empty");
         }
@@ -184,21 +189,62 @@ function restoreRunChangesTool(): RegisteredEffectTool {
       if (!action || action.kind !== "restore") {
         throw controlError("A frozen checkpoint restore plan is required.", "checkpoint_action_invalid");
       }
-      const restored = await requiredControl(context).restoreRunCheckpoint(action.checkpointId);
-      if (!restored.delta) {
-        throw controlError("The restored checkpoint has no workspace delta.", "checkpoint_delta_empty");
-      }
+      const restoration = await requiredControl(context).restoreRunChanges(request.callId);
+      const restored = (await requiredControl(context).listCheckpoints())
+        .filter((item) => restoration.restoredCheckpointIds.includes(item.checkpointId));
+      const delta = inverseRunDelta(restored);
       return {
         ...receipt(request, startedAt, {
-          checkpointId: restored.checkpointId,
-          status: restored.status
+          checkpointIds: restoration.restoredCheckpointIds,
+          status: "restored",
+          restoration
         }, effects),
-        workspaceDelta: {
-          added: [...restored.delta.deleted],
-          modified: [...restored.delta.modified],
-          deleted: [...restored.delta.added]
-        }
+        workspaceDelta: delta
       };
+    }
+  };
+}
+
+function inverseRunDelta(checkpoints: readonly import("agent-protocol").CheckpointRef[]): {
+  added: string[]; modified: string[]; deleted: string[];
+} {
+  const states = new Map<string, "added" | "modified" | "deleted">();
+  for (const checkpoint of checkpoints) {
+    if (!checkpoint.delta) continue;
+    for (const path of checkpoint.delta.added) {
+      const before = states.get(path);
+      states.set(path, before === "deleted" || before === "modified" ? "modified" : "added");
+    }
+    for (const path of checkpoint.delta.modified) if (states.get(path) !== "added") states.set(path, "modified");
+    for (const path of checkpoint.delta.deleted) {
+      if (states.get(path) === "added") states.delete(path);
+      else states.set(path, "deleted");
+    }
+  }
+  return {
+    added: [...states].filter(([, state]) => state === "deleted").map(([path]) => path).sort(),
+    modified: [...states].filter(([, state]) => state === "modified").map(([path]) => path).sort(),
+    deleted: [...states].filter(([, state]) => state === "added").map(([path]) => path).sort()
+  };
+}
+
+function confirmRunRestoredTool(): RegisteredEffectTool {
+  const effects: ToolDescriptor["possibleEffects"] = ["runtime.control", "filesystem.read"];
+  return {
+    descriptor: {
+      ...descriptor(
+        "confirm_run_restored",
+        "Confirm that a user-steered run is quiescent and its workspace exactly matches the recorded pre-run baseline. This does not mutate the workspace.",
+        {},
+        [],
+        effects
+      ),
+      availableModes: ["change"]
+    },
+    async execute(request, context) {
+      const startedAt = new Date().toISOString();
+      const restoration = await requiredControl(context).confirmRunRestored(request.callId);
+      return receipt(request, startedAt, restoration, effects);
     }
   };
 }
@@ -223,7 +269,7 @@ function loadSkillTool(): RegisteredEffectTool {
 export function registerControlTools(registry: EffectToolRegistry): EffectToolRegistry {
   for (const tool of [
     readPlanTool(), updatePlanTool(), budgetTool(), checkpointTool(), requestReviewTool(),
-    restoreRunChangesTool(), loadSkillTool()
+    restoreRunChangesTool(), confirmRunRestoredTool(), loadSkillTool()
   ]) {
     registry.register(tool);
   }

--- a/packages/agent-tui/src/components/commands.ts
+++ b/packages/agent-tui/src/components/commands.ts
@@ -8,7 +8,7 @@ export interface TuiCommandDefinition {
 
 export const tuiCommands: readonly TuiCommandDefinition[] = [
   { action: "new", name: "/new", usage: "/new", description: "Start a new session" },
-  { action: "mode", name: "/mode", usage: "/mode analyze|change", description: "Change mode for the next run", acceptsArguments: true },
+  { action: "mode", name: "/mode", usage: "/mode analyze|change", description: "Start an idle session in another mode", acceptsArguments: true },
   { action: "followup", name: "/followup", usage: "/followup <message>", description: "Queue work after the active answer", acceptsArguments: true },
   { action: "activity", name: "/activity", usage: "/activity", description: "Collapse or expand activity" },
   { action: "help", name: "/help", usage: "/help", description: "Show commands and shortcuts" },

--- a/packages/agent-tui/src/components/controller.ts
+++ b/packages/agent-tui/src/components/controller.ts
@@ -1,6 +1,7 @@
 import { createPresentationState, projectEvent } from "agent-presentation";
 import type { AgentEventEnvelope, RunMode } from "agent-protocol";
 import { parseTuiCommand } from "./commands.js";
+import { assertDurableSessionMode, ffiReady } from "./session-mode.js";
 import { TuiView } from "./view.js";
 import type { SubmissionKind, TuiAppOptions, TuiSnapshot, TuiViewActions } from "./types.js";
 
@@ -12,13 +13,6 @@ interface ControllerView {
 }
 
 type ViewFactory = (options: TuiAppOptions, actions: TuiViewActions) => Promise<ControllerView>;
-
-function ffiReady(): boolean {
-  const [major, minor] = process.versions.node.split(".").map(Number);
-  const supported = major > 26 || major === 26 && minor >= 4;
-  return supported && (process.execArgv.includes("--experimental-ffi")
-    || (process.env.NODE_OPTIONS ?? "").split(/\s+/u).includes("--experimental-ffi"));
-}
 
 export class TuiSessionController {
   private mode: RunMode;
@@ -75,7 +69,7 @@ export class TuiSessionController {
       }),
       interrupt: async () => await this.protect(async () => await this.interrupt()),
       newSession: async () => await this.protect(async () => await this.beginSessionTransition(async () => await this.newSession())),
-      setMode: (mode) => { this.mode = mode; this.notice(`Mode changed to ${mode}.`); this.refresh(); },
+      setMode: async (mode) => await this.protect(async () => await this.switchMode(mode)),
       stop: () => this.stop(),
       userAction: () => { if (this.noticeState?.error) this.notice(); }
     };
@@ -118,7 +112,7 @@ export class TuiSessionController {
     if (action === "activity") { this.view?.toggleActivity(); return true; }
     if (action === "mode") {
       if (argument !== "analyze" && argument !== "change") throw new Error("Mode must be analyze or change.");
-      this.mode = argument; this.notice(`Mode changed to ${argument}.`); this.refresh(); return true;
+      await this.switchMode(argument); return true;
     }
     if (action === "followup") {
       if (!argument) throw new Error("/followup requires a message.");
@@ -152,8 +146,22 @@ export class TuiSessionController {
     if (this.active) this.notice("New session. Type a request and press Enter.");
   }
 
+  private async switchMode(mode: RunMode): Promise<void> {
+    await this.sessionReady;
+    if (mode === this.mode) return;
+    if (["running", "needs_input"].includes(this.presentation.status)) {
+      throw new Error("Mode cannot change while a session is running. Cancel or wait for it to finish first.");
+    }
+    await this.beginSessionTransition(async () => {
+      this.mode = mode;
+      await this.newSession();
+      if (this.active) this.notice(`Started a new ${mode} session.`);
+    });
+  }
+
   private async resume(sessionId: string): Promise<void> {
     if (!this.active) return;
+    await assertDurableSessionMode(this.options.runtime, sessionId, this.mode);
     await this.options.runtime.command({ type: "resume", sessionId });
     if (!this.active) {
       await this.release(sessionId);

--- a/packages/agent-tui/src/components/session-mode.ts
+++ b/packages/agent-tui/src/components/session-mode.ts
@@ -1,0 +1,34 @@
+import type { RunMode } from "agent-protocol";
+import type { TuiAppOptions } from "./types.js";
+
+export function ffiReady(): boolean {
+  const [major, minor] = process.versions.node.split(".").map(Number);
+  const supported = major! > 26 || major === 26 && minor! >= 4;
+  return supported && (process.execArgv.includes("--experimental-ffi")
+    || (process.env.NODE_OPTIONS ?? "").split(/\s+/u).includes("--experimental-ffi"));
+}
+
+export async function assertDurableSessionMode(
+  runtime: TuiAppOptions["runtime"],
+  sessionId: string,
+  expectedMode: RunMode
+): Promise<void> {
+  for await (const event of runtime.sessionEvents(sessionId)) {
+    if (event.type !== "session.created") continue;
+    const createdMode = (event.payload as { mode?: unknown }).mode;
+    if (createdMode !== "analyze" && createdMode !== "change") {
+      throw Object.assign(new Error(`Session '${sessionId}' has an invalid durable mode.`), {
+        code: "session_creation_event_invalid"
+      });
+    }
+    if (createdMode !== expectedMode) {
+      throw Object.assign(new Error(
+        `Session '${sessionId}' was created in ${createdMode} mode, not ${expectedMode} mode.`
+      ), { code: "initial_mode_mismatch" });
+    }
+    return;
+  }
+  throw Object.assign(new Error(`Session '${sessionId}' has no durable creation event.`), {
+    code: "session_creation_event_missing"
+  });
+}

--- a/packages/agent-tui/src/components/types.ts
+++ b/packages/agent-tui/src/components/types.ts
@@ -26,7 +26,7 @@ export interface TuiViewActions {
   approve(requestId: string, decision: "allow" | "deny" | "always_allow"): Promise<void>;
   interrupt(): Promise<void>;
   newSession(): Promise<void>;
-  setMode(mode: RunMode): void;
+  setMode(mode: RunMode): Promise<void>;
   stop(): void;
   userAction(): void;
 }

--- a/packages/agent-tui/src/index.tsx
+++ b/packages/agent-tui/src/index.tsx
@@ -3,7 +3,7 @@ export { runTuiApp, type TuiAppOptions } from "./components/app.js";
 
 export async function main(argv = process.argv.slice(2)): Promise<number> {
   if (argv.includes("--help") || argv.includes("-h")) {
-    process.stdout.write(`agent tui [flags]\n\nThe TUI uses the same model, permission, workspace, and deadline flags as agent run.\n\nCommands:\n  /new                 Start a new session\n  /mode analyze|change Change mode for the next run\n  /followup <message>  Queue work after the active answer\n  /activity            Collapse or expand activity\n  /help                Show shortcuts and commands\n  /quit                Exit\n\nEnter sends or steers. Shift+Enter/Ctrl+J adds a line. Alt+Enter queues a follow-up.\nCtrl+C cancels the active run; press it again within 1.5 seconds to exit.\n`);
+    process.stdout.write(`agent tui [flags]\n\nThe TUI uses the same model, permission, workspace, and deadline flags as agent run. Use --initial-mode analyze|change to create the first session in the requested mode.\n\nCommands:\n  /new                 Start a new session\n  /mode analyze|change Start an idle session in another mode\n  /followup <message>  Queue work after the active answer\n  /activity            Collapse or expand activity\n  /help                Show shortcuts and commands\n  /quit                Exit\n\nEnter sends or steers. Shift+Enter/Ctrl+J adds a line. Alt+Enter queues a follow-up.\nCtrl+C cancels the active run; press it again within 1.5 seconds to exit.\n`);
     return 0;
   }
   process.stderr.write("Launch the TUI through the agent CLI so it can inject a configured RuntimeClient.\n");

--- a/tests/agent-cli.test.ts
+++ b/tests/agent-cli.test.ts
@@ -193,10 +193,11 @@ describe("Sigma CLI", () => {
     const workspace = await mkdtemp(path.join(os.tmpdir(), "sigma-cli-tui-"));
     const canonicalWorkspace = await realpath(workspace);
     let received = false;
-    await expect(runAgentCommand(["tui", "--workspace", workspace], {
+    await expect(runAgentCommand(["tui", "--workspace", workspace, "--initial-mode", "analyze"], {
       runtimeFactoryDeps: { executionBroker: createHostExecutionBroker() },
       tuiRunner: async (options) => {
-        received = typeof options.runtime.command === "function" && options.workspace === canonicalWorkspace;
+        received = typeof options.runtime.command === "function"
+          && options.workspace === canonicalWorkspace && options.mode === "analyze";
       }
     })).resolves.toBe(0);
     expect(received).toBe(true);

--- a/tests/agent-kernel.coverage.test.ts
+++ b/tests/agent-kernel.coverage.test.ts
@@ -1396,6 +1396,21 @@ describe("agent-kernel exhaustive protocol behavior", () => {
     });
 
     frontier = frontierAfterEvidence(frontier, [], {
+      ...importedCheckpoint,
+      evidenceId: "imported-later",
+      data: {
+        checkpointId: "imported-cp-later",
+        preManifestDigest: "9".repeat(64),
+        sourceSessionId: "source-session-later"
+      }
+    });
+    expect(frontier).toMatchObject({
+      revision: 2,
+      baselineManifestDigest: "a".repeat(64),
+      sourceCheckpointIds: ["imported-cp", "imported-cp-later"]
+    });
+
+    frontier = frontierAfterEvidence(frontier, [], {
       evidenceId: "repo", sessionId: "session", runId: "run",
       kind: "repository_delta", status: "passed", createdAt: "2026-01-01T00:00:01.000Z",
       producer: { authority: "runtime" }, summary: "updated repository",
@@ -1408,7 +1423,7 @@ describe("agent-kernel exhaustive protocol behavior", () => {
       }
     });
     expect(frontier).toMatchObject({
-      revision: 2, repositoryStateDigest: "d".repeat(64), changedPaths: [".git"]
+      revision: 3, repositoryStateDigest: "d".repeat(64), changedPaths: [".git"]
     });
 
     const unchanged = frontierAfterEvidence(frontier, [], diagnosticEvidence("diagnostic-v4"));

--- a/tests/agent-kernel.coverage.test.ts
+++ b/tests/agent-kernel.coverage.test.ts
@@ -12,17 +12,20 @@ import {
   acceptMutationFrontier,
   assertKernelInvariants,
   createKernelState,
+  completionEvidenceObligation,
+  createTaskControlState,
   decide,
   emptyMutationFrontier,
   evolve,
   frontierAfterCheckpoint,
   frontierAfterEvidence,
-  isCompletionRepairState,
+  isTaskControlStateV1,
   InvalidBudgetTransitionError,
   isKernelState,
   isStaleEffect,
   isTerminal,
   netChangedPaths,
+  protectCompletionCandidate,
   rehydrate,
   type KernelState
 } from "../packages/agent-kernel/src/index.js";
@@ -139,22 +142,16 @@ function completedReceipt(
 }
 
 describe("agent-kernel exhaustive protocol behavior", () => {
-  it("rejects a mixed terminal batch atomically and bounds a repeated conflict", () => {
+  it("durably records every call in a mixed terminal batch for runtime policy receipts", () => {
     let state = apply(initial(), "user.message", { text: "inspect or ask" });
     const mixed = (turn: number) => [
       { id: `ask-${turn}`, name: "request_user_input", arguments: { message: "Which path?" } },
       { id: `read-${turn}`, name: "read", arguments: { path: "seed.txt" } }
     ];
     state = proposeToolBatch(state, 1, mixed(1));
-    expect(state).toMatchObject({ phase: "ready_model", completionRepairAttempts: 1 });
-    expect(state.pendingTools).toEqual([]);
+    expect(state).toMatchObject({ phase: "tool_pending" });
+    expect(state.pendingTools.map((item) => item.request.callId)).toEqual(["ask-1", "read-1"]);
     expect(state.receipts).toEqual([]);
-
-    state = proposeToolBatch(state, 2, mixed(2));
-    expect(state.pendingTools).toEqual([]);
-    expect(state.proposedOutcome).toMatchObject({
-      kind: "recoverable_failure", code: "terminal_batch_conflict"
-    });
   });
 
   it("allows one completion alongside ordinary work outside a repair turn", () => {
@@ -163,33 +160,29 @@ describe("agent-kernel exhaustive protocol behavior", () => {
       { id: "write-1", name: "write", arguments: { path: "result.txt", content: "done" } },
       { id: "complete-1", name: "runtime_finalize", arguments: { summary: "done" } }
     ]);
-    expect(state).toMatchObject({ phase: "tool_pending", completionRepairAttempts: 0 });
+    expect(state).toMatchObject({ phase: "tool_pending" });
     expect(state.pendingTools.map((item) => item.request.callId)).toEqual(["write-1", "complete-1"]);
   });
 
-  it("rejects completion mixed with ordinary work during a repair turn", () => {
+  it("retains the active obligation while recording a mixed repair batch", () => {
     let state = apply(initial(), "user.message", { text: "finish cleanly" });
     state = {
       ...state,
-      completionRepairAttempts: 1,
-      completionRepair: { kind: "evidence_acquisition" }
+      taskControl: completionEvidenceObligation(state.taskControl, state.revision, "acquire", 0)
     };
     state = proposeToolBatch(state, 1, [
       { id: "read-1", name: "read", arguments: { path: "seed.txt" } },
       { id: "complete-1", name: "runtime_finalize", arguments: { summary: "done" } }
     ]);
-    expect(state.pendingTools).toEqual([]);
-    expect(state.proposedOutcome).toMatchObject({
-      kind: "recoverable_failure", code: "terminal_batch_conflict"
-    });
+    expect(state.pendingTools.map((item) => item.request.callId)).toEqual(["read-1", "complete-1"]);
+    expect(state.taskControl.obligation).toMatchObject({ kind: "completion_evidence", stage: "acquire" });
   });
 
   it("returns recoverable task-state failures from terminal repair to normal tools", () => {
     let state = apply(initial(), "user.message", { text: "finish after the process exits" });
     state = {
       ...state,
-      completionRepairAttempts: 1,
-      completionRepair: { kind: "terminal_action" },
+      taskControl: completionEvidenceObligation(state.taskControl, state.revision, "terminal", 1),
       evidence: [diagnosticEvidence("current-run-evidence")]
     };
     state = proposeToolBatch(state, 1, [{
@@ -204,7 +197,13 @@ describe("agent-kernel exhaustive protocol behavior", () => {
       diagnostics: ["active_processes"]
     };
     state = toolEvent(state, "tool.failed", "complete-while-active", failed);
-    expect(state).toMatchObject({ phase: "ready_model", completionRepairAttempts: 0 });
+    expect(state).toMatchObject({
+      phase: "ready_model",
+      taskControl: {
+        obligation: { kind: "completion_evidence", stage: "terminal" },
+        policyCorrection: { attempts: 1 }
+      }
+    });
     expect(state.proposedOutcome).toBeUndefined();
     expect(state.receipts.at(-1)?.diagnostics).toEqual(["active_processes"]);
   });
@@ -219,7 +218,6 @@ describe("agent-kernel exhaustive protocol behavior", () => {
     });
     expect(state).toMatchObject({
       phase: "tool_pending",
-      completionRepairAttempts: 0,
       pendingTools: [{ request: { name: "runtime_finalize", arguments: {
         summary: "Which target should I change?"
       } } }]
@@ -250,13 +248,12 @@ describe("agent-kernel exhaustive protocol behavior", () => {
     });
     expect(state).toMatchObject({
       phase: "terminal",
-      completionRepairAttempts: 0,
       outcome: {
         kind: "completed",
         message: "Which target should I change?"
       }
     });
-    expect(state.completionRepair).toBeUndefined();
+    expect(state.taskControl.completionCandidate?.answer).toBe("Which target should I change?");
     expect(() => assertKernelInvariants(state)).not.toThrow();
   });
 
@@ -306,9 +303,7 @@ describe("agent-kernel exhaustive protocol behavior", () => {
       completedAt: "end"
     });
     expect(state).toMatchObject({
-      phase: "ready_model",
-      completionRepairAttempts: 0,
-      completionRepair: undefined
+      phase: "ready_model"
     });
     expect(() => assertKernelInvariants(state)).not.toThrow();
 
@@ -319,8 +314,7 @@ describe("agent-kernel exhaustive protocol behavior", () => {
     }]);
     expect(requestedInput).toMatchObject({
       phase: "tool_pending",
-      pendingTools: [{ request: { callId: "blocked-input-request", name: "request_user_input" } }],
-      completionRepair: undefined
+      pendingTools: [{ request: { callId: "blocked-input-request", name: "request_user_input" } }]
     });
     requestedInput = toolEvent(requestedInput, "tool.completed", "blocked-input-request", {
       ok: true,
@@ -344,12 +338,11 @@ describe("agent-kernel exhaustive protocol behavior", () => {
       arguments: { processId: "process" }
     }]);
     expect(recoveryWork).toMatchObject({
-      phase: "tool_pending",
-      completionRepair: undefined
+      phase: "tool_pending"
     });
   });
 
-  it("blocks a third identical batch only after two identical completed outcomes", () => {
+  it("counts duplicate content as no progress without terminating before the seven-batch bound", () => {
     let state = apply(initial(), "user.message", { text: "inspect repeatedly" });
     for (const index of [1, 2]) {
       const callId = `same-${index}`;
@@ -359,11 +352,10 @@ describe("agent-kernel exhaustive protocol behavior", () => {
         `2026-01-01T00:00:0${index}.000Z`
       ));
     }
-    expect(state.repeatedToolBatchCount).toBe(2);
+    expect(state.taskControl.episode.noProgressBatches).toBe(1);
     state = proposeToolBatch(state, 3, [{ id: "same-3", name: "read", arguments: { path: "seed.txt" } }]);
-    expect(state.pendingTools).toEqual([]);
-    expect(state.proposedOutcome).toMatchObject({ kind: "recoverable_failure", code: "convergence_no_progress" });
-    expect(state.repeatedToolBatchCount).toBe(2);
+    expect(state.pendingTools).toHaveLength(1);
+    expect(state.proposedOutcome).toBeUndefined();
   });
 
   it("hashes large repeated outputs without weakening repeated-action convergence", () => {
@@ -379,8 +371,8 @@ describe("agent-kernel exhaustive protocol behavior", () => {
     }
     state = proposeToolBatch(state, 3, [{ id: "large-3", name: "read", arguments: { path: "large.txt" } }]);
 
-    expect(state.pendingTools).toEqual([]);
-    expect(state.proposedOutcome).toMatchObject({ kind: "recoverable_failure", code: "convergence_no_progress" });
+    expect(state.pendingTools).toHaveLength(1);
+    expect(state.proposedOutcome).toBeUndefined();
   });
 
   it("resets the completed-outcome streak when another batch intervenes", () => {
@@ -392,7 +384,7 @@ describe("agent-kernel exhaustive protocol behavior", () => {
     }
     state = proposeToolBatch(state, 3, [{ id: "other-path", name: "read", arguments: { path: "b.txt" } }]);
     state = toolEvent(state, "tool.completed", "other-path", completedReceipt("B", "2026-01-01T00:00:03.000Z"));
-    expect(state.repeatedToolBatchCount).toBe(1);
+    expect(state.taskControl.episode.noProgressBatches).toBe(0);
     state = proposeToolBatch(state, 4, [{ id: "first-path-again", name: "read", arguments: { path: "a.txt" } }]);
     expect(state.phase).toBe("tool_pending");
     expect(state.proposedOutcome).toBeUndefined();
@@ -412,7 +404,7 @@ describe("agent-kernel exhaustive protocol behavior", () => {
     state = toolEvent(state, "tool.completed", "changing-1", first);
     state = proposeToolBatch(state, 2, [{ id: "changing-2", name: "read", arguments: { path: "seed.txt" } }]);
     state = toolEvent(state, "tool.completed", "changing-2", second);
-    expect(state.repeatedToolBatchCount).toBe(1);
+    expect(state.taskControl.episode.noProgressBatches).toBe(0);
     state = proposeToolBatch(state, 3, [{ id: "changing-3", name: "read", arguments: { path: "seed.txt" } }]);
     expect(state.phase).toBe("tool_pending");
     expect(state.pendingTools).toHaveLength(1);
@@ -434,17 +426,18 @@ describe("agent-kernel exhaustive protocol behavior", () => {
     state = proposeToolBatch(state, 2, calls(2));
     state = toolEvent(state, "tool.completed", "batch-2-b", completedReceipt("B", "2026-01-01T00:00:03.000Z"));
     state = toolEvent(state, "tool.completed", "batch-2-a", completedReceipt("A", "2026-01-01T00:00:04.000Z"));
-    expect(state.repeatedToolBatchCount).toBe(2);
+    expect(state.taskControl.episode.noProgressBatches).toBe(1);
     state = proposeToolBatch(state, 3, calls(3, true));
-    expect(state.proposedOutcome).toMatchObject({ kind: "recoverable_failure", code: "convergence_no_progress" });
+    expect(state.pendingTools).toHaveLength(2);
+    expect(state.proposedOutcome).toBeUndefined();
   });
 
-  it("accepts legacy repetition snapshots without an outcome signature", () => {
+  it("rejects legacy repetition authorities in new snapshots", () => {
     expect(isKernelState({
       ...initial(),
       lastToolBatchSignature: "legacy-call-signature",
       repeatedToolBatchCount: 2
-    })).toBe(true);
+    })).toBe(false);
     expect(isKernelState({ ...initial(), lastToolBatchOutcomeSignature: 42 })).toBe(false);
   });
 
@@ -554,7 +547,6 @@ describe("agent-kernel exhaustive protocol behavior", () => {
     const conversational = settleModel(inFlight(), "model.completed", { message: { role: "assistant", content: "answer" }, toolCalls: [], finishReason: "stop" });
     expect(conversational).toMatchObject({
       phase: "tool_pending",
-      completionRepairAttempts: 0,
       proposedOutcome: undefined
     });
     const receipt = {
@@ -611,9 +603,16 @@ describe("agent-kernel exhaustive protocol behavior", () => {
       code: "model_protocol_error"
     });
     const invalidMessage = settleModel(inFlight(), "model.completed", { message: { role: "invalid" }, text: "fallback", toolCalls: [] });
-    expect(invalidMessage.proposedOutcome).toMatchObject({ kind: "recoverable_failure", code: "model_no_action" });
+    expect(invalidMessage).toMatchObject({
+      phase: "ready_model",
+      taskControl: { obligation: { kind: "terminal_resolution", failureCode: "empty_visible_response" } }
+    });
+    const invalidTwice = settleModel(startModel(invalidMessage, 2), "model.completed", {
+      message: { role: "invalid" }, toolCalls: []
+    });
+    expect(invalidTwice.proposedOutcome).toMatchObject({ kind: "recoverable_failure", code: "model_no_action" });
     const missingMessage = settleModel(inFlight(), "model.completed", { message: null, toolCalls: [] });
-    expect(missingMessage.proposedOutcome).toMatchObject({ kind: "recoverable_failure", code: "model_no_action" });
+    expect(missingMessage.taskControl.obligation).toMatchObject({ failureCode: "empty_visible_response" });
 
     const modelFailure = settleModel(inFlight(), "model.failed", { message: "network" });
     expect(modelFailure.proposedOutcome).toMatchObject({ kind: "recoverable_failure", code: "model_error" });
@@ -756,8 +755,10 @@ describe("agent-kernel exhaustive protocol behavior", () => {
     let repairedCompletion = withPendingTool("repair-complete", "runtime_finalize");
     repairedCompletion = {
       ...repairedCompletion,
-      completionRepairAttempts: 1,
-      completionRepair: { kind: "protected_completion", answer: "Detailed final answer." },
+      taskControl: protectCompletionCandidate(
+        repairedCompletion.taskControl,
+        "Detailed final answer."
+      ),
       evidence: [diagnosticEvidence("repair-evidence")],
       messages: [...repairedCompletion.messages, {
         role: "assistant",
@@ -770,7 +771,10 @@ describe("agent-kernel exhaustive protocol behavior", () => {
       startedAt: "start", completedAt: "end"
     });
     expect(repairedCompletion).toMatchObject({
-      proposedOutcome: { kind: "completed", message: "Detailed final answer." }
+      proposedOutcome: {
+        kind: "completed",
+        message: "Detailed final answer.\n\nResult: short summary"
+      }
     });
     const committedRevision = completion.revision;
     expect(apply(completion, "run.completed", {
@@ -860,12 +864,13 @@ describe("agent-kernel exhaustive protocol behavior", () => {
     });
     expect(state).toMatchObject({
       phase: "ready_model",
-      completionRepair: {
-        kind: "completion_prerequisite",
+      taskControl: { obligation: {
+        kind: "completion_evidence",
+        stage: "acquire",
         originalCallId: "completion-needs-validation",
         evidenceCount: 0,
-        retryCount: 0
-      }
+        attempts: 0
+      } }
     });
 
     state = apply(state, "evidence.recorded", {
@@ -900,7 +905,7 @@ describe("agent-kernel exhaustive protocol behavior", () => {
     expect(state).toMatchObject({
       phase: "ready_model",
       pendingTools: [],
-      completionRepair: { kind: "completion_prerequisite" }
+      taskControl: { phase: "normal", obligation: undefined }
     });
     expect(decide(state).map((effect) => effect.type)).toEqual(["request_model"]);
     expect(() => assertKernelInvariants(state)).not.toThrow();
@@ -1052,33 +1057,17 @@ describe("agent-kernel exhaustive protocol behavior", () => {
     })).toBe(false);
     expect(() => assertKernelInvariants({
       ...initial(), completionRepairAttempts: 1
-    })).toThrow("attempts require explicit repair state");
-    expect(() => assertKernelInvariants({
+    })).toThrow("superseded task-control authorities");
+    expect(isKernelState({
       ...initial(),
-      completionRepairAttempts: 1,
-      completionRepair: { kind: "protected_completion", answer: "answer" }
-    })).toThrow("requires current-run referenceable evidence");
-    expect(() => assertKernelInvariants({
-      ...initial(),
-      phase: "outcome_pending",
-      completionRepairAttempts: 1,
-      completionRepair: { kind: "protected_completion", answer: "answer" },
-      evidence: [diagnosticEvidence("protected-invariant")],
-      proposedOutcome: { kind: "needs_input", requestId: "ask", message: "question" }
-    })).not.toThrow();
+      taskControl: {
+        ...initial().taskControl,
+        completionCandidate: { answer: "   ", digest: "a".repeat(64) }
+      }
+    })).toBe(false);
     expect(() => assertKernelInvariants({
       ...initial(),
       phase: "needs_input",
-      completionRepairAttempts: 1,
-      completionRepair: { kind: "protected_completion", answer: "answer" },
-      evidence: [diagnosticEvidence("protected-snapshot")],
-      outcome: { kind: "needs_input", requestId: "forged", message: "question" }
-    })).toThrow("only for a pending tool approval");
-    expect(() => assertKernelInvariants({
-      ...initial(),
-      phase: "needs_input",
-      completionRepair: { kind: "protected_recovery", answer: "answer" },
-      evidence: [diagnosticEvidence("protected-approval")],
       toolCallIds: ["approve-read"],
       pendingTools: [{
         request: { callId: "approve-read", name: "read", arguments: null },
@@ -1113,14 +1102,6 @@ describe("agent-kernel exhaustive protocol behavior", () => {
       consumed: { inputTokens: 0, outputTokens: 0, costMicroUsd: 0, modelTurns: 0, toolCalls: 0, children: 0 },
       createdAt: "2026-01-01T00:00:00.000Z"
     };
-    const semanticCluster: NonNullable<KernelState["semanticFailureCluster"]> = {
-      family: "infrastructure",
-      attempts: 1,
-      firstRevision: 0,
-      lastRevision: 0,
-      diagnosticCodes: ["fixture_failure"],
-      progress: { workspaceChanges: 0, durableEvidence: 0, revision: 0 }
-    };
     const invalidStates: Array<[KernelState, string]> = [
       [{ ...base, schemaVersion: 2 } as unknown as KernelState, "schema version"],
       [{ ...base, plan: { revision: 0, goal: "", activeNodeId: "missing", nodes: [] } }, "plan graph"],
@@ -1144,24 +1125,16 @@ describe("agent-kernel exhaustive protocol behavior", () => {
         ...base.budget,
         reserved: { ...base.budget.reserved, inputTokens: 1 }
       } }, "does not match its active reservations"],
-      [{ ...base, semanticProgress: null } as unknown as KernelState, "semantic failure progress"],
-      [{ ...base, semanticFailureCluster: {} } as unknown as KernelState, "semantic failure progress"],
-      [{ ...base, semanticFailureCluster: {
-        ...semanticCluster, progress: { ...semanticCluster.progress, workspaceChanges: 1 }
-      } }, "does not match its progress watermark"],
-      [{ ...base, semanticFailureCluster: {
-        ...semanticCluster, progress: { ...semanticCluster.progress, durableEvidence: 1 }
-      } }, "does not match its progress watermark"],
-      [{ ...base, semanticFailureCluster: {
-        ...semanticCluster, progress: { ...semanticCluster.progress, revision: 1 }
-      } }, "does not match its progress watermark"],
-      [{ ...base, semanticProgress: { ...base.semanticProgress, revision: 1 } }, "exceeds the current revision"],
-      [{ ...base, semanticFailureCluster: {
-        ...semanticCluster, firstRevision: 1
-      } }, "semantic failure revisions"],
-      [{ ...base, semanticFailureCluster: {
-        ...semanticCluster, lastRevision: 1
-      } }, "semantic failure revisions"],
+      [{ ...base, semanticProgress: null } as unknown as KernelState, "superseded task-control authorities"],
+      [{ ...base, semanticFailureCluster: {} } as unknown as KernelState, "superseded task-control authorities"],
+      [{ ...base, taskControl: {} } as unknown as KernelState, "task-control state is invalid"],
+      [{
+        ...base,
+        taskControl: {
+          ...base.taskControl,
+          semanticFacts: { entries: [{ kind: "content", digest: "a".repeat(64), revision: 1 }] }
+        }
+      }, "exceed the current kernel revision"],
       [{ ...base, toolCallIds: ["same", "same"] }, "Duplicate run tool"],
       [{ ...base, phase: "tool_pending", pendingTools: [{
         request: { callId: "missing", name: "read", arguments: null },
@@ -1450,37 +1423,32 @@ describe("agent-kernel exhaustive protocol behavior", () => {
     expect(workspace.changedPaths).toEqual([".git", "file.ts"]);
   });
 
-  it("validates optional persisted state branches and rejects malformed repair state", () => {
+  it("validates optional persisted branches and the sole task-control schema", () => {
     const base = initial();
     expect(isKernelState({ ...base, deadlineRemainingMs: 1 })).toBe(true);
-    expect(isKernelState({ ...base, lastToolBatchSignature: "read:{}" })).toBe(true);
+    expect(isKernelState({ ...base, lastToolBatchSignature: "read:{}" })).toBe(false);
     expect(isKernelState({
       ...base,
       lastToolBatchSignature: "read:{}",
       lastToolBatchOutcomeSignature: "a".repeat(64),
       repeatedToolBatchCount: 1
-    })).toBe(true);
+    })).toBe(false);
     expect(isKernelState({ ...base, activeModelSemanticDelta: true })).toBe(true);
-    expect(isKernelState({ ...base, semanticProgress: { ...base.semanticProgress, revision: 1 } })).toBe(false);
-    expect(isKernelState({
-      ...base,
-      semanticFailureCluster: {
-        family: "validation", attempts: 1, firstRevision: 0, lastRevision: 0,
-        diagnosticCodes: ["validation_failed"], progress: base.semanticProgress
-      }
-    })).toBe(true);
+    expect(isKernelState({ ...base, semanticProgress: { revision: 1 } })).toBe(false);
     expect(isKernelState({ schemaVersion: base.schemaVersion })).toBe(false);
 
-    expect(isCompletionRepairState(null)).toBe(false);
-    expect(isCompletionRepairState({ kind: "evidence_acquisition" })).toBe(true);
-    expect(isCompletionRepairState({ kind: "terminal_action" })).toBe(true);
-    expect(isCompletionRepairState({
-      kind: "completion_prerequisite", answer: "continue", originalCallId: "complete-1",
-      arguments: { summary: "done" }, evidenceCount: 0, retryCount: 0,
-      modelTurn: { turnId: 1, effectRevision: 0 }
-    })).toBe(true);
-    expect(isCompletionRepairState({ kind: "protected_completion", answer: "preserved" })).toBe(true);
-    expect(isCompletionRepairState({ kind: "protected_completion", answer: "" })).toBe(false);
+    expect(isTaskControlStateV1(null)).toBe(false);
+    expect(isTaskControlStateV1(createTaskControlState())).toBe(true);
+    expect(isTaskControlStateV1({ ...createTaskControlState(), goalEpochSource: "unknown" })).toBe(false);
+    expect(isTaskControlStateV1({
+      ...createTaskControlState(),
+      semanticFacts: {
+        entries: [
+          { kind: "content", digest: "a".repeat(64), revision: 0 },
+          { kind: "content", digest: "a".repeat(64), revision: 0 }
+        ]
+      }
+    })).toBe(false);
   });
 
   it.skip("reconciles V3 evidence-id relationships across checkpoint restoration", () => {

--- a/tests/agent-kernel.durable-reducer-contract.test.ts
+++ b/tests/agent-kernel.durable-reducer-contract.test.ts
@@ -8,7 +8,10 @@ import {
 } from "../packages/agent-protocol/src/index.js";
 import {
   assertKernelInvariants,
+  completionEvidenceObligation,
   createKernelState,
+  protectCompletionCandidate,
+  terminalResolutionObligation,
   type KernelState
 } from "../packages/agent-kernel/src/index.js";
 import {
@@ -258,30 +261,23 @@ describe("durable reducer contracts", () => {
 
   it("transitions evidence-acquisition repairs according to the first referenceable evidence", () => {
     const eligible = diagnosticEvidence("eligible");
+    const base = initial();
     const explicitRepair: KernelState = {
-      ...initial(),
-      completionRepairAttempts: 2,
-      completionRepair: { kind: "evidence_acquisition" }
+      ...base,
+      taskControl: completionEvidenceObligation(base.taskControl, base.revision, "acquire", 0)
     };
-    expect(reduce(explicitRepair, "evidence.recorded", eligible)).toMatchObject({
-      completionRepairAttempts: 0,
-      completionRepair: undefined
-    });
+    expect(reduce(explicitRepair, "evidence.recorded", eligible).taskControl)
+      .toMatchObject({ phase: "normal", obligation: undefined });
 
-    const inferredRepair: KernelState = {
-      ...initial(),
-      completionRepairAttempts: 2
-    };
-    expect(reduce(inferredRepair, "evidence.recorded", {
+    const ordinary = initial();
+    expect(reduce(ordinary, "evidence.recorded", {
       ...eligible,
       evidenceId: "inferred-eligible"
-    })).toMatchObject({ completionRepairAttempts: 0, completionRepair: undefined });
+    }).taskControl).toEqual(ordinary.taskControl);
 
     const failedValidation = failedValidationEvidence("failed-referenceable");
-    expect(reduce(explicitRepair, "evidence.recorded", failedValidation)).toMatchObject({
-      completionRepairAttempts: 2,
-      completionRepair: { kind: "terminal_action" }
-    });
+    expect(reduce(explicitRepair, "evidence.recorded", failedValidation).taskControl.obligation)
+      .toMatchObject({ kind: "completion_evidence", stage: "terminal" });
   });
 
   it("requires monotonic plans and validates frozen runtime identities", () => {
@@ -416,37 +412,40 @@ describe("durable reducer contracts", () => {
     expect(reduce(state, "checkpoint.restored", { malformed: true })).toBe(state);
 
     const delta = workspaceDelta("protected-delta");
+    const protectedControl = completionEvidenceObligation(
+      protectCompletionCandidate(state.taskControl, "Protected answer."),
+      state.revision,
+      "terminal",
+      1
+    );
     const protectedCompletion: KernelState = {
       ...state,
-      completionRepairAttempts: 1,
-      completionRepair: { kind: "protected_completion", answer: "Protected answer." },
+      taskControl: protectedControl,
       messages: [{ role: "assistant", content: "Protected answer." }],
       evidence: [delta],
       mutationEvidence: [delta]
     };
     const reconciled = reduce(protectedCompletion, "checkpoint.restored", restored);
     expect(reconciled).toMatchObject({
-      completionRepairAttempts: 1,
-      completionRepair: { kind: "evidence_acquisition" },
+      taskControl: { obligation: { kind: "completion_evidence", stage: "acquire" } },
       evidence: [],
       mutationEvidence: []
     });
     expect(reconciled.messages.at(-1)?.content).toContain("removed the durable evidence");
     expect(() => assertKernelInvariants(reconciled)).not.toThrow();
 
-    for (const completionRepair of [
-      { kind: "protected_recovery", answer: "Recovered answer." },
-      { kind: "terminal_action" }
-    ] as const) {
+    for (const taskControl of [
+      completionEvidenceObligation(state.taskControl, state.revision, "terminal", 1),
+      terminalResolutionObligation(state.taskControl, state.revision, "terminal_action_failed")
+    ]) {
       const repairing: KernelState = {
         ...state,
-        completionRepairAttempts: 1,
-        completionRepair,
+        taskControl,
         evidence: [delta],
         mutationEvidence: [delta]
       };
-      expect(reduce(repairing, "checkpoint.restored", restored).completionRepair)
-        .toEqual({ kind: "evidence_acquisition" });
+      expect(reduce(repairing, "checkpoint.restored", restored).taskControl.obligation)
+        .toMatchObject({ kind: "completion_evidence", stage: "acquire" });
     }
   });
 

--- a/tests/agent-kernel.semantic-failure.test.ts
+++ b/tests/agent-kernel.semantic-failure.test.ts
@@ -1,251 +1,77 @@
 import { describe, expect, it } from "vitest";
 import {
-  EVENT_SCHEMA_VERSION,
-  type AgentEventEnvelope,
-  type AgentEventType,
   type EvidenceRecord,
-  type JsonValue,
-  type ToolEffect,
-  type WorkspaceDelta
+  type ToolReceipt
 } from "../packages/agent-protocol/src/index.js";
 import {
-  assertKernelInvariants,
   createKernelState,
-  decide,
-  evolve,
-  rehydrate,
-  SEMANTIC_INFRASTRUCTURE_FAILURE_CODE,
+  recordSemanticEvidenceProgress,
+  recordSemanticToolResult,
   type KernelState
 } from "../packages/agent-kernel/src/index.js";
 import { receiptContent, toolReceipt } from "../packages/agent-kernel/src/receipt-parsing.js";
+
+const NOW = "2026-07-12T00:00:00.000Z";
 
 function initial(): KernelState {
   return createKernelState({
     sessionId: "semantic-session",
     runId: "semantic-run",
     mode: "change",
-    startedAt: "2026-07-12T00:00:00.000Z",
+    startedAt: NOW,
     deadlineAt: "2026-07-12T00:15:00.000Z"
   });
 }
 
-function envelope(
-  state: KernelState,
-  type: AgentEventType,
-  payload: JsonValue,
-  authority: AgentEventEnvelope["authority"] = "runtime"
-): AgentEventEnvelope {
+function receipt(overrides: Partial<ToolReceipt> = {}): ToolReceipt {
   return {
-    schemaVersion: EVENT_SCHEMA_VERSION,
-    seq: state.lastSeq + 1,
-    eventId: `semantic-${state.lastSeq + 1}`,
-    sessionId: state.sessionId,
-    runId: state.runId,
-    occurredAt: "2026-07-12T00:00:00.000Z",
-    type,
-    authority,
-    payload
-  };
-}
-
-function apply(
-  state: KernelState,
-  type: AgentEventType,
-  payload: JsonValue,
-  events?: AgentEventEnvelope[],
-  authority?: AgentEventEnvelope["authority"]
-): KernelState {
-  const event = envelope(state, type, payload, authority);
-  events?.push(event);
-  return evolve(state, event);
-}
-
-function queueTool(
-  state: KernelState,
-  callId: string,
-  name: string,
-  events?: AgentEventEnvelope[]
-): KernelState {
-  let next = state;
-  if (next.phase === "idle") next = apply(next, "user.message", { text: "diagnose" }, events, "user");
-  const turnId = next.toolCallIds.length + 1;
-  next = apply(next, "model.started", { turnId, effectRevision: next.revision }, events);
-  const turn = next.activeModelTurn!;
-  return apply(next, "model.completed", {
-    ...turn,
-    message: { role: "assistant", content: "" },
-    toolCalls: [{ id: callId, name, arguments: { alternative: callId } }],
-    finishReason: "tool_calls"
-  }, events);
-}
-
-function queueTools(
-  state: KernelState,
-  calls: Array<{ id: string; name: string }>,
-  events?: AgentEventEnvelope[]
-): KernelState {
-  let next = state;
-  if (next.phase === "idle") next = apply(next, "user.message", { text: "diagnose" }, events, "user");
-  const turnId = next.toolCallIds.length + 1;
-  next = apply(next, "model.started", { turnId, effectRevision: next.revision }, events);
-  const turn = next.activeModelTurn!;
-  return apply(next, "model.completed", {
-    ...turn,
-    message: { role: "assistant", content: "" },
-    toolCalls: calls.map((call) => ({ id: call.id, name: call.name, arguments: {} })),
-    finishReason: "tool_calls"
-  }, events);
-}
-
-interface SuccessfulReceiptOptions {
-  observedEffects?: ToolEffect[];
-  actualEffects?: ToolEffect[];
-  workspaceDelta?: WorkspaceDelta;
-}
-
-function completePendingTool(
-  state: KernelState,
-  callId: string,
-  options: SuccessfulReceiptOptions = {},
-  events?: AgentEventEnvelope[]
-): KernelState {
-  const pending = state.pendingTools.find((item) => item.request.callId === callId)!;
-  const observedEffects = options.observedEffects ?? ["filesystem.read"];
-  return apply(state, "tool.completed", {
-    callId,
-    ...pending.modelTurn,
+    callId: "call",
     ok: true,
     output: "completed",
     outcome: { status: "succeeded", output: "completed", diagnosticCodes: [] },
-    observedEffects,
-    ...(options.actualEffects === undefined ? {} : { actualEffects: options.actualEffects }),
-    ...(options.workspaceDelta ? { workspaceDelta: options.workspaceDelta } : {}),
+    observedEffects: ["filesystem.read"],
+    actualEffects: ["filesystem.read"],
     artifacts: [],
     diagnostics: [],
-    evidence: [],
     startedAt: "start",
-    completedAt: "end"
-  }, events, "tool");
+    completedAt: "end",
+    ...overrides
+  };
 }
 
-function successfulReceipt(
-  state: KernelState,
-  callId: string,
-  toolName: string,
-  options: SuccessfulReceiptOptions = {},
-  events?: AgentEventEnvelope[]
-): KernelState {
-  return completePendingTool(queueTool(state, callId, toolName, events), callId, options, events);
-}
-
-function failedReceipt(
-  state: KernelState,
-  callId: string,
-  diagnosticCode: string,
-  events?: AgentEventEnvelope[],
-  workspaceDelta?: { added: string[]; modified: string[]; deleted: string[] }
-): KernelState {
-  const pending = state.pendingTools.find((item) => item.request.callId === callId)!;
-  return apply(state, "tool.failed", {
-    callId,
-    ...pending.modelTurn,
-    ok: false,
-    output: "execution failed",
-    outcome: { status: "failed", output: "execution failed", diagnosticCodes: [diagnosticCode] },
-    observedEffects: ["process.spawn.readonly"],
-    ...(workspaceDelta ? { workspaceDelta } : {}),
-    artifacts: [],
-    diagnostics: [diagnosticCode],
-    evidence: [],
-    startedAt: "start",
-    completedAt: "end"
-  }, events, "tool");
-}
-
-function failAlternative(
-  state: KernelState,
-  callId: string,
-  toolName: string,
-  diagnosticCode: string,
-  events?: AgentEventEnvelope[]
-): KernelState {
-  return failedReceipt(queueTool(state, callId, toolName, events), callId, diagnosticCode, events);
-}
-
-describe("semantic execution failure convergence", () => {
-  it("bounds missing-dependency recovery even when diagnostic commands succeed between attempts", () => {
-    let state = failAlternative(initial(), "missing-one", "exec", "dependency_missing");
-    state = successfulReceipt(state, "diagnostic-one", "shell", {
-      observedEffects: ["process.spawn.readonly"],
-      actualEffects: ["process.spawn.readonly"]
-    });
-    state = failAlternative(state, "missing-two", "shell", "dependency_missing");
-    state = successfulReceipt(state, "diagnostic-two", "exec", {
-      observedEffects: ["process.spawn.readonly"],
-      actualEffects: ["process.spawn.readonly"]
-    });
-    state = failAlternative(state, "missing-three", "exec", "dependency_missing");
-
-    expect(state.proposedOutcome).toMatchObject({
-      kind: "recoverable_failure",
-      code: SEMANTIC_INFRASTRUCTURE_FAILURE_CODE
-    });
-    expect(state.semanticFailureCluster).toMatchObject({
-      family: "execution_dependency",
-      attempts: 3
-    });
-  });
-
-  it("does not classify child-command dependency errors as infrastructure failures", () => {
-    let state = failAlternative(initial(), "missing-one", "exec", "command_dependency_missing");
-    state = failAlternative(state, "missing-two", "shell", "command_dependency_missing");
-    state = failAlternative(state, "missing-three", "exec", "command_dependency_missing");
-
-    expect(state.proposedOutcome).toBeUndefined();
-    expect(state.semanticFailureCluster).toBeUndefined();
-  });
-
-  it("puts structured outcome, diagnostics, and evidence summaries in modern tool history", () => {
+describe("semantic fact ledger", () => {
+  it("puts structured outcome, diagnostics, and evidence summaries in model-visible history", () => {
     const evidence: EvidenceRecord = {
       evidenceId: "diagnostic-proof",
       sessionId: "semantic-session",
       runId: "semantic-run",
       kind: "diagnostic",
       status: "failed",
-      createdAt: "2026-07-12T00:00:00.000Z",
+      createdAt: NOW,
       producer: { authority: "tool", id: "modern" },
       summary: "Executable capability probe failed.",
       data: { source: "sigma-exec", diagnostic: { code: "executable_not_found" } }
     };
-    let state = queueTool(initial(), "modern", "exec");
-    const pending = state.pendingTools[0]!;
-    state = apply(state, "tool.failed", {
+    const content = receiptContent(receipt({
       callId: "modern",
-      ...pending.modelTurn,
       ok: false,
       output: "node was unavailable",
-      outcome: { status: "failed", output: "node was unavailable", diagnosticCodes: ["executable_not_found"] },
-      observedEffects: ["process.spawn.readonly"],
-      artifacts: [],
+      outcome: {
+        status: "failed",
+        output: "node was unavailable",
+        diagnosticCodes: ["executable_not_found"]
+      },
       diagnostics: ["executable_not_found"],
-      evidence: [evidence],
-      startedAt: "start",
-      completedAt: "end"
-    }, undefined, "tool");
-
-    const content = state.messages.at(-1)?.content ?? "";
+      evidence: [evidence]
+    }));
     expect(content).toContain("Failed tool receipt ID: modern");
-    expect(content).toContain("Receipt summary (JSON):");
     expect(content).toContain('"diagnosticCodes":["executable_not_found"]');
     expect(content).toContain('"evidenceId":"diagnostic-proof"');
     expect(content).toContain("Output:\nnode was unavailable");
-    expect(state.receipts[0]).toMatchObject({
-      outcome: { status: "failed", diagnosticCodes: ["executable_not_found"] }
-    });
   });
 
   it("clips large receipt output while retaining artifact and digest summaries", () => {
-    const receipt = toolReceipt({
+    const parsed = toolReceipt({
       callId: "large-receipt",
       ok: true,
       output: "head\n" + "payload ".repeat(20_000) + "\ntail",
@@ -259,112 +85,13 @@ describe("semantic execution failure convergence", () => {
       startedAt: "start",
       completedAt: "end"
     });
-    expect(receipt).not.toBeNull();
-    const content = receiptContent(receipt!);
+    expect(parsed).not.toBeNull();
+    const content = receiptContent(parsed!);
     expect(content.length).toBeLessThan(20_000);
     expect(content).toContain("receipt output omitted");
     expect(content).toContain("artifact-1");
     expect(content).toContain("sha256=");
     expect(content).toContain("tail");
-  });
-
-  it("clusters equivalent infrastructure diagnostics across different tools and stops after three attempts", () => {
-    let state = failAlternative(initial(), "powershell-attempt", "shell", "process_spawn_failed");
-    state = failAlternative(state, "node-attempt", "exec", "executable_not_found");
-    expect(state).toMatchObject({
-      phase: "ready_model",
-      semanticFailureCluster: { family: "execution_capability", attempts: 2 }
-    });
-
-    state = failAlternative(state, "cmd-attempt", "shell", "shell_unavailable");
-    expect(state).toMatchObject({
-      phase: "outcome_pending",
-      semanticFailureCluster: { family: "execution_capability", attempts: 3 },
-      proposedOutcome: {
-        kind: "recoverable_failure",
-        code: SEMANTIC_INFRASTRUCTURE_FAILURE_CODE,
-        message: expect.stringContaining("successful process launch")
-      }
-    });
-  });
-
-  it("converges repeated workspace transaction infrastructure failures across mutation tools", () => {
-    let state = failAlternative(initial(), "edit-attempt", "edit", "workspace_transaction_root_unavailable");
-    state = failAlternative(state, "write-attempt", "write", "workspace_transaction_root_unavailable");
-    expect(state).toMatchObject({
-      phase: "ready_model",
-      semanticFailureCluster: { family: "workspace_transaction", attempts: 2 }
-    });
-
-    state = failAlternative(state, "patch-attempt", "apply_patch", "workspace_transaction_cleanup_failed");
-    expect(state).toMatchObject({
-      phase: "outcome_pending",
-      semanticFailureCluster: { family: "workspace_transaction", attempts: 3 },
-      proposedOutcome: {
-        kind: "recoverable_failure",
-        code: SEMANTIC_INFRASTRUCTURE_FAILURE_CODE
-      }
-    });
-  });
-
-  it("keeps checkpoint recovery failures in their own public family", () => {
-    let state = failAlternative(initial(), "restore-one", "apply_patch", "checkpoint_recovery_failed");
-    state = failAlternative(state, "restore-two", "edit", "recovery_retry_denied");
-    state = failAlternative(state, "restore-three", "write", "recovery_result_lost_no_replay");
-    expect(state).toMatchObject({
-      phase: "outcome_pending",
-      semanticFailureCluster: { family: "checkpoint_recovery", attempts: 3 },
-      proposedOutcome: { code: SEMANTIC_INFRASTRUCTURE_FAILURE_CODE }
-    });
-  });
-
-  it("latches a reached cluster across another failure family and same-call evidence", () => {
-    let state = queueTools(initial(), [
-      { id: "infra-one", name: "shell" },
-      { id: "infra-two", name: "exec" },
-      { id: "infra-three", name: "shell" },
-      { id: "other-family-last", name: "validate" }
-    ]);
-    state = failedReceipt(state, "infra-one", "process_spawn_failed");
-    state = failedReceipt(state, "infra-two", "executable_not_found");
-    state = failedReceipt(state, "infra-three", "shell_unavailable");
-    expect(state.phase).toBe("tool_pending");
-    state = failedReceipt(state, "other-family-last", "broker_timeout");
-    expect(state).toMatchObject({
-      phase: "outcome_pending",
-      semanticFailureCluster: { family: "execution_capability", attempts: 3 },
-      proposedOutcome: { code: SEMANTIC_INFRASTRUCTURE_FAILURE_CODE }
-    });
-
-    const evidence: EvidenceRecord = {
-      evidenceId: "failed-call-warning",
-      sessionId: state.sessionId,
-      runId: state.runId,
-      kind: "diagnostic",
-      status: "warning",
-      createdAt: "2026-07-12T00:00:00.000Z",
-      producer: { authority: "tool", id: "infra-three" },
-      summary: "The failed call emitted a warning.",
-      data: { source: "fixture", diagnostic: { retryable: true } }
-    };
-    state = apply(state, "evidence.recorded", evidence, undefined, "tool");
-    expect(state.phase).toBe("outcome_pending");
-    expect(state.semanticFailureCluster?.attempts).toBe(3);
-  });
-
-  it("never treats ordinary non-zero command or validation exits as infrastructure failure clusters", () => {
-    let state = initial();
-    for (const callId of ["test-one", "test-two", "test-three", "test-four"]) {
-      state = failAlternative(state, callId, "validate", "exit_code=1");
-    }
-    expect(state.phase).toBe("ready_model");
-    expect(state.semanticFailureCluster).toBeUndefined();
-    expect(state.proposedOutcome).toBeUndefined();
-
-    for (const callId of ["policy-one", "policy-two", "policy-three"]) {
-      state = failAlternative(state, callId, "exec", "policy_denied");
-    }
-    expect(state.semanticFailureCluster).toBeUndefined();
   });
 
   it("preserves an explicit empty actual-effects projection during durable parsing", () => {
@@ -381,194 +108,60 @@ describe("semantic execution failure convergence", () => {
     })).toMatchObject({ actualEffects: [] });
   });
 
-  it("keeps an execution cluster across read/list work and informational evidence", () => {
-    let state = failAlternative(initial(), "first", "exec", "process_spawn_failed");
-    state = failAlternative(state, "second", "shell", "executable_not_found");
-    state = successfulReceipt(state, "read-progress", "read_file", {
-      observedEffects: ["filesystem.read"], actualEffects: ["filesystem.read"]
+  it("does not count process output, call IDs, or diagnostics as task progress", () => {
+    let state = recordSemanticToolResult(initial(), receipt({
+      callId: "one", output: "first output", diagnostics: ["first"]
+    }), "exec").state;
+    state = recordSemanticToolResult(state, receipt({
+      callId: "two", output: "different output", diagnostics: ["second"]
+    }), "shell").state;
+    expect(state.taskControl.semanticFacts.entries).toEqual([]);
+  });
+
+  it("deduplicates exact content facts while accepting a genuinely new content digest", () => {
+    const read = (callId: string, sha256: string): ToolReceipt => receipt({
+      callId,
+      result: { status: "read", path: "README.md", sha256 },
+      output: `content ${sha256}`
     });
-    state = successfulReceipt(state, "list-progress", "list_files", {
-      observedEffects: ["filesystem.read"], actualEffects: ["filesystem.read"]
-    });
-    const evidence: EvidenceRecord = {
-      evidenceId: "real-progress",
-      sessionId: state.sessionId,
-      runId: state.runId,
-      kind: "diagnostic",
-      status: "informational",
-      createdAt: "2026-07-12T00:00:00.000Z",
+    let state = recordSemanticToolResult(initial(), read("one", "a".repeat(64)), "read").state;
+    state = recordSemanticToolResult(state, read("two", "a".repeat(64)), "read").state;
+    expect(state.taskControl.semanticFacts.entries).toHaveLength(1);
+    state = recordSemanticToolResult(state, read("three", "b".repeat(64)), "read").state;
+    expect(state.taskControl.semanticFacts.entries).toHaveLength(2);
+  });
+
+  it("records canonical workspace and validation facts but ignores diagnostic evidence", () => {
+    const workspace: EvidenceRecord = {
+      evidenceId: "workspace",
+      sessionId: "semantic-session",
+      runId: "semantic-run",
+      kind: "workspace_delta",
+      status: "passed",
+      createdAt: NOW,
       producer: { authority: "runtime" },
-      summary: "A capability was independently verified.",
-      data: { source: "probe", diagnostic: { available: true } }
+      summary: "changed",
+      data: {
+        checkpointId: "checkpoint",
+        delta: { added: [], modified: ["src/index.ts"], deleted: [] },
+        reviewDiff: "diff",
+        reviewDiffPaths: ["src/index.ts"]
+      }
     };
-    state = apply(state, "evidence.recorded", evidence);
-    expect(state.semanticFailureCluster).toMatchObject({ family: "execution_capability", attempts: 2 });
-    expect(state.semanticProgress.durableEvidence).toBe(1);
-    expect(state.semanticFailureCluster?.progress).toEqual(state.semanticProgress);
-
-    state = failAlternative(state, "third", "validate", "shell_unavailable");
-    expect(state).toMatchObject({
-      phase: "outcome_pending",
-      semanticFailureCluster: { family: "execution_capability", attempts: 3 },
-      proposedOutcome: { code: SEMANTIC_INFRASTRUCTURE_FAILURE_CODE }
-    });
-
-    state = apply(state, "evidence.recorded", {
-      ...evidence,
-      evidenceId: "post-threshold-information",
-      summary: "A read-only inventory completed after the execution failures."
-    });
-    expect(state).toMatchObject({
-      phase: "outcome_pending",
-      semanticFailureCluster: { attempts: 3 },
-      proposedOutcome: { code: SEMANTIC_INFRASTRUCTURE_FAILURE_CODE }
-    });
-    expect(decide(state)).toEqual([expect.objectContaining({
-      type: "finish_run",
-      outcome: expect.objectContaining({ code: SEMANTIC_INFRASTRUCTURE_FAILURE_CODE })
-    })]);
-  });
-
-  it("only treats a verified launch-tool receipt as execution recovery", () => {
-    let state = failAlternative(initial(), "first", "exec", "process_spawn_failed");
-    state = failAlternative(state, "second", "shell", "executable_not_found");
-    for (const toolName of ["process_poll", "process_write", "process_terminate"]) {
-      state = successfulReceipt(state, `successful-${toolName}`, toolName, {
-        observedEffects: ["process.spawn.readonly"], actualEffects: ["process.spawn.readonly"]
-      });
-      expect(state.semanticFailureCluster?.attempts).toBe(2);
-    }
-
-    state = successfulReceipt(state, "real-launch", "exec", {
-      observedEffects: ["process.spawn.readonly"], actualEffects: ["process.spawn.readonly"]
-    });
-    expect(state.semanticFailureCluster).toBeUndefined();
-    state = failAlternative(state, "after-recovery", "exec", "process_spawn_failed");
-    expect(state.semanticFailureCluster?.attempts).toBe(1);
-
-    state = successfulReceipt(state, "legacy-launch", "shell", {
-      observedEffects: ["process.spawn.readonly"]
-    });
-    expect(state.semanticFailureCluster).toBeUndefined();
-  });
-
-  it("does not fall back to observed effects when actualEffects is explicitly empty", () => {
-    let state = failAlternative(initial(), "first", "exec", "process_spawn_failed");
-    state = failAlternative(state, "second", "shell", "executable_not_found");
-    state = successfulReceipt(state, "empty-actual-launch", "exec", {
-      observedEffects: ["process.spawn.readonly"], actualEffects: []
-    });
-    expect(state.semanticFailureCluster?.attempts).toBe(2);
-    state = failAlternative(state, "third", "validate", "shell_unavailable");
-    expect(state).toMatchObject({
-      phase: "outcome_pending",
-      semanticFailureCluster: { attempts: 3 },
-      proposedOutcome: { code: SEMANTIC_INFRASTRUCTURE_FAILURE_CODE }
-    });
-  });
-
-  it("preserves the reached execution cluster through a fourth receipt and failed workspace delta", () => {
-    const events: AgentEventEnvelope[] = [];
-    let state = queueTools(initial(), [
-      { id: "first", name: "exec" },
-      { id: "second", name: "shell" },
-      { id: "third", name: "validate" },
-      { id: "fourth", name: "exec" }
-    ], events);
-    state = failedReceipt(state, "first", "process_spawn_failed", events);
-    state = failedReceipt(state, "second", "executable_not_found", events);
-    state = failedReceipt(state, "third", "shell_unavailable", events, {
-      added: [], modified: ["src/transient-third.ts"], deleted: []
-    });
-    expect(state).toMatchObject({
-      phase: "tool_pending",
-      semanticProgress: { workspaceChanges: 1 },
-      semanticFailureCluster: { family: "execution_capability", attempts: 3 }
-    });
-
-    state = failedReceipt(state, "fourth", "process_spawn_failed", events, {
-      added: [], modified: ["src/transient-fourth.ts"], deleted: []
-    });
-    expect(state).toMatchObject({
-      phase: "outcome_pending",
-      semanticProgress: { workspaceChanges: 2 },
-      semanticFailureCluster: { family: "execution_capability", attempts: 3 },
-      proposedOutcome: { code: SEMANTIC_INFRASTRUCTURE_FAILURE_CODE }
-    });
-    expect(state.semanticFailureCluster?.progress).toEqual(state.semanticProgress);
-
-    const replayed = rehydrate(initial(), events);
-    assertKernelInvariants(replayed);
-    expect(replayed).toMatchObject({
-      phase: "outcome_pending",
-      semanticFailureCluster: { family: "execution_capability", attempts: 3 }
-    });
-    expect(decide(replayed)).toEqual(decide(state));
-  });
-
-  it("allows an already-started successful launch to recover a threshold cluster", () => {
-    let state = queueTools(initial(), [
-      { id: "first", name: "exec" },
-      { id: "second", name: "shell" },
-      { id: "third", name: "validate" },
-      { id: "recovery", name: "process_spawn" }
-    ]);
-    state = failedReceipt(state, "first", "process_spawn_failed");
-    state = failedReceipt(state, "second", "executable_not_found");
-    state = failedReceipt(state, "third", "shell_unavailable");
-    expect(state.semanticFailureCluster?.attempts).toBe(3);
-    state = completePendingTool(state, "recovery", {
-      observedEffects: ["process.spawn.readonly"], actualEffects: ["process.spawn.readonly"]
-    });
-    expect(state).toMatchObject({ phase: "ready_model" });
-    expect(state.semanticFailureCluster).toBeUndefined();
-    expect(state.proposedOutcome).toBeUndefined();
-  });
-
-  it("retains legacy reset behavior for non-execution infrastructure clusters", () => {
-    let state = failAlternative(initial(), "first", "edit", "workspace_transaction_root_unavailable");
-    state = failAlternative(state, "second", "write", "workspace_transaction_cleanup_failed");
-    state = failAlternative(state, "third", "apply_patch", "workspace_transaction_root_unavailable");
-    expect(state).toMatchObject({
-      phase: "outcome_pending",
-      semanticFailureCluster: { family: "workspace_transaction", attempts: 3 }
-    });
-    const evidence: EvidenceRecord = {
-      evidenceId: "non-execution-progress",
-      sessionId: state.sessionId,
-      runId: state.runId,
+    const diagnostic: EvidenceRecord = {
+      evidenceId: "diagnostic",
+      sessionId: "semantic-session",
+      runId: "semantic-run",
       kind: "diagnostic",
       status: "passed",
-      createdAt: "2026-07-12T00:00:00.000Z",
+      createdAt: NOW,
       producer: { authority: "runtime" },
-      summary: "The workspace transaction service recovered.",
-      data: { source: "transaction-probe", diagnostic: { available: true } }
+      summary: "probe",
+      data: { source: "test", diagnostic: { output: "variant" } }
     };
-    state = apply(state, "evidence.recorded", evidence);
-    expect(state).toMatchObject({ phase: "ready_model" });
-    expect(state.semanticFailureCluster).toBeUndefined();
-    expect(state.proposedOutcome).toBeUndefined();
-
-    state = failAlternative(state, "after-evidence", "edit", "workspace_transaction_root_unavailable");
-    state = successfulReceipt(state, "workspace-progress", "write_file", {
-      observedEffects: ["filesystem.write"],
-      actualEffects: ["filesystem.write"],
-      workspaceDelta: { added: [], modified: ["src/recovered.ts"], deleted: [] }
-    });
-    expect(state.semanticFailureCluster).toBeUndefined();
-    expect(state.semanticProgress.workspaceChanges).toBe(1);
-
-    state = failAlternative(state, "before-steer", "exec", "process_spawn_failed");
-    state = apply(state, "user.steer", { text: "use the verified route" }, undefined, "user");
-    expect(state.semanticFailureCluster).toBeUndefined();
-  });
-
-  it("replays the same semantic cluster and progress watermark from durable events", () => {
-    const events: AgentEventEnvelope[] = [];
-    let state = failAlternative(initial(), "first-replay", "shell", "process_spawn_failed", events);
-    state = failAlternative(state, "second-replay", "exec", "executable_not_found", events);
-    const replayed = rehydrate(initial(), events);
-    expect(replayed.semanticFailureCluster).toEqual(state.semanticFailureCluster);
-    expect(replayed.semanticProgress).toEqual(state.semanticProgress);
+    let state = recordSemanticEvidenceProgress(initial(), workspace);
+    expect(state.taskControl.semanticFacts.entries.map((item) => item.kind)).toEqual(["workspace_frontier"]);
+    state = recordSemanticEvidenceProgress(state, diagnostic);
+    expect(state.taskControl.semanticFacts.entries).toHaveLength(1);
   });
 });

--- a/tests/agent-kernel.task-control.test.ts
+++ b/tests/agent-kernel.task-control.test.ts
@@ -226,7 +226,7 @@ describe("TaskControlStateV1", () => {
     const second = recordToolPolicyViolation(first, "tool_unavailable_for_repair", 2);
     expect(second).toMatchObject({
       phase: "terminal",
-      obligation: { kind: "terminal_resolution", failureCode: "tool_unavailable_for_repair" }
+      obligation: { kind: "terminal_resolution", failureCode: "action_convergence_no_progress" }
     });
   });
 
@@ -244,6 +244,60 @@ describe("TaskControlStateV1", () => {
       phase: "terminal",
       obligation: { kind: "terminal_resolution", failureCode: "validation_evidence_required" }
     });
+  });
+
+  it("classifies an exhausted review-scope correction as review repair failure", () => {
+    const repair = reviewRepairObligation(
+      createTaskControlState(),
+      1,
+      DIGEST_A,
+      ["src/target.ts"]
+    );
+    const first = recordToolPolicyViolation(repair, "tool_unavailable_for_repair", 2);
+    const second = recordToolPolicyViolation(first, "tool_unavailable_for_repair", 3);
+    expect(second).toMatchObject({
+      phase: "terminal",
+      obligation: { kind: "terminal_resolution", failureCode: "review_repair_exhausted" }
+    });
+  });
+
+  it("clears repair and convergence state when current-epoch restoration is accepted", () => {
+    let state = workspaceDelta(initial());
+    state = {
+      ...state,
+      taskControl: terminalResolutionObligation(state.taskControl, state.revision, "review_repair_exhausted")
+    };
+    const frontier = state.mutationFrontier;
+    const evidence: EvidenceRecord = {
+      evidenceId: "restoration-current-epoch",
+      sessionId: state.sessionId,
+      runId: state.runId,
+      kind: "restoration",
+      status: "passed",
+      createdAt: NOW,
+      producer: { authority: "runtime", id: "workspace-restoration-v1" },
+      summary: "restored",
+      data: {
+        schemaVersion: 1,
+        goalEpoch: state.taskControl.goalEpoch,
+        frontierRevision: frontier.revision,
+        frontierStateDigest: frontier.currentStateDigest,
+        baselineManifestDigest: DIGEST_B,
+        currentManifestDigest: DIGEST_B,
+        restoredCheckpointIds: ["checkpoint-current-run"],
+        quiescence: {
+          supersededExecutionStopped: true,
+          noPendingMutations: true,
+          noProcesses: true,
+          noChildren: true,
+          noOpenCheckpoint: true
+        },
+        repository: { status: "unchanged" }
+      }
+    };
+    state = apply(state, "evidence.recorded", evidence);
+    expect(state.mutationFrontier.changedPaths).toEqual([]);
+    expect(state.taskControl).toMatchObject({ phase: "normal", obligation: undefined });
   });
 
   it("runs one review repair cycle and resolves only after validation and approval", () => {

--- a/tests/agent-kernel.task-control.test.ts
+++ b/tests/agent-kernel.task-control.test.ts
@@ -1,0 +1,293 @@
+import fc from "fast-check";
+import { describe, expect, it } from "vitest";
+import {
+  EVENT_SCHEMA_VERSION,
+  type AgentEventEnvelope,
+  type AgentEventType,
+  type EvidenceRecord,
+  type JsonValue,
+  type ToolReceipt
+} from "../packages/agent-protocol/src/index.js";
+import {
+  assertKernelInvariants,
+  completionEvidenceObligation,
+  completeActionBatch,
+  createKernelState,
+  createTaskControlState,
+  evolve,
+  isKernelState,
+  recordSemanticFact,
+  recordSemanticToolResult,
+  recordToolPolicyViolation,
+  startActionBatch,
+  type KernelState,
+  type TaskControlStateV1
+} from "../packages/agent-kernel/src/index.js";
+
+const NOW = "2026-07-22T00:00:00.000Z";
+const DIGEST_A = "a".repeat(64);
+const DIGEST_B = "b".repeat(64);
+
+function initial(): KernelState {
+  return createKernelState({
+    sessionId: "task-control-session",
+    runId: "task-control-run",
+    mode: "change",
+    startedAt: NOW,
+    deadlineAt: "2026-07-22T01:00:00.000Z"
+  });
+}
+
+function noProgress(control: TaskControlStateV1, revision: number): TaskControlStateV1 {
+  return completeActionBatch(startActionBatch(control), revision);
+}
+
+function envelope(
+  state: KernelState,
+  type: AgentEventType,
+  payload: JsonValue,
+  authority: AgentEventEnvelope["authority"] = "runtime"
+): AgentEventEnvelope {
+  return {
+    schemaVersion: EVENT_SCHEMA_VERSION,
+    seq: state.lastSeq + 1,
+    eventId: `event-${state.lastSeq + 1}`,
+    sessionId: state.sessionId,
+    runId: state.runId,
+    occurredAt: NOW,
+    type,
+    authority,
+    payload
+  };
+}
+
+function apply(
+  state: KernelState,
+  type: AgentEventType,
+  payload: JsonValue,
+  authority?: AgentEventEnvelope["authority"]
+): KernelState {
+  return evolve(state, envelope(state, type, payload, authority));
+}
+
+function review(
+  state: KernelState,
+  id: string,
+  verdict: "approved" | "changes_requested",
+  options: { failureKind?: "protocol"; basis?: string } = {}
+): KernelState {
+  const evidence: EvidenceRecord = {
+    evidenceId: id,
+    sessionId: state.sessionId,
+    runId: state.runId,
+    kind: "review",
+    status: verdict === "approved" ? "passed" : "failed",
+    createdAt: NOW,
+    producer: { authority: "runtime", id: "reviewer" },
+    summary: verdict,
+    data: {
+      reviewerId: "reviewer",
+      verdict,
+      findings: options.failureKind ? [] : verdict === "approved" ? [] : [{
+        actionable: true,
+        severity: "error",
+        summary: "Repair the current frontier."
+      }],
+      frontierRevision: state.mutationFrontier.revision,
+      stateDigest: state.mutationFrontier.currentStateDigest,
+      reviewBasisDigest: options.basis ?? DIGEST_A,
+      validationEvidenceIds: [],
+      ...(options.failureKind
+        ? { failureKind: options.failureKind, failureCode: "review_protocol_invalid" }
+        : {})
+    }
+  };
+  return apply(state, "review.completed", evidence);
+}
+
+function workspaceDelta(state: KernelState): KernelState {
+  const evidence: EvidenceRecord = {
+    evidenceId: `delta-${state.revision}`,
+    sessionId: state.sessionId,
+    runId: state.runId,
+    kind: "workspace_delta",
+    status: "passed",
+    createdAt: NOW,
+    producer: { authority: "runtime" },
+    summary: "repair delta",
+    data: {
+      checkpointId: `checkpoint-${state.revision}`,
+      delta: { added: [], modified: ["src/index.ts"], deleted: [] },
+      reviewDiff: "diff --git a/src/index.ts b/src/index.ts\n",
+      reviewDiffPaths: ["src/index.ts"]
+    }
+  };
+  return apply(state, "evidence.recorded", evidence);
+}
+
+function validation(state: KernelState, status: "passed" | "failed"): KernelState {
+  const evidence: EvidenceRecord = {
+    evidenceId: `validation-${status}-${state.revision}`,
+    sessionId: state.sessionId,
+    runId: state.runId,
+    kind: "validation",
+    status,
+    createdAt: NOW,
+    producer: { authority: "runtime" },
+    summary: `validation ${status}`,
+    data: {
+      validator: "command",
+      command: "pnpm test",
+      exitCode: status === "passed" ? 0 : 1,
+      termination: {
+        processStarted: true,
+        state: "exited",
+        exitCode: status === "passed" ? 0 : 1,
+        signal: null,
+        timedOut: false,
+        idleTimedOut: false,
+        cancelled: false
+      },
+      artifactIds: [],
+      frontierRevision: state.mutationFrontier.revision,
+      stateDigest: state.mutationFrontier.currentStateDigest,
+      coveredPaths: ["src/index.ts"]
+    }
+  };
+  return apply(state, "evidence.recorded", evidence);
+}
+
+function receipt(output: string): ToolReceipt {
+  return {
+    callId: "exec-call",
+    ok: true,
+    output,
+    outcome: { status: "succeeded", output, diagnosticCodes: [] },
+    observedEffects: ["process.spawn.readonly"],
+    artifacts: [],
+    diagnostics: [],
+    startedAt: NOW,
+    completedAt: NOW
+  };
+}
+
+describe("TaskControlStateV1", () => {
+  it("moves monotonically through focused and repair-only to terminal in seven no-progress batches", () => {
+    let control = createTaskControlState();
+    const phases: string[] = [];
+    for (let revision = 1; revision <= 7; revision += 1) {
+      control = noProgress(control, revision);
+      phases.push(control.phase);
+    }
+    expect(phases).toEqual([
+      "normal", "focused", "focused", "focused", "focused", "repair_only", "terminal"
+    ]);
+    expect(control.obligation).toMatchObject({
+      kind: "terminal_resolution",
+      failureCode: "action_convergence_no_progress"
+    });
+  });
+
+  it("resets an episode only for a new runtime fact and not for a duplicate fact", () => {
+    const control = noProgress(noProgress(createTaskControlState(), 1), 2);
+    expect(control.phase).toBe("focused");
+    const first = recordSemanticFact(control, "content", { path: "README.md", digest: DIGEST_A }, 3);
+    expect(first.trustedProgress).toBe(true);
+    expect(first.control).toMatchObject({ phase: "normal", episode: { noProgressBatches: 0 } });
+    const duplicate = recordSemanticFact(first.control, "content", { path: "README.md", digest: DIGEST_A }, 4);
+    expect(duplicate.trustedProgress).toBe(false);
+    expect(duplicate.control).toBe(first.control);
+  });
+
+  it("does not treat argv or stdout variants from process tools as progress", () => {
+    fc.assert(fc.property(fc.string(), fc.string(), (left, right) => {
+      const state = initial();
+      const first = recordSemanticToolResult(state, receipt(left), "exec").state;
+      const second = recordSemanticToolResult(first, { ...receipt(right), callId: "other-call" }, "shell").state;
+      expect(second.taskControl.semanticFacts.entries).toEqual([]);
+    }));
+  });
+
+  it("allows one policy correction per episode regardless of call or error variation", () => {
+    const first = recordToolPolicyViolation(createTaskControlState(), "unknown_tool", 1);
+    expect(first).toMatchObject({ phase: "focused", policyCorrection: { attempts: 1 } });
+    const second = recordToolPolicyViolation(first, "tool_unavailable_for_repair", 2);
+    expect(second).toMatchObject({
+      phase: "terminal",
+      obligation: { kind: "terminal_resolution", failureCode: "tool_unavailable_for_repair" }
+    });
+  });
+
+  it("preserves the unresolved completion prerequisite when correction is exhausted", () => {
+    const evidenceRequired = completionEvidenceObligation(
+      createTaskControlState(),
+      1,
+      "acquire",
+      0,
+      { failureCode: "validation_evidence_required" }
+    );
+    const first = recordToolPolicyViolation(evidenceRequired, "unknown_tool", 2);
+    const second = recordToolPolicyViolation(first, "model_tool_policy_violation", 3);
+    expect(second).toMatchObject({
+      phase: "terminal",
+      obligation: { kind: "terminal_resolution", failureCode: "validation_evidence_required" }
+    });
+  });
+
+  it("runs one review repair cycle and resolves only after validation and approval", () => {
+    let state = review(initial(), "review-one", "changes_requested");
+    expect(state.taskControl.obligation).toMatchObject({ kind: "review_repair", stage: "mutate" });
+    state = workspaceDelta(state);
+    expect(state.taskControl.obligation).toMatchObject({ kind: "review_repair", stage: "validate" });
+    state = validation(state, "passed");
+    expect(state.taskControl.obligation).toMatchObject({ kind: "review_repair", stage: "re_review" });
+    state = review(state, "review-two", "approved", { basis: DIGEST_B });
+    expect(state.taskControl).toMatchObject({ phase: "normal", obligation: undefined });
+    assertKernelInvariants(state);
+  });
+
+  it("exhausts repair after failed validation, a no-delta mutation, or a second rejection", () => {
+    let failedValidation = workspaceDelta(review(initial(), "review-a", "changes_requested"));
+    failedValidation = validation(failedValidation, "failed");
+    expect(failedValidation.taskControl.obligation).toMatchObject({
+      kind: "terminal_resolution", failureCode: "validation_failed"
+    });
+
+    let noDelta = review(initial(), "review-b", "changes_requested");
+    noDelta = apply(noDelta, "diagnostic", {
+      kind: "tool.batch_settled",
+      callId: "repair-call",
+      ok: true,
+      evidenceIds: [],
+      diagnosticCodes: []
+    });
+    expect(noDelta.taskControl.obligation).toMatchObject({
+      kind: "terminal_resolution", failureCode: "review_repair_no_delta"
+    });
+
+    let rejected = workspaceDelta(review(initial(), "review-c", "changes_requested"));
+    rejected = validation(rejected, "passed");
+    rejected = review(rejected, "review-d", "changes_requested", { basis: DIGEST_B });
+    expect(rejected.taskControl.obligation).toMatchObject({
+      kind: "terminal_resolution", failureCode: "review_repair_exhausted"
+    });
+  });
+
+  it("classifies two malformed re-reviews as review unavailable", () => {
+    let state = workspaceDelta(review(initial(), "review-one", "changes_requested"));
+    state = validation(state, "passed");
+    state = review(state, "protocol-one", "changes_requested", { failureKind: "protocol", basis: DIGEST_B });
+    expect(state.taskControl.obligation).toMatchObject({ kind: "review_repair", stage: "re_review" });
+    state = review(state, "protocol-two", "changes_requested", { failureKind: "protocol", basis: DIGEST_B });
+    expect(state.taskControl.obligation).toMatchObject({
+      kind: "terminal_resolution", failureCode: "review_unavailable"
+    });
+  });
+
+  it("rejects new snapshots that carry any legacy task-control authority", () => {
+    const state = initial();
+    expect(isKernelState(state)).toBe(true);
+    expect(isKernelState({ ...state, completionRepairAttempts: 0 })).toBe(false);
+    expect(isKernelState({ ...state, semanticFailureCluster: { attempts: 1 } })).toBe(false);
+  });
+});

--- a/tests/agent-kernel.task-control.test.ts
+++ b/tests/agent-kernel.task-control.test.ts
@@ -9,17 +9,29 @@ import {
   type ToolReceipt
 } from "../packages/agent-protocol/src/index.js";
 import {
+  advanceReviewRepair,
   assertKernelInvariants,
+  beginGoalEpoch,
   completionEvidenceObligation,
   completeActionBatch,
   createKernelState,
   createTaskControlState,
   evolve,
+  hasPublishedTaskControlLegacyFields,
   isKernelState,
+  isTaskControlStateV1,
+  openTaskObligation,
+  protectCompletionCandidate,
   recordSemanticFact,
   recordSemanticToolResult,
   recordToolPolicyViolation,
+  resolveTaskObligation,
+  reviewRepairObligation,
   startActionBatch,
+  taskControlAnswer,
+  taskControlFailureMessage,
+  terminalResolutionObligation,
+  userDecisionObligation,
   type KernelState,
   type TaskControlStateV1
 } from "../packages/agent-kernel/src/index.js";
@@ -74,7 +86,7 @@ function review(
   state: KernelState,
   id: string,
   verdict: "approved" | "changes_requested",
-  options: { failureKind?: "protocol"; basis?: string } = {}
+  options: { failureKind?: "protocol"; basis?: string; omitBasis?: boolean; findings?: JsonValue[] } = {}
 ): KernelState {
   const evidence: EvidenceRecord = {
     evidenceId: id,
@@ -88,14 +100,14 @@ function review(
     data: {
       reviewerId: "reviewer",
       verdict,
-      findings: options.failureKind ? [] : verdict === "approved" ? [] : [{
+      findings: options.findings ?? (options.failureKind ? [] : verdict === "approved" ? [] : [{
         actionable: true,
         severity: "error",
         summary: "Repair the current frontier."
-      }],
+      }]),
       frontierRevision: state.mutationFrontier.revision,
       stateDigest: state.mutationFrontier.currentStateDigest,
-      reviewBasisDigest: options.basis ?? DIGEST_A,
+      ...(options.omitBasis ? {} : { reviewBasisDigest: options.basis ?? DIGEST_A }),
       validationEvidenceIds: [],
       ...(options.failureKind
         ? { failureKind: options.failureKind, failureCode: "review_protocol_invalid" }
@@ -289,5 +301,118 @@ describe("TaskControlStateV1", () => {
     expect(isKernelState(state)).toBe(true);
     expect(isKernelState({ ...state, completionRepairAttempts: 0 })).toBe(false);
     expect(isKernelState({ ...state, semanticFailureCluster: { attempts: 1 } })).toBe(false);
+  });
+
+  it("validates every obligation family and rejects malformed durable control state", () => {
+    const base = createTaskControlState(3, 2);
+    const header = { basisDigest: DIGEST_A, openedRevision: 3, attempts: 0 };
+    const obligations = [
+      { ...header, kind: "completion_evidence", stage: "acquire", evidenceCount: 0 },
+      { ...header, kind: "completion_evidence", stage: "terminal", evidenceCount: 1, failureCode: "blocked" },
+      { ...header, kind: "review_repair", stage: "mutate", scopePaths: ["src/index.ts"] },
+      { ...header, kind: "capability_recovery", stage: "prepare", opportunityId: "opportunity" },
+      { ...header, kind: "repository_recovery", stage: "select" },
+      { ...header, kind: "restoration", stage: "confirm" },
+      { ...header, kind: "process_settlement", stage: "settle", processIds: ["process"] },
+      { ...header, kind: "user_decision", stage: "request", decisionCode: "choose" },
+      { ...header, kind: "terminal_resolution", stage: "report", failureCode: "blocked" }
+    ];
+    for (const obligation of obligations) {
+      expect(isTaskControlStateV1({ ...base, obligation })).toBe(true);
+    }
+
+    expect(isTaskControlStateV1(null)).toBe(false);
+    expect(isTaskControlStateV1({ ...base, obligation: [] })).toBe(false);
+    expect(isTaskControlStateV1({ ...base, obligation: { ...header, kind: "unknown", stage: "none" } })).toBe(false);
+    expect(isTaskControlStateV1({
+      ...base,
+      obligation: { ...header, kind: "completion_evidence", stage: "acquire", evidenceCount: 0, failureCode: "" }
+    })).toBe(false);
+    expect(isTaskControlStateV1({ ...base, semanticFacts: { entries: [{ kind: "content" }] } })).toBe(false);
+    expect(isTaskControlStateV1({
+      ...base,
+      semanticFacts: { entries: [
+        { kind: "content", digest: DIGEST_A, revision: 1 },
+        { kind: "content", digest: DIGEST_A, revision: 2 }
+      ] }
+    })).toBe(false);
+    expect(isTaskControlStateV1({
+      ...base,
+      policyCorrection: { basisDigest: DIGEST_A, attempts: -1, failureCode: "blocked" }
+    })).toBe(false);
+    expect(isTaskControlStateV1({
+      ...base,
+      policyCorrection: { basisDigest: DIGEST_A, attempts: 1, failureCode: 1 }
+    })).toBe(false);
+    expect(isTaskControlStateV1({
+      ...base,
+      completionCandidate: { answer: " ", digest: DIGEST_A }
+    })).toBe(false);
+  });
+
+  it("covers task-control helper boundaries without creating a second authority", () => {
+    const base = createTaskControlState(1, 2);
+    expect(protectCompletionCandidate(base, "   ")).toBe(base);
+    expect(taskControlAnswer(base)).toBeNull();
+    const protectedControl = protectCompletionCandidate(base, " final answer ");
+    expect(taskControlAnswer(protectedControl)).toBe("final answer");
+    const nextEpoch = beginGoalEpoch(protectedControl, 4, "steer");
+    expect(nextEpoch).toMatchObject({
+      goalEpoch: 3,
+      goalEpochSource: "steer"
+    });
+    expect(taskControlAnswer(nextEpoch)).toBeNull();
+
+    const reviewControl = reviewRepairObligation(base, 2, DIGEST_A, ["b.ts", "a.ts", "b.ts"]);
+    expect(reviewControl.obligation).toMatchObject({ scopePaths: ["a.ts", "b.ts"] });
+    expect(advanceReviewRepair(base, "validate", 3)).toBe(base);
+    expect(advanceReviewRepair(reviewControl, "validate", 3)).toMatchObject({
+      obligation: { kind: "review_repair", stage: "validate", attempts: 1 }
+    });
+
+    const decision = userDecisionObligation(base, 2, "select_candidate");
+    expect(decision.phase).toBe("terminal");
+    expect(resolveTaskObligation(decision)).toMatchObject({ phase: "normal", obligation: undefined });
+    expect(terminalResolutionObligation(base, 2, "validation_failed")).toMatchObject({
+      phase: "terminal",
+      obligation: { failureCode: "validation_failed" }
+    });
+    expect(openTaskObligation(base, {
+      kind: "restoration",
+      stage: "restore",
+      basisDigest: DIGEST_A,
+      openedRevision: 2,
+      attempts: 0
+    }).phase).toBe("repair_only");
+
+    expect(completeActionBatch(base, 2)).toBe(base);
+    const started = startActionBatch(reviewControl);
+    const withFact = recordSemanticFact(started, "review", { verdict: "approved" }, 3).control;
+    expect(completeActionBatch(withFact, 4)).toMatchObject({
+      phase: "repair_only",
+      episode: { noProgressBatches: 0, factCountAtBatchStart: undefined }
+    });
+    const alreadyTerminal = terminalResolutionObligation(base, 1, "validation_failed");
+    let exhausted = alreadyTerminal;
+    for (let revision = 2; revision <= 8; revision += 1) exhausted = noProgress(exhausted, revision);
+    expect(exhausted.obligation).toMatchObject({ failureCode: "validation_failed" });
+
+    expect(taskControlFailureMessage(base, "detail")).toBe("detail");
+    expect(taskControlFailureMessage(protectedControl, "detail")).toContain("final answer");
+    expect(taskControlFailureMessage(protectedControl, "final answer already included")).toBe(
+      "final answer already included"
+    );
+    expect(hasPublishedTaskControlLegacyFields([])).toBe(false);
+    expect(hasPublishedTaskControlLegacyFields({ continuationAttempts: 1 })).toBe(true);
+
+    const fallbackBasis = review(initial(), "fallback-basis", "changes_requested", { omitBasis: true });
+    expect(fallbackBasis.taskControl.obligation).toMatchObject({
+      kind: "review_repair",
+      basisDigest: fallbackBasis.mutationFrontier.currentStateDigest
+    });
+    const advisoryOnly = review(initial(), "advisory", "changes_requested", {
+      findings: [{ actionable: false, severity: "warning", summary: "Optional." }]
+    });
+    expect(advisoryOnly.taskControl.obligation).toBeUndefined();
   });
 });

--- a/tests/agent-runtime-queues.test.ts
+++ b/tests/agent-runtime-queues.test.ts
@@ -500,7 +500,7 @@ describe("runtime queues and non-blocking instruction steering", () => {
 
     await expect(runtime.waitForOutcome(session.sessionId)).resolves.toMatchObject({
       kind: "recoverable_failure",
-      code: "model_tool_policy_violation"
+      code: "action_convergence_no_progress"
     });
     expect(gateway.requests).toHaveLength(2);
     for (const request of gateway.requests) {
@@ -538,7 +538,7 @@ describe("runtime queues and non-blocking instruction steering", () => {
 
     await expect(runtime.waitForOutcome(session.sessionId)).resolves.toMatchObject({
       kind: "recoverable_failure",
-      code: "invalid_user_input_request"
+      code: "action_convergence_no_progress"
     });
     expect(gateway.requests).toHaveLength(2);
     const events = await storedEvents(store, session.sessionId);

--- a/tests/agent-runtime-queues.test.ts
+++ b/tests/agent-runtime-queues.test.ts
@@ -348,14 +348,13 @@ describe("runtime queues and non-blocking instruction steering", () => {
     const restored = await restoreStoredSession(store, session.sessionId, 30_000);
     expect(restored.state).toMatchObject({
       phase: "needs_input",
-      completionRepairAttempts: 0,
       outcome: {
         kind: "needs_input",
         requestId: "typed-protected-input",
         message: "Which target should I change?"
       }
     });
-    expect(restored.state.completionRepair).toBeUndefined();
+    expect(restored.state.taskControl.obligation).toBeUndefined();
     expect(restored.state.toolCallIds).toEqual(["read-protected-question", "typed-protected-input"]);
     expect(restored.state.evidence.length).toBeGreaterThan(0);
   }, 30_000);
@@ -468,22 +467,20 @@ describe("runtime queues and non-blocking instruction steering", () => {
     await expect(runtime.waitForOutcome(session.sessionId)).resolves.toMatchObject({
       kind: "recoverable_failure",
       code: "validation_failed",
-      message: expect.stringContaining("failed validation is reported")
+      message: expect.stringContaining("validation ran and failed")
     });
-    expect(gateway.requests).toHaveLength(4);
-    expect(gateway.requests[3]?.toolChoice).toBeUndefined();
-    expect(gateway.requests[3]?.tools?.map((tool) => tool.name)).toContain("report_blocked");
-    expect(gateway.requests[3]?.messages.at(-1)?.content).toContain("validation");
+    expect(gateway.requests).toHaveLength(3);
+    expect(gateway.requests[2]?.messages.at(-1)?.content).toContain("validation");
     const restored = await restoreStoredSession(store, session.sessionId, 30_000);
     expect(restored.state.budget.reservations.filter((reservation) => reservation.status === "reserved"))
       .toEqual([]);
   }, 30_000);
 
-  it("returns convergence_no_progress after three malformed completion calls", async () => {
+  it("stops a repeated unprojected completion call after one correction", async () => {
     const workspace = await mkdtemp(path.join(os.tmpdir(), "sigma-malformed-terminal-repair-"));
     await writeFile(path.join(workspace, "seed.txt"), "seed", "utf8");
     const gateway = new ScriptedGateway([
-      ...[1, 2, 3].map((attempt) => ({
+      ...[1, 2].map((attempt) => ({
         message: {
           role: "assistant" as const,
           content: "",
@@ -503,20 +500,20 @@ describe("runtime queues and non-blocking instruction steering", () => {
 
     await expect(runtime.waitForOutcome(session.sessionId)).resolves.toMatchObject({
       kind: "recoverable_failure",
-      code: "convergence_no_progress"
+      code: "model_tool_policy_violation"
     });
-    expect(gateway.requests).toHaveLength(3);
+    expect(gateway.requests).toHaveLength(2);
     for (const request of gateway.requests) {
       expect(request.tools?.map((tool) => tool.name)).not.toContain("runtime_finalize");
       expect(request.tools?.map((tool) => tool.name)).toContain("read");
     }
   }, 30_000);
 
-  it("returns convergence_no_progress after three malformed input requests", async () => {
+  it("stops malformed input requests after one exact correction", async () => {
     const workspace = await mkdtemp(path.join(os.tmpdir(), "sigma-malformed-input-repair-"));
     await writeFile(path.join(workspace, "seed.txt"), "seed", "utf8");
     const gateway = new ScriptedGateway([
-      ...[1, 2, 3].map((attempt) => ({
+      ...[1, 2].map((attempt) => ({
         message: {
           role: "assistant" as const,
           content: "",
@@ -541,9 +538,9 @@ describe("runtime queues and non-blocking instruction steering", () => {
 
     await expect(runtime.waitForOutcome(session.sessionId)).resolves.toMatchObject({
       kind: "recoverable_failure",
-      code: "convergence_no_progress"
+      code: "invalid_user_input_request"
     });
-    expect(gateway.requests).toHaveLength(3);
+    expect(gateway.requests).toHaveLength(2);
     const events = await storedEvents(store, session.sessionId);
     expect(events.filter((event) => event.type === "tool.failed"
       && String((event.payload as { callId?: string }).callId).startsWith("malformed-input-"))).toHaveLength(2);
@@ -703,10 +700,10 @@ describe("runtime queues and non-blocking instruction steering", () => {
     await expect(readFile(path.join(workspace, "b.txt"), "utf8")).rejects.toMatchObject({ code: "ENOENT" });
   });
 
-  it("stops three consecutive identical tool batches without executing the third", async () => {
+  it("bounds repeated successful reads by seven no-progress batches", async () => {
     const workspace = await mkdtemp(path.join(os.tmpdir(), "sigma-repeated-batch-"));
     await writeFile(path.join(workspace, "seed.txt"), "seed", "utf8");
-    const gateway = new ScriptedGateway([1, 2, 3].map((index) => ({
+    const gateway = new ScriptedGateway([1, 2, 3, 4, 5, 6, 7, 8].map((index) => ({
       message: { role: "assistant", content: "", toolCalls: [{ id: `repeat-${index}`, name: "read", arguments: { path: "seed.txt" } }] },
       finishReason: "tool_calls" as const
     })));
@@ -718,32 +715,35 @@ describe("runtime queues and non-blocking instruction steering", () => {
     const session = await runtime.createSession({ workspacePath: workspace, mode: "analyze" });
     await runtime.command({ type: "submit", sessionId: session.sessionId, text: "inspect without looping" });
     await expect(runtime.waitForOutcome(session.sessionId)).resolves.toMatchObject({
-      kind: "recoverable_failure", code: "convergence_no_progress"
+      kind: "recoverable_failure", code: "action_convergence_no_progress"
     });
     const events = await storedEvents(store, session.sessionId);
     const receipts = events.filter((event) => event.type === "tool.completed");
-    expect(receipts).toHaveLength(2);
+    expect(receipts).toHaveLength(7);
     expect(receipts.every((event) => (event.payload as { outcome?: unknown }).outcome
       && (event.payload as { outcome: { status?: unknown } }).outcome.status === "succeeded")).toBe(true);
     const restored = await restoreStoredSession(store, session.sessionId, 10_000);
-    expect(restored.state.repeatedToolBatchCount).toBe(2);
-    expect(restored.state.lastToolBatchOutcomeSignature).toMatch(/^[a-f0-9]{64}$/u);
+    expect(restored.state.taskControl).toMatchObject({
+      phase: "terminal",
+      episode: { noProgressBatches: 7 },
+      obligation: { kind: "terminal_resolution", failureCode: "action_convergence_no_progress" }
+    });
   });
 
   it.each([
     ["terminal before ordinary", [
       { id: "ask-mixed-first", name: "request_user_input", arguments: { message: "Need input." } },
       { id: "read-mixed-second", name: "read", arguments: { path: "seed.txt" } }
-    ]],
+    ], false],
     ["ordinary before terminal", [
       { id: "read-mixed-first", name: "read", arguments: { path: "seed.txt" } },
       { id: "ask-mixed-second", name: "request_user_input", arguments: { message: "Need input." } }
-    ]],
+    ], false],
     ["multiple terminal calls", [
       { id: "ask-terminal-first", name: "request_user_input", arguments: { message: "Need input." } },
       { id: "complete-terminal-second", name: "runtime_finalize", arguments: {} }
-    ]]
-  ])("rejects a conflicting %s batch before any call executes", async (_label, toolCalls) => {
+    ], true]
+  ])("settles a %s batch without ambiguous terminal execution", async (_label, toolCalls, conflict) => {
     const workspace = await mkdtemp(path.join(os.tmpdir(), "sigma-terminal-batch-"));
     await writeFile(path.join(workspace, "seed.txt"), "seed", "utf8");
     const gateway = new ScriptedGateway([
@@ -773,16 +773,26 @@ describe("runtime queues and non-blocking instruction steering", () => {
     await runtime.command({ type: "submit", sessionId: session.sessionId, text: "Inspect, or ask if a target is required." });
 
     await expect(runtime.waitForOutcome(session.sessionId)).resolves.toMatchObject({
-      kind: "needs_input", message: "Which target should I inspect?"
+      kind: "needs_input",
+      message: conflict ? "Which target should I inspect?" : "Need input."
     });
     const events = await storedEvents(store, session.sessionId);
     const conflictingIds = new Set(toolCalls.map((call) => call.id));
     const conflictLifecycle = events.filter((event) =>
       (event.type === "tool.requested" || event.type === "tool.completed" || event.type === "tool.failed")
       && conflictingIds.has((event.payload as { callId?: string }).callId ?? ""));
-    expect(conflictLifecycle).toHaveLength(0);
-    expect(events.filter((event) => event.type === "execution.started"
-      && conflictingIds.has((event.payload as { executionId?: string }).executionId ?? ""))).toHaveLength(0);
+    if (conflict) {
+      expect(conflictLifecycle).toHaveLength(toolCalls.length);
+      expect(conflictLifecycle.every((event) => event.type === "tool.failed"
+        && (event.payload as { diagnostics?: string[] }).diagnostics?.includes("model_tool_policy_violation")))
+        .toBe(true);
+      expect(events.filter((event) => event.type === "execution.started"
+        && conflictingIds.has((event.payload as { executionId?: string }).executionId ?? ""))).toHaveLength(0);
+    } else {
+      expect(conflictLifecycle).toHaveLength(toolCalls.length * 2);
+      expect(conflictLifecycle.filter((event) => event.type === "tool.requested")).toHaveLength(toolCalls.length);
+      expect(conflictLifecycle.filter((event) => event.type === "tool.completed")).toHaveLength(toolCalls.length);
+    }
   });
 
   it("removes aborted outcome waiters", async () => {
@@ -1019,6 +1029,10 @@ describe("runtime queues and non-blocking instruction steering", () => {
         kind: "protected_completion" as const,
         answer: "The durable natural answer."
       },
+      continuationAttempts: 0,
+      repeatedToolBatchCount: 0,
+      receiptCountAtLastUserInput: 0,
+      semanticProgress: { workspaceChanges: 0, durableEvidence: 1, revision: 1 },
       messages: [{ role: "assistant" as const, content: "The durable natural answer." }],
       evidence: [{
         evidenceId: "protected-completion-evidence",
@@ -1032,6 +1046,7 @@ describe("runtime queues and non-blocking instruction steering", () => {
         data: { source: "recovery-test", diagnostic: { ok: true } }
       }]
     };
+    delete (snapshotState as Partial<typeof snapshotState>).taskControl;
     await store.writeSnapshot({
       schemaVersion: SNAPSHOT_SCHEMA_VERSION,
       storeLayoutVersion: STORE_LAYOUT_VERSION,
@@ -1042,11 +1057,10 @@ describe("runtime queues and non-blocking instruction steering", () => {
     });
 
     const restored = await restoreStoredSession(store, sessionId, 30_000);
-    expect(restored.state.completionRepair).toEqual({
-      kind: "protected_completion",
-      answer: "The durable natural answer."
+    expect(restored.state.taskControl).toMatchObject({
+      completionCandidate: { answer: "The durable natural answer." },
+      obligation: { kind: "completion_evidence", stage: "terminal", attempts: 1 }
     });
-    expect(restored.state.completionRepairAttempts).toBe(1);
   });
 
   it("does not synthesize a V3 completion-repair state while rebuilding V5 events", async () => {
@@ -1109,8 +1123,9 @@ describe("runtime queues and non-blocking instruction steering", () => {
     await store.writeSnapshot({ ...rebuilt, state: legacyState });
 
     const restored = await restoreStoredSession(store, sessionId, 30_000);
-    expect(restored.state.completionRepair).toBeUndefined();
-    expect(restored.state.completionRepairAttempts).toBe(0);
+    expect(restored.state).not.toHaveProperty("completionRepair");
+    expect(restored.state).not.toHaveProperty("completionRepairAttempts");
+    expect(restored.state.taskControl.completionCandidate?.answer).toBe("Legacy protected answer.");
     expect(restored.state.messages.at(-1)).toMatchObject({
       role: "assistant",
       content: "Legacy protected answer."

--- a/tests/agent-runtime.evidence.test.ts
+++ b/tests/agent-runtime.evidence.test.ts
@@ -2,7 +2,7 @@ import { mkdir, mkdtemp, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { createKernelState } from "../packages/agent-kernel/src/index.js";
+import { createKernelState, reviewRepairObligation } from "../packages/agent-kernel/src/index.js";
 import type {
   AgentEventEnvelope,
   EvidenceRecord,
@@ -23,6 +23,7 @@ import { RuntimeControlService } from "../packages/agent-runtime/src/runtime-con
 import type { RuntimeControlServiceOptions } from "../packages/agent-runtime/src/runtime-control-contracts.js";
 import { assertToolReceiptIdentity, normalizeReceiptEvidence } from "../packages/agent-runtime/src/tool-evidence.js";
 import {
+  assertTaskControlPlanAllowed,
   assertReceiptWithinPlan,
   validationScope
 } from "../packages/agent-runtime/src/tool-plan-enforcement.js";
@@ -456,6 +457,46 @@ describe("leaf-aware effect-plan enforcement", () => {
     };
 
     await expect(assertReceiptWithinPlan(active, result, plan)).resolves.toBeUndefined();
+  });
+});
+
+describe("review repair plan enforcement", () => {
+  function repairPlan(writePaths: string[]): ToolCallPlan {
+    return {
+      exactEffects: ["filesystem.write"], readPaths: [], writePaths,
+      network: "none", processMode: "none", checkpointScope: writePaths,
+      idempotence: "non_replayable"
+    };
+  }
+
+  it("allows only writes inside the runtime-authenticated finding scope", async () => {
+    const workspace = await mkdtemp(path.join(os.tmpdir(), "sigma-review-repair-plan-"));
+    await mkdir(path.join(workspace, "src"));
+    const active = runtimeSessionFixture({ workspacePath: workspace });
+    active.durable.state.taskControl = reviewRepairObligation(
+      active.durable.state.taskControl,
+      active.durable.state.revision,
+      "a".repeat(64),
+      ["src/target.ts"]
+    );
+
+    await expect(assertTaskControlPlanAllowed(active, repairPlan(["src/target.ts"])))
+      .resolves.toBeUndefined();
+    await expect(assertTaskControlPlanAllowed(active, repairPlan(["src/other.ts"])))
+      .rejects.toMatchObject({ code: "tool_unavailable_for_repair" });
+  });
+
+  it("rejects mutation plans without an exact write target", async () => {
+    const workspace = await mkdtemp(path.join(os.tmpdir(), "sigma-review-repair-empty-plan-"));
+    const active = runtimeSessionFixture({ workspacePath: workspace });
+    active.durable.state.taskControl = reviewRepairObligation(
+      active.durable.state.taskControl,
+      active.durable.state.revision,
+      "b".repeat(64),
+      ["target.ts"]
+    );
+    await expect(assertTaskControlPlanAllowed(active, repairPlan([])))
+      .rejects.toMatchObject({ code: "tool_unavailable_for_repair" });
   });
 });
 

--- a/tests/agent-runtime.fault-recovery.test.ts
+++ b/tests/agent-runtime.fault-recovery.test.ts
@@ -130,9 +130,11 @@ class RecoveryGateway implements ModelGateway {
 class CountingReviewer implements AccountableReviewerPort {
   readonly reviewerId = "fault-injection-reviewer";
   calls = 0;
+  readonly inputs: ReviewerInput[] = [];
 
   async review(input: ReviewerInput): Promise<ReviewEvidence> {
     this.calls += 1;
+    this.inputs.push(input);
     return this.evidence(input);
   }
 
@@ -155,6 +157,7 @@ class CountingReviewer implements AccountableReviewerPort {
     _signal: AbortSignal
   ): Promise<{ evidence: ReviewEvidence; usage: UsageRecord }> {
     this.calls += 1;
+    this.inputs.push(input);
     return { evidence: this.evidence(input), usage: this.usage(input, requestId, {
       inputTokens: 1, outputTokens: 1, costMicroUsd: 0, modelTurns: 1,
       toolCalls: 0, children: 0
@@ -842,10 +845,19 @@ describe("durable transaction fault-injection recovery", () => {
       const outcome = await runtime.waitForOutcome(fixture.sessionId);
       const stored = await events(fixture.store, fixture.sessionId);
       expect(executions.count).toBe(0);
-      expect(reviewer.calls).toBe(boundary === "validation_evidence" ? 1 : 0);
+      const completionReviewRequired = boundary === "validation_evidence"
+        || boundary === "review_started" || boundary === "review_completed";
+      expect(reviewer.calls).toBe(completionReviewRequired ? 1 : 0);
       const convergedCompletion = boundary === "validation_evidence"
         || boundary === "review_started" || boundary === "review_completed";
-      expect(outcome.kind).toBe(convergedCompletion ? "completed" : "needs_input");
+      if (boundary === "delta_evidence") {
+        expect(outcome).toMatchObject({
+          kind: "recoverable_failure",
+          code: "validation_evidence_required"
+        });
+      } else {
+        expect(outcome.kind).toBe(convergedCompletion ? "completed" : "needs_input");
+      }
       if (convergedCompletion) expect(gateway.calls).toBe(1);
 
       const checkpointId = fixture.checkpoint!.checkpointId;
@@ -877,17 +889,35 @@ describe("durable transaction fault-injection recovery", () => {
           if (item.type !== "budget.reserved") return [];
           const payload = item.payload as {
             ledger?: { reservations?: Array<{ reservationId?: string; ownerId?: string }> };
+            mutation?: {
+              kind?: string;
+              reservation?: { reservationId?: string; ownerId?: string };
+            };
           };
-          return (payload.ledger?.reservations ?? []).flatMap((reservation) =>
+          const legacy = (payload.ledger?.reservations ?? []).flatMap((reservation) =>
             reservation.ownerId?.startsWith("reviewer:") && reservation.reservationId
               ? [reservation.reservationId] : []);
+          const compact = payload.mutation?.kind === "reserve"
+            && payload.mutation.reservation?.ownerId?.startsWith("reviewer:")
+            && payload.mutation.reservation.reservationId
+            ? [payload.mutation.reservation.reservationId] : [];
+          return [...legacy, ...compact];
         }));
+        const expectedReviewRecords = boundary === "review_completed" ? 2 : 1;
         expect(stored.filter((item) => item.type === "budget.committed"
           && reviewerReservationIds.has((item.payload as { reservationId?: string }).reservationId ?? "")))
-          .toHaveLength(1);
+          .toHaveLength(expectedReviewRecords);
         expect(stored.filter((item) => item.type === "usage.recorded"
-          && (item.payload as { role?: string }).role === "reviewer")).toHaveLength(1);
-        expect(stored.filter((item) => item.type === "review.completed")).toHaveLength(1);
+          && (item.payload as { role?: string }).role === "reviewer")).toHaveLength(expectedReviewRecords);
+        expect(stored.filter((item) => item.type === "review.completed")).toHaveLength(expectedReviewRecords);
+      }
+      if (completionReviewRequired) {
+        expect(reviewer.inputs).toHaveLength(1);
+        expect(reviewer.inputs[0]).toMatchObject({
+          reviewMode: "completion",
+          completionCandidate: "Recovered mutation is complete."
+        });
+        expect(reviewer.inputs[0]?.completionCandidateDigest).toMatch(/^[a-f0-9]{64}$/u);
       }
     });
   }

--- a/tests/agent-runtime.live-checkpoint-failure.test.ts
+++ b/tests/agent-runtime.live-checkpoint-failure.test.ts
@@ -147,6 +147,13 @@ describe("live mutation checkpoint failure recovery", () => {
     expect(stored.some((event) => event.type === "tool.requested"
       && (event.payload as { callId?: string }).callId === "same-turn-completion")).toBe(false);
     expect(stored).toContainEqual(expect.objectContaining({
+      type: "tool.failed",
+      payload: expect.objectContaining({
+        callId: "same-turn-completion",
+        diagnostics: expect.arrayContaining(["checkpoint_recovery_required"])
+      })
+    }));
+    expect(stored).toContainEqual(expect.objectContaining({
       type: "run.suspended",
       payload: expect.objectContaining({ requestId: expect.stringMatching(/^checkpoint:/u) })
     }));

--- a/tests/agent-runtime.recovery-convergence.test.ts
+++ b/tests/agent-runtime.recovery-convergence.test.ts
@@ -87,7 +87,7 @@ describe("runtime recovery convergence", () => {
     }
   });
 
-  it("defaults semantic progress when restoring a pre-feature V5 snapshot", async () => {
+  it("migrates the published V5 task authorities and strips every legacy field", async () => {
     const workspacePath = await mkdtemp(path.join(os.tmpdir(), "sigma-semantic-restore-"));
     const store = new SegmentedJsonlStore({ rootDir: path.join(workspacePath, ".agent") });
     const sessionId = "legacy-semantic-session";
@@ -112,8 +112,14 @@ describe("runtime recovery convergence", () => {
       deadlineAt: "2026-07-12T00:15:00.000Z"
     });
     const oldSnapshot = JSON.parse(JSON.stringify({ ...current, lastSeq: 1 })) as Record<string, JsonValue>;
-    delete oldSnapshot.semanticProgress;
-    delete oldSnapshot.semanticFailureCluster;
+    delete oldSnapshot.taskControl;
+    Object.assign(oldSnapshot, {
+      completionRepairAttempts: 0,
+      continuationAttempts: 0,
+      repeatedToolBatchCount: 0,
+      receiptCountAtLastUserInput: 0,
+      semanticProgress: { workspaceChanges: 0, durableEvidence: 0, revision: 0 }
+    });
     await store.writeSnapshot({
       schemaVersion: SNAPSHOT_SCHEMA_VERSION,
       storeLayoutVersion: STORE_LAYOUT_VERSION,
@@ -124,8 +130,16 @@ describe("runtime recovery convergence", () => {
     });
 
     const restored = await restoreStoredSession(store, sessionId, 60_000);
-    expect(restored.state.semanticProgress).toEqual({ workspaceChanges: 0, durableEvidence: 0, revision: 0 });
-    expect(restored.state.semanticFailureCluster).toBeUndefined();
+    expect(restored.state.taskControl).toMatchObject({
+      schemaVersion: 1,
+      phase: "normal",
+      semanticFacts: { entries: [] }
+    });
+    for (const key of [
+      "completionRepairAttempts", "completionRepair", "continuationAttempts",
+      "repeatedToolBatchCount", "receiptCountAtLastUserInput", "semanticProgress",
+      "semanticFailureCluster", "lastToolBatchSignature", "lastToolBatchOutcomeSignature"
+    ]) expect(restored.state).not.toHaveProperty(key);
   });
 
   it("preserves failed validation status, scope, and execution claim across snapshot restore", async () => {

--- a/tests/agent-runtime.recovery-convergence.test.ts
+++ b/tests/agent-runtime.recovery-convergence.test.ts
@@ -43,9 +43,8 @@ function runtime(toolIdleWatchdogMs?: number | false): RuntimeOptions {
 }
 
 describe("runtime recovery convergence", () => {
-  it("counts repeated capability failures per semantic invocation", () => {
+  it("leaves capability retry authority to the durable task-control reducer", () => {
     const session = runtimeSessionFixture();
-    session.interaction.capabilityFailures = new Map();
     const signal = new AbortController().signal;
     const failure = Object.assign(new Error("runtime unavailable"), { code: "toolchain_unavailable" });
     const first = { id: "first", name: "exec", arguments: { executable: "node", args: ["--version"] } };
@@ -58,7 +57,8 @@ describe("runtime recovery convergence", () => {
     ).diagnostics).toContain("toolchain_unavailable");
     expect(convergedToolFailure(
       session, { ...first, id: "retry" }, "2026-01-01T00:00:00.000Z", failure, signal
-    ).diagnostics).toContain("capability_retry_exhausted");
+    ).diagnostics).toContain("toolchain_unavailable");
+    expect(session.interaction).not.toHaveProperty("capabilityFailures");
   });
 
   it("keeps the outer idle watchdog behind a tool-owned idle deadline and allows an explicit policy", () => {

--- a/tests/agent-runtime.restore-run-changes.test.ts
+++ b/tests/agent-runtime.restore-run-changes.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
@@ -10,6 +10,7 @@ import { EffectToolRegistry, registerBuiltinTools } from "../packages/agent-tool
 import {
   fakeToolCall,
   fakeToolTurn,
+  fakeFinalTurn,
   SmokeFakeGateway
 } from "../scripts/smoke-fake-model.mjs";
 
@@ -20,6 +21,43 @@ async function events(store: SegmentedJsonlStore, sessionId: string): Promise<Ag
 }
 
 describe("restore_run_changes transaction control", () => {
+  it("restores every current-run checkpoint as one baseline transaction and completes from restoration evidence", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "sigma-restore-run-group-"));
+    const workspace = path.join(root, "workspace");
+    await mkdir(workspace);
+    await writeFile(path.join(workspace, "state.txt"), "baseline", "utf8");
+    const storeRootDir = path.join(root, "state");
+    const store = new SegmentedJsonlStore({ rootDir: storeRootDir });
+    const runtime = createRuntime({
+      gateway: new SmokeFakeGateway([
+        fakeToolTurn([fakeToolCall("first", "write", { path: "state.txt", content: "changed" })]),
+        fakeToolTurn([fakeToolCall("second", "write", { path: "extra.txt", content: "temporary" })]),
+        fakeToolTurn([fakeToolCall("restore-all", "restore_run_changes", {})]),
+        fakeFinalTurn("All run changes were restored.")
+      ]),
+      tools: registerBuiltinTools(new EffectToolRegistry()),
+      store,
+      storeRootDir,
+      permissionMode: "auto",
+      runDeadlineMs: 60_000
+    });
+    const session = await runtime.createSession({ workspacePath: workspace, mode: "change" });
+
+    await runtime.command({ type: "submit", sessionId: session.sessionId, text: "Make temporary changes, then restore them." });
+    await expect(runtime.waitForOutcome(session.sessionId)).resolves.toMatchObject({
+      kind: "completed",
+      message: expect.stringContaining("All run changes were restored.")
+    });
+    await expect(readFile(path.join(workspace, "state.txt"), "utf8")).resolves.toBe("baseline");
+    await expect(readFile(path.join(workspace, "extra.txt"))).rejects.toMatchObject({ code: "ENOENT" });
+    const stored = await events(store, session.sessionId);
+    expect(stored.filter((event) => event.type === "checkpoint.restored")).toHaveLength(2);
+    expect(stored).toContainEqual(expect.objectContaining({
+      type: "evidence.recorded",
+      payload: expect.objectContaining({ kind: "restoration", status: "passed" })
+    }));
+  });
+
   it("restores the latest mutation from this run without creating a nested checkpoint", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "sigma-restore-run-"));
     const workspace = path.join(root, "workspace");

--- a/tests/agent-terminal-convergence.property.test.ts
+++ b/tests/agent-terminal-convergence.property.test.ts
@@ -13,6 +13,7 @@ import {
   assertKernelInvariants,
   createKernelState,
   evolve,
+  terminalResolutionObligation,
   type KernelState
 } from "../packages/agent-kernel/src/index.js";
 import {
@@ -22,6 +23,7 @@ import {
   descriptorAllowedForRepair,
   effectsAllowedForRepair
 } from "../packages/agent-runtime/src/tool-turn-policy.js";
+import type { RuntimeSession } from "../packages/agent-runtime/src/types.js";
 
 const NOW = "2026-01-01T00:00:00.000Z";
 const nonBlankText = fc.string({ minLength: 1, maxLength: 80 })
@@ -115,7 +117,7 @@ function descriptor(
 }
 
 describe("terminal convergence properties", () => {
-  it("keeps every normal tool available during terminal correction", () => {
+  it("projects only terminal effects during terminal resolution", () => {
     const effects = fc.uniqueArray(fc.constantFrom<ToolEffect>(
       "outcome.propose",
       "outcome.request_input",
@@ -127,18 +129,24 @@ describe("terminal convergence properties", () => {
     fc.assert(fc.property(effects, effects, effects, names,
       (possibleEffects, maximumEffects, exactEffects, name) => {
       const tool = descriptor(possibleEffects, maximumEffects, name);
-      expect(descriptorAllowedForRepair(tool, "protected_completion")).toBe(true);
+      const state = initial();
+      state.taskControl = terminalResolutionObligation(state.taskControl, state.revision, "property_terminal");
+      const session = { durable: { state } } as RuntimeSession;
+      const terminalEffects = new Set<ToolEffect>([
+        "outcome.propose", "outcome.report_blocked", "outcome.request_input"
+      ]);
+      const expectedDescriptor = name !== "request_user_input" && possibleEffects.length > 0
+        && possibleEffects.every((effect) => terminalEffects.has(effect));
+      expect(descriptorAllowedForRepair(session, tool, "terminal")).toBe(expectedDescriptor);
       const pureAction = possibleEffects.length === 1 && maximumEffects.length === 1
         && possibleEffects[0] === maximumEffects[0]
         ? possibleEffects[0] === "outcome.propose" ? "complete"
           : possibleEffects[0] === "outcome.request_input" ? "request_input" : null
         : null;
       expect(terminalProtocolAction(tool)).toBe(pureAction);
-      expect(descriptorAllowedForRepair(tool, "evidence")).toBe(true);
-      expect(descriptorAllowedForRepair(tool, "protected_recovery")).toBe(true);
-      expect(effectsAllowedForRepair(exactEffects, "protected_completion")).toBe(true);
-      expect(effectsAllowedForRepair(exactEffects, "evidence")).toBe(true);
-      expect(effectsAllowedForRepair(exactEffects, "protected_recovery")).toBe(true);
+      expect(effectsAllowedForRepair(session, exactEffects, "terminal")).toBe(
+        exactEffects.length > 0 && exactEffects.every((effect) => terminalEffects.has(effect))
+      );
     }));
   });
 
@@ -248,8 +256,11 @@ describe("terminal convergence properties", () => {
       const recoveryState: KernelState = {
         ...protectedState,
         phase: "tool_pending",
-        completionRepairAttempts: 0,
-        completionRepair: { kind: "protected_recovery", answer: answer.trim() },
+        taskControl: terminalResolutionObligation(
+          protectedState.taskControl,
+          protectedState.revision,
+          "terminal_protocol_invalid"
+        ),
         pendingTools: [{
           request: { callId: "custom-input", name: "custom_terminal_alias", arguments: {} },
           modelTurn,

--- a/tests/agent-tui.test.ts
+++ b/tests/agent-tui.test.ts
@@ -22,11 +22,13 @@ function event(seq: number, type: AgentEventEnvelope["type"], payload: AgentEven
 class FakeRuntime implements RuntimeClient {
   readonly commands: RunCommand[] = [];
   readonly released: string[] = [];
+  readonly creations: StartSession[] = [];
   private sessions = 0;
 
   constructor(readonly events: AgentEventEnvelope[] = [event(1, "session.created", {})]) {}
 
-  async createSession(_input: StartSession): Promise<SessionRef> {
+  async createSession(input: StartSession): Promise<SessionRef> {
+    this.creations.push(input);
     this.sessions += 1;
     return { sessionId: this.sessions === 1 ? "session" : `session-${this.sessions}`, runId: "run" };
   }
@@ -34,7 +36,7 @@ class FakeRuntime implements RuntimeClient {
   async *subscribe(): AsyncIterable<AgentEventEnvelope> { for (const item of this.events) yield item; }
   async waitForOutcome(): Promise<RunOutcome> { return { kind: "completed", message: "ok", evidence: [] }; }
   async listSessions(): Promise<SessionOverview[]> { return []; }
-  async *sessionEvents(): AsyncIterable<AgentEventEnvelope> { /* no persisted events */ }
+  async *sessionEvents(): AsyncIterable<AgentEventEnvelope> { for (const item of this.events) yield item; }
   async releaseSession(sessionId: string): Promise<void> { this.released.push(sessionId); }
 }
 
@@ -53,7 +55,7 @@ async function viewHarness(width = 80, height = 24) {
     approve: async (requestId, decision) => { approvals.push({ requestId, decision }); },
     interrupt: async () => { interrupts += 1; },
     newSession: async () => undefined,
-    setMode: () => undefined,
+    setMode: async () => undefined,
     stop: () => undefined,
     userAction: () => undefined
   };
@@ -409,6 +411,45 @@ describe("Sigma OpenTUI", () => {
     expect(runtime.commands).toContainEqual({ type: "cancel", sessionId: "session", reason: "Replaced by /new from TUI." });
     expect(runtime.released).toContain("session");
     expect(activityToggles).toBe(1);
+  });
+
+  it("creates analyze mode before the first request and changes mode only through a new idle session", async () => {
+    const runtime = new FakeRuntime([]);
+    const stdin = Object.assign(new PassThrough(), { isTTY: true }) as unknown as NodeJS.ReadStream;
+    const stdout = Object.assign(new PassThrough(), { columns: 80, rows: 24 }) as unknown as NodeJS.WriteStream;
+    let actions!: TuiViewActions;
+    let latest!: TuiSnapshot;
+    const controller = new TuiSessionController({
+      runtime, workspace: ".", mode: "analyze", stdin, stdout
+    }, async (_options, nextActions) => {
+      actions = nextActions;
+      return { update: (next) => { latest = next; }, showHelp: () => undefined,
+        toggleActivity: () => undefined, destroy: () => undefined };
+    });
+    const running = controller.run();
+    await waitUntil(() => latest?.sessionId === "session");
+    expect(runtime.creations[0]).toMatchObject({ mode: "analyze" });
+    await actions.submit("/mode change", "default");
+    await waitUntil(() => latest?.sessionId === "session-2");
+    expect(runtime.creations[1]).toMatchObject({ mode: "change" });
+    expect(runtime.released).toContain("session");
+    await actions.interrupt(); await actions.interrupt(); await running;
+  });
+
+  it("rejects a resumed session whose durable mode conflicts with --initial-mode", async () => {
+    const created = event(1, "session.created", {
+      workspacePath: ".", mode: "change", title: "", writeScope: [], strictWriteScope: false,
+      modelRole: "orchestrator"
+    });
+    const runtime = new FakeRuntime([created]);
+    const stdin = Object.assign(new PassThrough(), { isTTY: true }) as unknown as NodeJS.ReadStream;
+    const stdout = Object.assign(new PassThrough(), { columns: 80, rows: 24 }) as unknown as NodeJS.WriteStream;
+    const controller = new TuiSessionController({
+      runtime, workspace: ".", mode: "analyze", sessionId: "session", stdin, stdout
+    }, async () => ({ update: () => undefined, showHelp: () => undefined,
+      toggleActivity: () => undefined, destroy: () => undefined }));
+    await expect(controller.run()).rejects.toMatchObject({ code: "initial_mode_mismatch" });
+    expect(runtime.commands).not.toContainEqual(expect.objectContaining({ type: "resume" }));
   });
 
   it("exits promptly while initial session creation is still blocked", async () => {


### PR DESCRIPTION
## Summary
- replace parallel completion, repair, convergence, and terminal authorities with one durable `TaskControlStateV1` reducer
- bind completion review to the current candidate and classify invalid reviewer output as retryable protocol failure
- add atomic run restoration evidence and deterministic TUI `--initial-mode`
- emit durable receipts for rejected/deferred calls and safely order ordinary work before one terminal intent

## Compatibility
- migrate only the task-control fields published by the mainline V5 schema
- reject experimental PR #55 V2-V4 session shapes with `unsupported_experimental_session_schema`

## Validation
- `pnpm build`
- `pnpm lint`
- `pnpm test` (128 files, 1208 passed, 51 skipped)
- `pnpm smoke:product`
- `pnpm smoke:tui-product`
- `git diff --check`

Stacked on #56. This is product/runtime work only; it does not contain benchmark-specific behavior or verifier-driven retries.