### PR TITLE
Harden agent runtime recovery and convergence

### DIFF
--- a/native/sigma-exec/README.md
+++ b/native/sigma-exec/README.md
@@ -21,5 +21,10 @@ network access, and ConPTY for interactive background processes. Run
 `agent sandbox setup` once per Windows user to create and verify the base
 profile. A failed setup or self-test is never replaced with host execution.
 
+Linux system executables receive read-only views of the standard executable,
+configuration, shared-state, and cache roots. Session HOME and temporary
+directories remain broker-owned writable scratch, while other filesystem
+locations stay absent unless the execution policy explicitly grants them.
+
 V5 has no unsafe host-execution switch. Commands must use the native sandbox;
 an OCI execution mode must be backed by a real container runtime or fail closed.

--- a/native/sigma-exec/README.md
+++ b/native/sigma-exec/README.md
@@ -21,10 +21,12 @@ network access, and ConPTY for interactive background processes. Run
 `agent sandbox setup` once per Windows user to create and verify the base
 profile. A failed setup or self-test is never replaced with host execution.
 
-Linux system executables receive read-only views of the standard executable,
-configuration, shared-state, and cache roots. Session HOME and temporary
-directories remain broker-owned writable scratch, while other filesystem
-locations stay absent unless the execution policy explicitly grants them.
+Linux system executables receive read-only views of standard executable and
+configuration roots plus narrowly selected toolchain-owned runtime state (for
+example TeX data and font caches). General host service state and caches remain
+absent. Session HOME and temporary directories remain broker-owned writable
+scratch, while other filesystem locations stay absent unless the execution
+policy explicitly grants them.
 
 V5 has no unsafe host-execution switch. Commands must use the native sandbox;
 an OCI execution mode must be backed by a real container runtime or fail closed.

--- a/native/sigma-exec/src/repository_transaction.rs
+++ b/native/sigma-exec/src/repository_transaction.rs
@@ -20,6 +20,8 @@ const JOURNAL_VERSION: u32 = 2;
 const RUN_BASELINE_VERSION: u32 = 1;
 const DEFAULT_MAX_FILES: u64 = 200_000;
 const DEFAULT_MAX_BYTES: u64 = 8 * 1024 * 1024 * 1024;
+const BROKER_FALLBACK_USER_NAME: &str = "user.name=Sigma Repository Transaction";
+const BROKER_FALLBACK_USER_EMAIL: &str = "user.email=sigma-repository-transaction@example.invalid";
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -2119,29 +2121,83 @@ fn run_git_bounded(
     args: &[String],
     cancelled: impl Fn() -> bool,
 ) -> Result<GitOutput, RpcError> {
+    let cancelled = &cancelled as &dyn Fn() -> bool;
+    let identity_fallbacks = if git_operation_may_create_commit(args) {
+        repository_identity_fallbacks(journal, cancelled)?
+    } else {
+        Vec::new()
+    };
+    run_git_bounded_inner(journal, args, cancelled, &identity_fallbacks)
+}
+
+fn git_operation_may_create_commit(args: &[String]) -> bool {
+    args.first().is_some_and(|command| {
+        matches!(
+            command.as_str(),
+            "commit" | "merge" | "rebase" | "cherry-pick" | "revert"
+        )
+    })
+}
+
+fn repository_identity_fallbacks(
+    journal: &RepositoryTransactionJournalV2,
+    cancelled: &dyn Fn() -> bool,
+) -> Result<Vec<&'static str>, RpcError> {
+    let mut fallbacks = Vec::new();
+    for (key, fallback) in [
+        ("user.name", BROKER_FALLBACK_USER_NAME),
+        ("user.email", BROKER_FALLBACK_USER_EMAIL),
+    ] {
+        let output = run_git_bounded_inner(
+            journal,
+            &["config".into(), "--get".into(), key.into()],
+            cancelled,
+            &[],
+        )?;
+        match output.exit_code {
+            0 if !output.stdout.trim().is_empty() => {}
+            0 | 1 => fallbacks.push(fallback),
+            _ => {
+                return Err(RpcError::new(
+                    "repository_state_unavailable",
+                    format!("repository Git identity setting {key} could not be inspected"),
+                ));
+            }
+        }
+    }
+    Ok(fallbacks)
+}
+
+fn run_git_bounded_inner(
+    journal: &RepositoryTransactionJournalV2,
+    args: &[String],
+    cancelled: &dyn Fn() -> bool,
+    config_overrides: &[&str],
+) -> Result<GitOutput, RpcError> {
     repin_executable(&journal.executable, &journal.executable_sha256)?;
     validate_live_topology(journal)?;
     let null_device = if cfg!(windows) { "NUL" } else { "/dev/null" };
     let mut command = Command::new(&journal.executable);
-    command
-        .current_dir(&journal.repository_root)
-        .args([
-            "-c",
-            &format!("core.hooksPath={null_device}"),
-            "-c",
-            "core.fsmonitor=false",
-            "-c",
-            "commit.gpgSign=false",
-            "-c",
-            "tag.gpgSign=false",
-            "-c",
-            "merge.gpgSign=false",
-            "-c",
-            "merge.verifySignatures=false",
-            "-c",
-            "rebase.gpgSign=false",
-        ])
-        .arg(format!("--git-dir={}", journal.git_dir.display()));
+    command.current_dir(&journal.repository_root).args([
+        "-c",
+        &format!("core.hooksPath={null_device}"),
+        "-c",
+        "core.fsmonitor=false",
+        "-c",
+        "commit.gpgSign=false",
+        "-c",
+        "tag.gpgSign=false",
+        "-c",
+        "merge.gpgSign=false",
+        "-c",
+        "merge.verifySignatures=false",
+        "-c",
+        "rebase.gpgSign=false",
+    ]);
+    for value in config_overrides {
+        command.args(["-c", value]);
+    }
+    command.arg(format!("--git-dir={}", journal.git_dir.display()));
     if journal.repository_root != journal.git_dir {
         command.arg(format!("--work-tree={}", journal.repository_root.display()));
     }

--- a/native/sigma-exec/src/repository_transaction_tests.rs
+++ b/native/sigma-exec/src/repository_transaction_tests.rs
@@ -127,6 +127,19 @@ fn conflict_repository(label: &str) -> PathBuf {
     root
 }
 
+fn non_conflicting_merge_repository(label: &str) -> PathBuf {
+    let root = repository(label);
+    git_ok(&root, &["switch", "-qc", "topic"]);
+    fs::write(root.join("topic.txt"), b"topic\n").unwrap();
+    git_ok(&root, &["add", "topic.txt"]);
+    git_ok(&root, &["commit", "-qm", "topic"]);
+    git_ok(&root, &["switch", "-q", "main"]);
+    fs::write(root.join("main.txt"), b"main\n").unwrap();
+    git_ok(&root, &["add", "main.txt"]);
+    git_ok(&root, &["commit", "-qm", "main"]);
+    root
+}
+
 fn begin_conflict(store: &RepositoryTransactions, root: &Path, session: &str, run: &str) -> String {
     let lease_id = acquire(store, root, session, run, None).unwrap();
     let result = store
@@ -207,6 +220,97 @@ fn conflict_begin_edit_continue_and_seal_is_broker_journaled() {
         })
         .unwrap_err();
     assert_eq!(reused.code, "repository_transaction_handle_invalid");
+    remove_any(&root).unwrap();
+}
+
+#[test]
+fn merge_uses_an_isolated_identity_fallback_when_local_identity_is_missing() {
+    let root = non_conflicting_merge_repository("identity-fallback");
+    git_ok(&root, &["config", "--unset", "user.name"]);
+    git_ok(&root, &["config", "--unset", "user.email"]);
+    git_ok(&root, &["config", "user.useConfigOnly", "true"]);
+    let store = test_store("test-identity-fallback");
+    let Some(lease_id) = acquire(&store, &root, "session-identity", "run-identity", None) else {
+        let _ = remove_any(&root);
+        return;
+    };
+    let result = store
+        .begin(
+            2,
+            BeginRepositoryTransactionParams {
+                protocol_version: 2,
+                lease_id,
+                expected_postconditions: None,
+                operations: vec![RepositoryOperationV2 {
+                    operation_class: "merge".into(),
+                    args: vec![
+                        "merge".into(),
+                        "--no-edit".into(),
+                        "--no-verify".into(),
+                        "topic".into(),
+                    ],
+                }],
+            },
+        )
+        .unwrap();
+    assert_eq!(result["status"], "completed_pending_seal");
+    let handle = result["transactionHandle"].as_str().unwrap().to_owned();
+    store
+        .seal(BoundRepositoryTransactionParams {
+            protocol_version: 2,
+            transaction_handle: handle,
+            session_id: "session-identity".into(),
+            run_id: "run-identity".into(),
+        })
+        .unwrap();
+    assert_eq!(
+        git_ok(&root, &["show", "-s", "--format=%an <%ae>", "HEAD"]),
+        "Sigma Repository Transaction <sigma-repository-transaction@example.invalid>"
+    );
+    remove_any(&root).unwrap();
+}
+
+#[test]
+fn merge_preserves_a_repository_local_identity_over_the_broker_fallback() {
+    let root = non_conflicting_merge_repository("identity-local");
+    let store = test_store("test-identity-local");
+    let Some(lease_id) = acquire(&store, &root, "session-local", "run-local", None) else {
+        let _ = remove_any(&root);
+        return;
+    };
+    let result = store
+        .begin(
+            3,
+            BeginRepositoryTransactionParams {
+                protocol_version: 2,
+                lease_id,
+                expected_postconditions: None,
+                operations: vec![RepositoryOperationV2 {
+                    operation_class: "merge".into(),
+                    args: vec![
+                        "merge".into(),
+                        "--no-edit".into(),
+                        "--no-verify".into(),
+                        "topic".into(),
+                    ],
+                }],
+            },
+        )
+        .unwrap();
+    assert_eq!(result["status"], "completed_pending_seal");
+    let handle = result["transactionHandle"].as_str().unwrap().to_owned();
+    store
+        .seal(BoundRepositoryTransactionParams {
+            protocol_version: 2,
+            transaction_handle: handle,
+            session_id: "session-local".into(),
+            run_id: "run-local".into(),
+        })
+        .unwrap();
+    assert_eq!(
+        git_ok(&root, &["show", "-s", "--format=%an <%ae>", "HEAD"]),
+        "Sigma <sigma@example.invalid>"
+    );
     remove_any(&root).unwrap();
 }
 

--- a/native/sigma-exec/src/sandbox.rs
+++ b/native/sigma-exec/src/sandbox.rs
@@ -1794,8 +1794,8 @@ const LINUX_SYSTEM_ROOT_CANDIDATES: &[&str] = &[
     "/lib",
     "/lib64",
     "/etc",
-    "/var/lib",
-    "/var/cache",
+    "/var/lib/texmf",
+    "/var/cache/fontconfig",
 ];
 
 #[cfg(target_os = "linux")]
@@ -1810,13 +1810,25 @@ fn linux_system_roots() -> Vec<PathBuf> {
 
 #[cfg(any(target_os = "linux", test))]
 fn linux_system_mount_parents(roots: &[PathBuf]) -> Vec<PathBuf> {
-    let mut parents = roots
-        .iter()
-        .filter_map(|root| root.parent())
-        .filter(|parent| *parent != Path::new("/") && !roots.iter().any(|root| root == *parent))
-        .map(Path::to_owned)
-        .collect::<Vec<_>>();
-    parents.sort();
+    let mut parents = Vec::new();
+    for root in roots {
+        let mut ancestor = root.parent();
+        while let Some(parent) = ancestor {
+            if parent == Path::new("/") {
+                break;
+            }
+            if !roots.iter().any(|root| root == parent) {
+                parents.push(parent.to_owned());
+            }
+            ancestor = parent.parent();
+        }
+    }
+    parents.sort_by(|left, right| {
+        left.components()
+            .count()
+            .cmp(&right.components().count())
+            .then_with(|| left.cmp(right))
+    });
     parents.dedup();
     parents
 }
@@ -2041,16 +2053,22 @@ mod tests {
     use super::*;
 
     #[test]
-    fn standard_linux_runtime_state_is_read_only_system_data() {
-        assert!(LINUX_SYSTEM_ROOT_CANDIDATES.contains(&"/var/lib"));
-        assert!(LINUX_SYSTEM_ROOT_CANDIDATES.contains(&"/var/cache"));
+    fn selected_linux_toolchain_state_is_read_only_system_data() {
+        assert!(!LINUX_SYSTEM_ROOT_CANDIDATES.contains(&"/var/lib"));
+        assert!(!LINUX_SYSTEM_ROOT_CANDIDATES.contains(&"/var/cache"));
+        assert!(LINUX_SYSTEM_ROOT_CANDIDATES.contains(&"/var/lib/texmf"));
+        assert!(LINUX_SYSTEM_ROOT_CANDIDATES.contains(&"/var/cache/fontconfig"));
         assert_eq!(
             linux_system_mount_parents(&[
                 PathBuf::from("/usr"),
-                PathBuf::from("/var/lib"),
-                PathBuf::from("/var/cache"),
+                PathBuf::from("/var/lib/texmf"),
+                PathBuf::from("/var/cache/fontconfig"),
             ]),
-            vec![PathBuf::from("/var")]
+            vec![
+                PathBuf::from("/var"),
+                PathBuf::from("/var/cache"),
+                PathBuf::from("/var/lib"),
+            ]
         );
     }
 

--- a/native/sigma-exec/src/sandbox.rs
+++ b/native/sigma-exec/src/sandbox.rs
@@ -1213,6 +1213,9 @@ fn build_sandboxed_command(
     let executable =
         authorize_linux_executable(params, &system_roots, &execution_roots, &runtime_cwd_source)?;
     let executable_destination = executable.source.destination().to_owned();
+    for parent in linux_system_mount_parents(&system_roots) {
+        command.arg("--dir").arg(parent);
+    }
     for root in &system_roots {
         let value = root.to_string_lossy();
         command.args(["--ro-bind", value.as_ref(), value.as_ref()]);
@@ -1783,13 +1786,39 @@ fn trusted_bwrap_from(candidates: &[PathBuf]) -> Result<PathBuf, String> {
     }
 }
 
+#[cfg(any(target_os = "linux", test))]
+const LINUX_SYSTEM_ROOT_CANDIDATES: &[&str] = &[
+    "/usr",
+    "/bin",
+    "/sbin",
+    "/lib",
+    "/lib64",
+    "/etc",
+    "/var/lib",
+    "/var/cache",
+];
+
 #[cfg(target_os = "linux")]
 fn linux_system_roots() -> Vec<PathBuf> {
-    ["/usr", "/bin", "/sbin", "/lib", "/lib64", "/etc"]
-        .into_iter()
+    LINUX_SYSTEM_ROOT_CANDIDATES
+        .iter()
+        .copied()
         .map(PathBuf::from)
         .filter(|root| root.exists())
         .collect()
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn linux_system_mount_parents(roots: &[PathBuf]) -> Vec<PathBuf> {
+    let mut parents = roots
+        .iter()
+        .filter_map(|root| root.parent())
+        .filter(|parent| *parent != Path::new("/") && !roots.iter().any(|root| root == *parent))
+        .map(Path::to_owned)
+        .collect::<Vec<_>>();
+    parents.sort();
+    parents.dedup();
+    parents
 }
 
 #[cfg(target_os = "linux")]
@@ -2010,6 +2039,20 @@ fn detect_sandbox() -> SandboxStatus {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn standard_linux_runtime_state_is_read_only_system_data() {
+        assert!(LINUX_SYSTEM_ROOT_CANDIDATES.contains(&"/var/lib"));
+        assert!(LINUX_SYSTEM_ROOT_CANDIDATES.contains(&"/var/cache"));
+        assert_eq!(
+            linux_system_mount_parents(&[
+                PathBuf::from("/usr"),
+                PathBuf::from("/var/lib"),
+                PathBuf::from("/var/cache"),
+            ]),
+            vec![PathBuf::from("/var")]
+        );
+    }
 
     fn non_git_params(root: &Path) -> ProcessParams {
         ProcessParams {

--- a/packages/agent-kernel/src/index.ts
+++ b/packages/agent-kernel/src/index.ts
@@ -7,6 +7,7 @@ export * from "./semantic-failures.js";
 export * from "./durable-budget-reducers.js";
 export * from "./task-control-state.js";
 export * from "./task-control.js";
+export * from "./task-control-migration.js";
 export * from "./capability-task-control.js";
 export * from "./repository-task-control.js";
 export * from "./restoration-task-control.js";

--- a/packages/agent-kernel/src/model-convergence.ts
+++ b/packages/agent-kernel/src/model-convergence.ts
@@ -13,7 +13,8 @@ import {
   startActionBatch,
   taskControlAnswer,
   taskControlFailureMessage,
-  terminalResolutionObligation
+  terminalResolutionObligation,
+  toolPolicyCorrectionExhausted
 } from "./task-control.js";
 
 const TERMINAL_PROTOCOL_FAILURE_CODES = new Set([
@@ -92,6 +93,12 @@ export function blockedReport(receipt: ToolReceipt): { code: string; message: st
   } catch { return null; }
 }
 
+function reachedSemanticConvergence(taskControl: KernelState["taskControl"]): boolean {
+  return taskControl.obligation?.kind === "terminal_resolution"
+    && taskControl.obligation.failureCode === "action_convergence_no_progress"
+    && taskControl.episode.noProgressBatches >= 7;
+}
+
 export function failedTerminalRepairState(
   state: KernelState,
   repairPending: boolean,
@@ -112,7 +119,11 @@ export function failedTerminalRepairState(
         detail,
         state.revision
       );
-  if (taskControl.phase !== "terminal") {
+  // Let the semantic convergence transition report its own truthful failure
+  // instead of mislabelling the first rejected repair action as two rejected
+  // corrections.
+  if (reachedSemanticConvergence(taskControl) && !toolPolicyCorrectionExhausted(taskControl)) return null;
+  if (!toolPolicyCorrectionExhausted(taskControl)) {
     return {
       ...state,
       phase: "ready_model",
@@ -144,7 +155,7 @@ export function repairConflictingTerminalBatch(state: KernelState, messages: Mod
     "terminal_batch_conflict",
     state.revision
   );
-  return taskControl.phase === "terminal"
+  return toolPolicyCorrectionExhausted(taskControl)
     ? propose({ ...state, messages, taskControl }, {
         kind: "recoverable_failure",
         code: taskControl.obligation?.kind === "terminal_resolution"

--- a/packages/agent-kernel/src/semantic-failures.ts
+++ b/packages/agent-kernel/src/semantic-failures.ts
@@ -72,20 +72,39 @@ const CONTENT_READ_TOOLS = new Set([
   "repository_inspect", "lsp"
 ]);
 
+const READ_ONLY_PROCESS_EFFECTS = new Set([
+  "filesystem.read",
+  "process.spawn.readonly"
+]);
+
 function object(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object" && !Array.isArray(value)
     ? value as Record<string, unknown> : null;
 }
 
 function semanticReadSubject(toolName: string, receipt: ToolReceipt): unknown | null {
-  if (!CONTENT_READ_TOOLS.has(toolName)) return null;
-  const result = object(receipt.result);
-  if (toolName === "read" && result?.status === "read"
-    && typeof result.path === "string" && typeof result.sha256 === "string") {
-    return { toolName, path: result.path, contentDigest: result.sha256 };
+  if (CONTENT_READ_TOOLS.has(toolName)) {
+    const result = object(receipt.result);
+    if (toolName === "read" && result?.status === "read"
+      && typeof result.path === "string" && typeof result.sha256 === "string") {
+      return { toolName, path: result.path, contentDigest: result.sha256 };
+    }
+    return {
+      toolName,
+      contentDigest: createHash("sha256").update(receipt.output, "utf8").digest("hex")
+    };
   }
+
+  // A successful, runtime-confirmed read-only process can reveal the same
+  // kind of new workspace fact as a structured grep/list adapter. Require
+  // actualEffects rather than the requested/observed projection so failed,
+  // mutating, or open-world process calls cannot reset convergence.
+  const effects = receipt.actualEffects;
+  if (!effects?.includes("process.spawn.readonly")
+    || effects.some((effect) => !READ_ONLY_PROCESS_EFFECTS.has(effect))) return null;
   return {
     toolName,
+    source: "readonly_process",
     contentDigest: createHash("sha256").update(receipt.output, "utf8").digest("hex")
   };
 }

--- a/packages/agent-kernel/src/semantic-failures.ts
+++ b/packages/agent-kernel/src/semantic-failures.ts
@@ -72,11 +72,6 @@ const CONTENT_READ_TOOLS = new Set([
   "repository_inspect", "lsp"
 ]);
 
-const READ_ONLY_PROCESS_EFFECTS = new Set([
-  "filesystem.read",
-  "process.spawn.readonly"
-]);
-
 function object(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object" && !Array.isArray(value)
     ? value as Record<string, unknown> : null;
@@ -94,19 +89,12 @@ function semanticReadSubject(toolName: string, receipt: ToolReceipt): unknown | 
       contentDigest: createHash("sha256").update(receipt.output, "utf8").digest("hex")
     };
   }
-
-  // A successful, runtime-confirmed read-only process can reveal the same
-  // kind of new workspace fact as a structured grep/list adapter. Require
-  // actualEffects rather than the requested/observed projection so failed,
-  // mutating, or open-world process calls cannot reset convergence.
-  const effects = receipt.actualEffects;
-  if (!effects?.includes("process.spawn.readonly")
-    || effects.some((effect) => !READ_ONLY_PROCESS_EFFECTS.has(effect))) return null;
-  return {
-    toolName,
-    source: "readonly_process",
-    contentDigest: createHash("sha256").update(receipt.output, "utf8").digest("hex")
-  };
+  // Process receipts describe an execution result, not a stable workspace
+  // subject. Their output may vary with clocks, progress reporting, entropy,
+  // or process state while the workspace is unchanged. Semantic validation
+  // and input-access evidence are recorded separately with authenticated
+  // frontier bindings; arbitrary process stdout must not reset convergence.
+  return null;
 }
 
 export function recordSemanticEvidenceProgress(state: KernelState, evidence: EvidenceRecord): KernelState {

--- a/packages/agent-kernel/src/task-control-migration.ts
+++ b/packages/agent-kernel/src/task-control-migration.ts
@@ -1,0 +1,112 @@
+import type { JsonValue } from "agent-protocol";
+import type { TaskControlStateV1 } from "./task-control-state.js";
+import { isTaskControlStateV1 } from "./task-control-state.js";
+import {
+  completionEvidenceObligation,
+  createTaskControlState,
+  hasPublishedTaskControlLegacyFields,
+  protectCompletionCandidate
+} from "./task-control.js";
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown> : null;
+}
+
+function legacyCount(value: unknown): number {
+  return Number.isSafeInteger(value) && Number(value) >= 0 ? Number(value) : 0;
+}
+
+const PUBLISHED_V5_REQUIRED_KEYS = [
+  "completionRepairAttempts", "continuationAttempts", "repeatedToolBatchCount",
+  "receiptCountAtLastUserInput", "semanticProgress"
+] as const;
+
+const PUBLISHED_V5_REPAIR_KINDS = new Set([
+  "evidence_acquisition", "terminal_action", "protected_completion",
+  "completion_prerequisite", "protected_recovery"
+]);
+
+function validPublishedLegacyShape(stored: Record<string, unknown>): boolean {
+  return PUBLISHED_V5_REQUIRED_KEYS.every((key) => key in stored);
+}
+
+function validLegacyRepair(
+  stored: Record<string, unknown>,
+  repair: Record<string, unknown> | null,
+  repairAttempts: number
+): boolean {
+  if (stored.completionRepair !== undefined && !repair) return false;
+  if (repairAttempts > 0 && !repair) return false;
+  return !repair || typeof repair.kind === "string" && PUBLISHED_V5_REPAIR_KINDS.has(repair.kind);
+}
+
+function migrateLegacyRepair(
+  control: TaskControlStateV1,
+  repair: Record<string, unknown> | null,
+  revision: number
+): TaskControlStateV1 {
+  const answer = typeof repair?.answer === "string" ? repair.answer.trim() : "";
+  const protectedControl = answer ? protectCompletionCandidate(control, answer) : control;
+  if (repair?.kind === "evidence_acquisition") {
+    return completionEvidenceObligation(protectedControl, revision, "acquire", 0);
+  }
+  if (repair?.kind === "terminal_action" || repair?.kind === "protected_completion") {
+    return completionEvidenceObligation(protectedControl, revision, "terminal", 0);
+  }
+  if (repair?.kind !== "completion_prerequisite") return protectedControl;
+  return completionEvidenceObligation(
+    protectedControl,
+    revision,
+    "acquire",
+    legacyCount(repair.evidenceCount),
+    {
+      ...(typeof repair.originalCallId === "string" ? { originalCallId: repair.originalCallId } : {}),
+      ...(repair.arguments === undefined ? {} : { arguments: repair.arguments as JsonValue })
+    }
+  );
+}
+
+function phaseForLegacyDebt(
+  current: TaskControlStateV1["phase"],
+  noProgressBatches: number
+): TaskControlStateV1["phase"] {
+  if (noProgressBatches >= 7) return "terminal";
+  if (noProgressBatches >= 6) return "repair_only";
+  if (noProgressBatches >= 2) return "focused";
+  return current;
+}
+
+/** Migrate only fields written by published V5 main. Experimental #55 state
+ * carries separate versioned markers and is deliberately rejected by restore. */
+export function migratePublishedTaskControlState(
+  value: unknown,
+  revision: number
+): TaskControlStateV1 | null {
+  const stored = record(value);
+  if (!stored) return null;
+  if (isTaskControlStateV1(stored.taskControl)) {
+    return hasPublishedTaskControlLegacyFields(stored) ? null : stored.taskControl;
+  }
+  if (!validPublishedLegacyShape(stored)) return null;
+  const repair = stored.completionRepair === undefined ? null : record(stored.completionRepair);
+  const repairAttempts = legacyCount(stored.completionRepairAttempts);
+  if (!validLegacyRepair(stored, repair, repairAttempts)) return null;
+  const control = migrateLegacyRepair(createTaskControlState(revision), repair, revision);
+  const cluster = record(stored.semanticFailureCluster);
+  const noProgressBatches = Math.max(
+    legacyCount(stored.repeatedToolBatchCount),
+    legacyCount(cluster?.attempts)
+  );
+  const phase = phaseForLegacyDebt(control.phase, noProgressBatches);
+  const obligation = control.obligation && repairAttempts > 0
+    ? { ...control.obligation, attempts: repairAttempts }
+    : control.obligation;
+  return {
+    ...control,
+    phase,
+    ...(obligation ? { obligation } : {}),
+    modelContinuationAttempts: legacyCount(stored.continuationAttempts),
+    episode: { ...control.episode, noProgressBatches }
+  };
+}

--- a/packages/agent-kernel/src/task-control.ts
+++ b/packages/agent-kernel/src/task-control.ts
@@ -290,7 +290,18 @@ export function recordToolPolicyViolation(
     policyCorrection: { basisDigest, attempts, failureCode }
   };
   const resolutionCode = policyExhaustionCode(control);
-  return attempts >= 2 ? terminalResolutionObligation(updated, revision, resolutionCode) : updated;
+  if (attempts < 2) return updated;
+  return {
+    ...terminalResolutionObligation(updated, revision, resolutionCode),
+    // Preserve the exhausted counter until the terminal outcome is proposed.
+    // Callers must not infer exhaustion from phase="terminal" because some
+    // obligations (notably user decisions) are terminal from their first turn.
+    policyCorrection: updated.policyCorrection
+  };
+}
+
+export function toolPolicyCorrectionExhausted(control: TaskControlStateV1): boolean {
+  return (control.policyCorrection?.attempts ?? 0) >= 2;
 }
 
 export function taskControlFailureMessage(control: TaskControlStateV1, detail: string): string {

--- a/packages/agent-kernel/src/task-control.ts
+++ b/packages/agent-kernel/src/task-control.ts
@@ -5,7 +5,6 @@ import type {
   TaskControlStateV1,
   TaskObligationV1
 } from "./task-control-state.js";
-import { isTaskControlStateV1 } from "./task-control-state.js";
 import { policyExhaustionCode } from "./task-control-resolution.js";
 
 const EMPTY_BASIS = createHash("sha256").update("sigma-task-control-v1").digest("hex");
@@ -312,99 +311,4 @@ export function taskControlFailureMessage(control: TaskControlStateV1, detail: s
 
 function record(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : null;
-}
-
-function legacyCount(value: unknown): number {
-  return Number.isSafeInteger(value) && Number(value) >= 0 ? Number(value) : 0;
-}
-
-const PUBLISHED_V5_REQUIRED_KEYS = [
-  "completionRepairAttempts", "continuationAttempts", "repeatedToolBatchCount",
-  "receiptCountAtLastUserInput", "semanticProgress"
-] as const;
-
-const PUBLISHED_V5_REPAIR_KINDS = new Set([
-  "evidence_acquisition", "terminal_action", "protected_completion",
-  "completion_prerequisite", "protected_recovery"
-]);
-
-function validPublishedLegacyShape(stored: Record<string, unknown>): boolean {
-  return PUBLISHED_V5_REQUIRED_KEYS.every((key) => key in stored);
-}
-
-function validLegacyRepair(
-  stored: Record<string, unknown>,
-  repair: Record<string, unknown> | null,
-  repairAttempts: number
-): boolean {
-  if (stored.completionRepair !== undefined && !repair) return false;
-  if (repairAttempts > 0 && !repair) return false;
-  return !repair || typeof repair.kind === "string" && PUBLISHED_V5_REPAIR_KINDS.has(repair.kind);
-}
-
-function migrateLegacyRepair(
-  control: TaskControlStateV1,
-  repair: Record<string, unknown> | null,
-  revision: number
-): TaskControlStateV1 {
-  const answer = typeof repair?.answer === "string" ? repair.answer.trim() : "";
-  const protectedControl = answer ? protectCompletionCandidate(control, answer) : control;
-  if (repair?.kind === "evidence_acquisition") {
-    return completionEvidenceObligation(protectedControl, revision, "acquire", 0);
-  }
-  if (repair?.kind === "terminal_action" || repair?.kind === "protected_completion") {
-    return completionEvidenceObligation(protectedControl, revision, "terminal", 0);
-  }
-  if (repair?.kind !== "completion_prerequisite") return protectedControl;
-  return completionEvidenceObligation(
-    protectedControl,
-    revision,
-    "acquire",
-    legacyCount(repair.evidenceCount),
-    {
-      ...(typeof repair.originalCallId === "string" ? { originalCallId: repair.originalCallId } : {}),
-      ...(repair.arguments === undefined ? {} : { arguments: repair.arguments as JsonValue })
-    }
-  );
-}
-
-function phaseForLegacyDebt(
-  current: TaskControlStateV1["phase"],
-  noProgressBatches: number
-): TaskControlStateV1["phase"] {
-  if (noProgressBatches >= 7) return "terminal";
-  if (noProgressBatches >= 6) return "repair_only";
-  if (noProgressBatches >= 2) return "focused";
-  return current;
-}
-
-/** Migrate only fields written by published V5 main. Experimental #55 state
- * carries separate versioned markers and is deliberately rejected by restore. */
-export function migratePublishedTaskControlState(value: unknown, revision: number): TaskControlStateV1 | null {
-  const stored = record(value);
-  if (!stored) return null;
-  if (isTaskControlStateV1(stored.taskControl)) {
-    return hasPublishedTaskControlLegacyFields(stored) ? null : stored.taskControl;
-  }
-  if (!validPublishedLegacyShape(stored)) return null;
-  const repair = stored.completionRepair === undefined ? null : record(stored.completionRepair);
-  const repairAttempts = legacyCount(stored.completionRepairAttempts);
-  if (!validLegacyRepair(stored, repair, repairAttempts)) return null;
-  const control = migrateLegacyRepair(createTaskControlState(revision), repair, revision);
-  const cluster = record(stored.semanticFailureCluster);
-  const noProgressBatches = Math.max(
-    legacyCount(stored.repeatedToolBatchCount),
-    legacyCount(cluster?.attempts)
-  );
-  const phase = phaseForLegacyDebt(control.phase, noProgressBatches);
-  const obligation = control.obligation && repairAttempts > 0
-    ? { ...control.obligation, attempts: repairAttempts }
-    : control.obligation;
-  return {
-    ...control,
-    phase,
-    ...(obligation ? { obligation } : {}),
-    modelContinuationAttempts: legacyCount(stored.continuationAttempts),
-    episode: { ...control.episode, noProgressBatches }
-  };
 }

--- a/packages/agent-kernel/src/terminal-reducer-helpers.ts
+++ b/packages/agent-kernel/src/terminal-reducer-helpers.ts
@@ -16,7 +16,8 @@ import type { KernelState, PendingTool } from "./state.js";
 import {
   completionEvidenceObligation,
   protectCompletionCandidate,
-  recordToolPolicyViolation
+  recordToolPolicyViolation,
+  toolPolicyCorrectionExhausted
 } from "./task-control.js";
 
 export function nextPhase(pending: readonly PendingTool[]): KernelState["phase"] {
@@ -169,7 +170,7 @@ function invalidBlockedReportState(state: KernelState, progressed: KernelState):
     "invalid_blocked_report",
     progressed.revision
   );
-  if (taskControl.phase === "terminal") {
+  if (toolPolicyCorrectionExhausted(taskControl)) {
     return proposedOutcomeState({ ...progressed, taskControl }, {
       kind: "recoverable_failure",
       code: "invalid_blocked_report",

--- a/packages/agent-kernel/src/tool-batch-progress.ts
+++ b/packages/agent-kernel/src/tool-batch-progress.ts
@@ -14,18 +14,28 @@ export function completedToolBatchProgress(state: KernelState): Pick<KernelState
   const calls = [...state.messages].reverse().find((message) => message.role === "assistant"
     && message.toolCalls?.some((call) => state.receipts.some((receipt) => receipt.callId === call.id)))?.toolCalls ?? [];
   const receipts = new Map(state.receipts.map((receipt) => [receipt.callId, receipt]));
+  const batchSucceeded = calls.length > 0
+    && calls.every((call) => receipts.get(call.id)?.ok === true);
   const policyFailures = calls.flatMap((call) => {
     const receipt = receipts.get(call.id);
     const codes = receipt ? [...new Set([...(receipt.outcome?.diagnosticCodes ?? []), ...receipt.diagnostics])] : [];
     return codes.some((code) => code === "model_tool_policy_violation" || code === "tool_unavailable_for_repair")
       ? [call.name] : [];
   });
+  // One rejected model batch is one correction attempt, independent of how
+  // many calls the provider placed in that batch.
   if (policyFailures.length > 0) {
     taskControl = recordToolPolicyViolation(
       taskControl,
       "model_tool_policy_violation",
       state.revision
     );
+  } else if (batchSucceeded
+    && taskControl.policyCorrection && taskControl.policyCorrection.attempts < 2) {
+    // A compliant batch accepts the runtime's correction even when its
+    // read-only receipt does not create a new semantic fact. Only consecutive
+    // rejected batches should exhaust the correction budget.
+    taskControl = { ...taskControl, policyCorrection: undefined };
   }
   return { taskControl };
 }

--- a/packages/agent-runtime/src/model-budget-convergence.ts
+++ b/packages/agent-runtime/src/model-budget-convergence.ts
@@ -1,6 +1,7 @@
 import {
   type BudgetAmounts,
   type ContextItem,
+  type JsonValue,
   type ModelRequest,
   type ModelToolDefinition,
   type RunOutcome,
@@ -34,6 +35,82 @@ interface ActionPolicy {
   context: ContextItem[];
 }
 
+function jsonObject(value: JsonValue | undefined): Record<string, JsonValue> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, JsonValue> : null;
+}
+
+function exactProjectedArguments(descriptor: ToolDescriptor): Record<string, JsonValue> | null {
+  const properties = jsonObject(descriptor.inputSchema.properties);
+  const required = Array.isArray(descriptor.inputSchema.required)
+    ? descriptor.inputSchema.required.filter((item): item is string => typeof item === "string") : [];
+  if (!properties || required.length === 0) return null;
+  const entries: Array<[string, JsonValue]> = [];
+  for (const name of required) {
+    const property = jsonObject(properties[name]);
+    if (!property || property.const === undefined) return null;
+    entries.push([name, property.const]);
+  }
+  return Object.fromEntries(entries);
+}
+
+function repositoryConflictActionContext(session: RuntimeSession, names: readonly string[]): string | null {
+  const obligation = session.durable.state.taskControl.obligation;
+  if (obligation?.kind !== "repository_recovery" || obligation.stage !== "transact"
+    || !obligation.transactionId || !obligation.scopePaths?.length) return null;
+  return "Task control permits exactly one tool call. A broker-journaled merge conflict is active. "
+    + `You may read other workspace files for context, but may modify only these conflict paths: ${JSON.stringify(obligation.scopePaths)}. `
+    + "The merge already applied non-conflicting changes; do not rewrite other files during conflict resolution. "
+    + `After resolving conflict markers, call git_transaction continue with transactionHandle ${JSON.stringify(obligation.transactionId)} and add only listed conflict paths; abort only if safe resolution is impossible. `
+    + `Available action names: ${names.join(", ")}.`;
+}
+
+function noProgressActionGuidance(
+  session: RuntimeSession,
+  descriptors: readonly ToolDescriptor[]
+): string {
+  const count = session.durable.state.taskControl.episode.noProgressBatches;
+  if (count <= 0) return "";
+  const completionActions = descriptors
+    .filter((descriptor) => descriptor.possibleEffects.includes("outcome.propose"))
+    .map((descriptor) => descriptor.name);
+  const completion = completionActions.length > 0
+    ? ` If the user's task is already complete and the current mutation frontier has successful semantic validation, use a completion action now (${completionActions.join(", ")}).`
+    : "";
+  return ` The last ${count} completed tool ${count === 1 ? "batch produced" : "batches produced"} no new trusted task facts. Do not repeat a read or command whose result is already known. Otherwise, choose one action that changes the current workspace frontier or semantically validates it.${completion}`;
+}
+
+function toolArgumentRepairContext(session: RuntimeSession, names: readonly string[]): string | null {
+  const control = session.durable.state.taskControl;
+  if (control.obligation || control.episode.noProgressBatches >= 2
+    || control.policyCorrection?.failureCode !== "tool_arguments_invalid") return null;
+  return "The previous tool arguments were rejected. Retry each intended call with a direct JSON object "
+    + "that matches the displayed schema; do not JSON-encode the arguments object. "
+    + `Independent corrected calls may be submitted together. Available action names: ${names.join(", ")}.`;
+}
+
+function taskControlActionContext(
+  input: TurnPreparationInput,
+  descriptors: readonly ToolDescriptor[]
+): ContextItem[] {
+  if (!input.repairPending || descriptors.length === 0) return [];
+  const names = descriptors.map((descriptor) => descriptor.name);
+  const exact = descriptors.length === 1 ? exactProjectedArguments(descriptors[0]!) : null;
+  const argumentRepair = toolArgumentRepairContext(input.session, names);
+  const conflict = repositoryConflictActionContext(input.session, names);
+  const content = argumentRepair ?? conflict ?? (exact
+    ? `Task control permits exactly one tool call. Call ${names[0]} with exactly these arguments: ${JSON.stringify(exact)}. Do not invent an alias or omit a field.`
+    : `Task control permits exactly one tool call. Available action names: ${names.join(", ")}. Use one displayed name and follow its schema exactly; do not invent an alias.${noProgressActionGuidance(input.session, descriptors)}`);
+  return [{
+    id: `runtime:task-control-action:${input.session.durable.runId}:${input.turnId}`,
+    authority: "runtime",
+    provenance: "task-control projection",
+    content,
+    tokenCount: Math.max(32, Math.ceil(content.length / 3)),
+    priority: 20_000
+  }];
+}
+
 export interface TurnPreparationInput {
   session: RuntimeSession;
   forecast: DeadlineForecast;
@@ -49,22 +126,26 @@ export interface TurnPreparationInput {
   defaultOutputReserveTokens: number;
 }
 
-function actionPolicy(input: TurnPreparationInput): ActionPolicy {
+function actionPolicy(
+  input: TurnPreparationInput,
+  descriptors: readonly ToolDescriptor[]
+): ActionPolicy {
   const { session, forecast, turnId, defaultOutputReserveTokens, budgetStage } = input;
   const lengthRecovery = session.durable.state.taskControl.modelContinuationAttempts > 0;
   const required = lengthRecovery || forecast.stage === "converge" || budgetStage !== "normal";
   const outputReserveTokens = required ? Math.min(2_048, defaultOutputReserveTokens) : defaultOutputReserveTokens;
-  if (!required) return { required, outputReserveTokens, context: [] };
+  const projectedAction = taskControlActionContext(input, descriptors);
+  if (!required) return { required, outputReserveTokens, context: projectedAction };
   const content = lengthRecovery
     ? "The previous response reached its output limit, and its private reasoning is not replayed. Do not reconstruct or continue that reasoning. Choose one concrete tool action now, based on the durable conversation and evidence."
     : budgetStage === "terminal"
       ? "Budget stage is terminal. Use one available terminal tool now. Do not start or describe additional work."
       : forecast.stage === "converge"
-        ? "Deadline stage is converge. Choose one focused tool action now, then immediately use the appropriate terminal tool. Do not start exploratory work."
+        ? "Deadline stage is converge. Resolve the active prerequisite with one focused tool action now. Do not start exploratory work."
         : budgetStage === "converge"
           ? "Budget stage is converge. Choose one focused action now and preserve the next model turn for a terminal outcome. Do not start exploratory work."
           : "Convergence requires one focused tool action now, followed immediately by the appropriate terminal tool.";
-  return { required, outputReserveTokens, context: [{
+  return { required, outputReserveTokens, context: [...projectedAction, {
     id: `runtime:action-required:${session.durable.runId}:${turnId}`,
     authority: "runtime",
     provenance: lengthRecovery ? "length recovery" : "deadline stage",
@@ -89,6 +170,18 @@ export function availableModelBudget(session: RuntimeSession): BudgetAmounts {
 function terminalDescriptor(descriptor: ToolDescriptor): boolean {
   return descriptor.possibleEffects.some((effect) => effect === "outcome.propose"
     || effect === "outcome.report_blocked" || effect === "outcome.request_input");
+}
+
+export function deadlineBudgetStage(
+  forecast: DeadlineForecast,
+  descriptors: readonly ToolDescriptor[]
+): BudgetStage {
+  if (forecast.stage !== "converge") return "normal";
+  // A deadline convergence turn must be enforceable, not merely advisory.
+  // Project terminal actions immediately when one is available; otherwise
+  // preserve one focused prerequisite/repair action so task control can make
+  // a terminal action available on the following turn.
+  return descriptors.some(terminalDescriptor) ? "terminal" : "converge";
 }
 
 function firstAttemptBudget(prepared: PreparedModelBudget): Partial<BudgetAmounts> {
@@ -164,7 +257,7 @@ export async function prepareBudgetedModelTurn(
     });
   }
   const tools = modelTools(projectModelToolDescriptors(stageDescriptors, capabilities));
-  const policy = actionPolicy(input);
+  const policy = actionPolicy(input, stageDescriptors);
   const outputReserveTokens = budgetStage === "normal" ? policy.outputReserveTokens : Math.max(1, Math.min(
     policy.outputReserveTokens,
     Math.floor(available.outputTokens / APPROXIMATE_TOKEN_RESERVATION_MARGIN)

--- a/packages/agent-runtime/src/model-budget-convergence.ts
+++ b/packages/agent-runtime/src/model-budget-convergence.ts
@@ -136,10 +136,14 @@ function actionPolicy(
   const outputReserveTokens = required ? Math.min(2_048, defaultOutputReserveTokens) : defaultOutputReserveTokens;
   const projectedAction = taskControlActionContext(input, descriptors);
   if (!required) return { required, outputReserveTokens, context: projectedAction };
+  const naturalCompletion = !input.repairPending && budgetStage === "terminal"
+    && !descriptors.some(visibleCompletionDescriptor);
   const content = lengthRecovery
     ? "The previous response reached its output limit, and its private reasoning is not replayed. Do not reconstruct or continue that reasoning. Choose one concrete tool action now, based on the durable conversation and evidence."
     : budgetStage === "terminal"
-      ? "Budget stage is terminal. Use one available terminal tool now. Do not start or describe additional work."
+      ? naturalCompletion
+        ? "Budget stage is terminal. If the task is complete, stop naturally with the final user-facing summary now. Otherwise use one available terminal tool. Do not start or describe additional work."
+        : "Budget stage is terminal. Use one available terminal tool now. Do not start or describe additional work."
       : forecast.stage === "converge"
         ? "Deadline stage is converge. Resolve the active prerequisite with one focused tool action now. Do not start exploratory work."
         : budgetStage === "converge"
@@ -172,6 +176,10 @@ function terminalDescriptor(descriptor: ToolDescriptor): boolean {
     || effect === "outcome.report_blocked" || effect === "outcome.request_input");
 }
 
+function visibleCompletionDescriptor(descriptor: ToolDescriptor): boolean {
+  return descriptor.possibleEffects.includes("outcome.propose");
+}
+
 export function deadlineBudgetStage(
   forecast: DeadlineForecast,
   descriptors: readonly ToolDescriptor[]
@@ -182,6 +190,20 @@ export function deadlineBudgetStage(
   // preserve one focused prerequisite/repair action so task control can make
   // a terminal action available on the following turn.
   return descriptors.some(terminalDescriptor) ? "terminal" : "converge";
+}
+
+function forceToolChoice(
+  input: TurnPreparationInput,
+  descriptors: readonly ToolDescriptor[],
+  policy: ActionPolicy
+): boolean {
+  if (input.repairPending) return true;
+  if (!policy.required) return false;
+  // Successful completion is represented by a natural model stop because
+  // runtime_finalize is intentionally not model-visible. A final projection
+  // containing only failure/input actions must leave that stop available.
+  return input.budgetStage !== "terminal"
+    || descriptors.some(visibleCompletionDescriptor);
 }
 
 function firstAttemptBudget(prepared: PreparedModelBudget): Partial<BudgetAmounts> {
@@ -248,7 +270,7 @@ export async function prepareBudgetedModelTurn(
 ): Promise<{ turn: PreparedModelTurn; plan: ContextPlan }> {
   const {
     session, descriptors, capabilities, dynamic, hookContext, ledger,
-    available, repairPending, budgetStage
+    available, budgetStage
   } = input;
   const stageDescriptors = budgetStage === "terminal" ? descriptors.filter(terminalDescriptor) : descriptors;
   if (budgetStage === "terminal" && stageDescriptors.length === 0) {
@@ -294,7 +316,8 @@ export async function prepareBudgetedModelTurn(
     turn: {
       messages: plan.messages,
       tools,
-      ...(tools.length > 0 && (repairPending || policy.required) ? { toolChoice: "required" as const } : {}),
+      ...(tools.length > 0 && forceToolChoice(input, stageDescriptors, policy)
+        ? { toolChoice: "required" as const } : {}),
       budget,
       outputReserveTokens
     }

--- a/packages/agent-runtime/src/model-effect-runner.ts
+++ b/packages/agent-runtime/src/model-effect-runner.ts
@@ -30,6 +30,7 @@ import {
 } from "./model-effect-support.js";
 import { deadlineForecast, type DeadlineForecast } from "./convergence-policy.js";
 import {
+  deadlineBudgetStage,
   availableModelBudget,
   budgetFailure,
   fitPreparedBudget,
@@ -206,7 +207,7 @@ export class ModelEffectRunner {
       profileSkillNames: session.services.profile?.profile.skills
     });
 
-    let budgetStage: BudgetStage = forecast.stage === "converge" ? "converge" : "normal";
+    let budgetStage: BudgetStage = deadlineBudgetStage(forecast, descriptors);
     const preparation = {
       session, forecast, turnId, descriptors, capabilities, dynamic, hookContext,
       ledger, available, repairPending, defaultOutputReserveTokens: this.options.outputReserveTokens
@@ -214,7 +215,7 @@ export class ModelEffectRunner {
     let prepared = await prepareBudgetedModelTurn({ ...preparation, budgetStage: "normal" });
     const capacity = requestCapacity(available, prepared.turn.budget);
     if (capacity <= 1) budgetStage = "terminal";
-    else if (capacity === 2) budgetStage = "converge";
+    else if (capacity === 2 && budgetStage === "normal") budgetStage = "converge";
     if (budgetStage !== "normal") prepared = await prepareBudgetedModelTurn({ ...preparation, budgetStage });
     const fittedBudget = fitPreparedBudget(
       prepared.turn.budget,

--- a/packages/agent-runtime/src/repository-task-control-policy.ts
+++ b/packages/agent-runtime/src/repository-task-control-policy.ts
@@ -88,14 +88,23 @@ export async function assertRepositoryConflictPlanAllowed(
   const allowed = (await Promise.all(scopePaths.map(async (item) =>
     await canonicalPlannedPath(session.identity.workspacePath, item))))
     .filter((item): item is string => Boolean(item));
-  const targets = await Promise.all(requested.map(async (item) => ({
+  const readTargets = await Promise.all(plan.readPaths.map(async (item) => ({
     item,
     canonical: await canonicalPlannedPath(session.identity.workspacePath, item)
   })));
-  const outside = targets.filter(({ canonical }) => !canonical
+  const writeTargets = await Promise.all(
+    [...plan.writePaths, ...plan.checkpointScope].map(async (item) => ({
+      item,
+      canonical: await canonicalPlannedPath(session.identity.workspacePath, item)
+    }))
+  );
+  const outsideReads = readTargets.filter(({ canonical }) => !canonical).map(({ item }) => item);
+  const outsideWrites = writeTargets.filter(({ canonical }) => !canonical
     || !allowed.some((scope) => isInside(scope, canonical))).map(({ item }) => item);
+  const outside = [...new Set([...outsideReads, ...outsideWrites])];
   if (allowed.length === scopePaths.length && outside.length === 0) return;
   throw Object.assign(new Error(
-    `Repository conflict repair is outside the broker-observed conflict paths: ${outside.join(", ") || "invalid scope"}.`
+    "Repository conflict repair is outside the workspace read boundary or "
+      + `broker-observed conflict write paths: ${outside.join(", ") || "invalid scope"}.`
   ), { code: "tool_unavailable_for_repair" });
 }

--- a/packages/agent-runtime/src/repository-transaction-broker.ts
+++ b/packages/agent-runtime/src/repository-transaction-broker.ts
@@ -31,6 +31,8 @@ export interface PendingRepositoryTransaction {
     candidateId: string;
     selectionEvidenceId: string;
     selectedObject: string;
+    selectedSymbolicRef: string | null;
+    integrationMode: "exact_head" | "merge";
   };
 }
 

--- a/packages/agent-runtime/src/repository-transaction-evidence.ts
+++ b/packages/agent-runtime/src/repository-transaction-evidence.ts
@@ -16,6 +16,7 @@ import {
 } from "./repository-transaction-broker.js";
 import {
   collectRepositoryEvidenceState,
+  repositoryObjectIsAncestor,
   repositoryRevisionDelta
 } from "./repository-transaction-state.js";
 import type { RepositoryTransactionResultV2 } from "agent-execution";
@@ -24,11 +25,89 @@ function assertionDigest(value: unknown): string {
   return createHash("sha256").update(JSON.stringify(value), "utf8").digest("hex");
 }
 
-function assertRuntimeAndBrokerState(
+type CompletedAssertions = ReturnType<typeof requireCompletedAssertions>;
+type RepositoryEvidenceState = Awaited<ReturnType<typeof collectRepositoryEvidenceState>>;
+type RecoverySelection = NonNullable<PendingRepositoryTransaction["recoverySelection"]>;
+
+function recoveryPostconditionFailed(): Error {
+  return Object.assign(new Error(
+    "Repository recovery did not preserve the current history and integrate the runtime-authorized target."
+  ), { code: "repository_postcondition_failed" });
+}
+
+function exactRecoverySatisfied(
+  assertions: CompletedAssertions,
+  recovery: RecoverySelection
+): boolean {
+  return recovery.integrationMode === "exact_head"
+    && assertions.targetAssertions?.satisfied === true
+    && assertions.targetAssertions.selectedHead === recovery.selectedObject
+    && assertions.head === recovery.selectedObject
+    && assertions.targetAssertions.requiredReachableObjects.includes(recovery.selectedObject);
+}
+
+async function mergedRecoverySatisfied(
+  execution: RepositoryTransactionPort,
+  context: PlannedToolExecutionContext,
   transaction: PendingRepositoryTransaction,
-  after: Awaited<ReturnType<typeof collectRepositoryEvidenceState>>,
+  after: RepositoryEvidenceState,
+  recovery: RecoverySelection
+): Promise<boolean> {
+  if (recovery.integrationMode !== "merge" || !after.head) return false;
+  const selectedObjectPreserved = await repositoryObjectIsAncestor(
+    execution, transaction.topology, recovery.selectedObject, after.head, context.signal
+  );
+  if (!selectedObjectPreserved || !transaction.before.head) return selectedObjectPreserved;
+  return await repositoryObjectIsAncestor(
+    execution, transaction.topology, transaction.before.head, after.head, context.signal
+  );
+}
+
+async function assertRecoveryState(
+  execution: RepositoryTransactionPort,
+  context: PlannedToolExecutionContext,
+  transaction: PendingRepositoryTransaction,
+  after: RepositoryEvidenceState,
+  assertions: CompletedAssertions
+): Promise<CompletedAssertions> {
+  const recovery = transaction.recoverySelection;
+  if (!recovery) return assertions;
+  if (assertions.symbolicRef !== recovery.selectedSymbolicRef) {
+    throw recoveryPostconditionFailed();
+  }
+  if (exactRecoverySatisfied(assertions, recovery)) return assertions;
+  if (!await mergedRecoverySatisfied(execution, context, transaction, after, recovery)) {
+    throw recoveryPostconditionFailed();
+  }
+  // A merge cannot declare the selected object as the final HEAD before Git
+  // creates the merge commit, so the broker has no exact target assertion to
+  // return. The runtime has now independently established that both the
+  // selected object and the pre-transaction HEAD are ancestors of the leased
+  // post-transaction HEAD. Preserve that verified recovery target in the same
+  // assertion shape used by exact recovery so evidence normalization can issue
+  // repository acceptance without trusting model- or tool-authored claims.
+  return {
+    ...assertions,
+    targetAssertions: {
+      schemaVersion: 3,
+      selectedHead: recovery.selectedObject,
+      selectedSymbolicRef: recovery.selectedSymbolicRef,
+      requiredReachableObjects: [...new Set([
+        recovery.selectedObject,
+        ...(transaction.before.head ? [transaction.before.head] : [])
+      ])],
+      satisfied: true
+    }
+  };
+}
+
+async function assertRuntimeAndBrokerState(
+  execution: RepositoryTransactionPort,
+  context: PlannedToolExecutionContext,
+  transaction: PendingRepositoryTransaction,
+  after: RepositoryEvidenceState,
   result: RepositoryTransactionResultV2
-) {
+): Promise<CompletedAssertions> {
   const assertions = requireCompletedAssertions(result);
   if (after.head !== assertions.head
     || after.refsDigest !== assertions.refsDigest
@@ -38,18 +117,7 @@ function assertRuntimeAndBrokerState(
       "Broker and independently leased repository observations disagree."
     ), { code: "repository_postcondition_failed" });
   }
-  if (transaction.recoverySelection) {
-    const target = assertions.targetAssertions;
-    if (!target || target.satisfied !== true
-      || target.selectedHead !== transaction.recoverySelection.selectedObject
-      || assertions.head !== transaction.recoverySelection.selectedObject
-      || !target.requiredReachableObjects.includes(transaction.recoverySelection.selectedObject)) {
-      throw Object.assign(new Error(
-        "Repository recovery did not reach the runtime-authorized target."
-      ), { code: "repository_postcondition_failed" });
-    }
-  }
-  return assertions;
+  return await assertRecoveryState(execution, context, transaction, after, assertions);
 }
 
 async function abortAfterFailure(
@@ -129,7 +197,9 @@ export async function completedRepositoryReceipt(
     const after = await collectRepositoryEvidenceState(
       execution, transaction.topology, context.signal
     );
-    const assertions = assertRuntimeAndBrokerState(transaction, after, result);
+    const assertions = await assertRuntimeAndBrokerState(
+      execution, context, transaction, after, result
+    );
     const revisionDelta = await repositoryRevisionDelta(
       execution, transaction.topology, transaction.before.head, after.head, context.signal
     );

--- a/packages/agent-runtime/src/repository-transaction-recovery.ts
+++ b/packages/agent-runtime/src/repository-transaction-recovery.ts
@@ -15,6 +15,7 @@ export interface RecoveryBinding {
   selectionEvidenceId: string;
   selectedObject: string;
   selectedSymbolicRef: string | null;
+  integrationMode: "exact_head" | "merge";
 }
 
 function requireRecoverySelection(
@@ -82,13 +83,23 @@ export async function recoveryOperation(
       "Repository state changed after recovery selection; inspect again before recovery."
     ), { code: "repository_recovery_selection_stale" });
   }
+  if (candidate.relationToHead !== "descendant_of_head"
+    && candidate.relationToHead !== "diverged") {
+    throw Object.assign(new Error(
+      "The selected recovery candidate has no safe integration relation to the current HEAD."
+    ), { code: "repository_recovery_relation_unsupported" });
+  }
+  const integrationMode = candidate.relationToHead === "diverged" ? "merge" : "exact_head";
   return {
-    operation: { op: "reset", mode: "hard", target: selected.selectedObject },
+    operation: integrationMode === "merge"
+      ? { op: "merge", target: selected.selectedObject }
+      : { op: "reset", mode: "hard", target: selected.selectedObject },
     binding: {
       candidateId: input.candidateId!,
       selectionEvidenceId: input.selectionEvidenceId!,
       selectedObject: selected.selectedObject,
-      selectedSymbolicRef: current.symbolicRef
+      selectedSymbolicRef: current.symbolicRef,
+      integrationMode
     }
   };
 }

--- a/packages/agent-runtime/src/repository-transaction-state.ts
+++ b/packages/agent-runtime/src/repository-transaction-state.ts
@@ -60,6 +60,24 @@ export async function collectRepositoryEvidenceState(
   return { ...value, stateDigest: sha256(JSON.stringify(value)) };
 }
 
+export async function repositoryObjectIsAncestor(
+  execution: ProcessExecutionPort,
+  topology: RepositoryWorktreeTopology,
+  ancestor: string,
+  descendant: string,
+  signal: AbortSignal
+): Promise<boolean> {
+  const result = await runLeasedRepositoryGit(execution, topology, [
+    "merge-base", "--is-ancestor", ancestor, descendant
+  ], signal, 64 * 1024);
+  if (result.outputTruncated || (result.exitCode !== 0 && result.exitCode !== 1)) {
+    throw Object.assign(new Error("Repository ancestry postcondition could not be verified."), {
+      code: "repository_postcondition_failed"
+    });
+  }
+  return result.exitCode === 0;
+}
+
 /** Return only bounded, repository-relative unmerged paths. The broker-owned
  * transaction remains the mutation authority; this probe merely gives the
  * repair state machine an exact workspace scope. */

--- a/packages/agent-runtime/src/repository-transaction-tool.ts
+++ b/packages/agent-runtime/src/repository-transaction-tool.ts
@@ -175,12 +175,14 @@ async function beginTransaction(
     );
     operations = [recovery.operation];
     recoverySelection = recovery.binding;
-    expectedPostconditions = {
-      schemaVersion: 3 as const,
-      selectedHead: recovery.binding.selectedObject,
-      selectedSymbolicRef: recovery.binding.selectedSymbolicRef,
-      requiredReachableObjects: [recovery.binding.selectedObject]
-    };
+    if (recovery.binding.integrationMode === "exact_head") {
+      expectedPostconditions = {
+        schemaVersion: 3 as const,
+        selectedHead: recovery.binding.selectedObject,
+        selectedSymbolicRef: recovery.binding.selectedSymbolicRef,
+        requiredReachableObjects: [recovery.binding.selectedObject]
+      };
+    }
   }
   operations.forEach(gitOperationArgs);
   const before = await collectRepositoryEvidenceState(execution, topology, context.signal);

--- a/packages/agent-runtime/src/review-coordinator.ts
+++ b/packages/agent-runtime/src/review-coordinator.ts
@@ -1,5 +1,4 @@
 import { createHash, randomUUID } from "node:crypto";
-import path from "node:path";
 import type {
   BudgetReservation,
   InputAccessEvidence,
@@ -25,113 +24,17 @@ import {
   reviewInputFailureEvidence,
   type AccountableReviewerPort,
   type ReviewerInput,
-  type ReviewerPort,
-  type ReviewerWorkspaceRead
+  type ReviewerPort
 } from "./reviewer.js";
 import type { RuntimeEventEmitter } from "./runtime-event-emitter.js";
 import { reviewerWaivedDeltaIds } from "./review-waiver-policy.js";
 import { deadlineForecast } from "./convergence-policy.js";
 import { assuranceRequirement } from "./assurance-engine.js";
-
-const MAX_REVIEW_WORKSPACE_READS = 8;
-const MAX_REVIEW_WORKSPACE_READ_CHARS = 64_000;
-const MAX_REVIEW_WORKSPACE_READ_CHARS_PER_FILE = 24_000;
+import { goalReferencedWorkspaceReads } from "./reviewer-workspace-reads.js";
+export { goalReferencedWorkspaceReads } from "./reviewer-workspace-reads.js";
 
 function profileReviewMode(session: RuntimeSession): "off" | "advisory" | "required" {
   return session.services.profile?.profile.mutationPolicy.reviewMode ?? "advisory";
-}
-
-function record(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? value as Record<string, unknown> : null;
-}
-
-function normalizedWorkspacePath(value: string): string {
-  return value.replaceAll("\\", "/").replace(/^(?:\.\/)+/u, "");
-}
-
-function goalMentionsPath(goal: string, candidate: string): boolean {
-  const normalizedGoal = goal.replaceAll("\\", "/").toLowerCase();
-  const normalized = normalizedWorkspacePath(candidate).toLowerCase();
-  const basename = path.posix.basename(normalized);
-  return normalized.length >= 3 && normalizedGoal.includes(normalized)
-    || basename.length >= 3 && normalizedGoal.includes(basename);
-}
-
-function safeInteger(value: unknown): number | undefined {
-  return Number.isSafeInteger(value) ? Number(value) : undefined;
-}
-
-function workspaceReadMetadata(
-  result: Record<string, unknown>,
-  requestedPath: string
-): Omit<ReviewerWorkspaceRead, "content"> {
-  const offset = safeInteger(result.offset);
-  const returnedLines = safeInteger(result.returnedLines);
-  const totalLines = safeInteger(result.totalLines);
-  const metadata: Omit<ReviewerWorkspaceRead, "content"> = {
-    path: normalizedWorkspacePath(typeof result.path === "string" ? result.path : requestedPath),
-    complete: offset === 0 && returnedLines !== undefined
-      && totalLines !== undefined && returnedLines === totalLines
-  };
-  if (typeof result.sha256 === "string") metadata.sha256 = result.sha256;
-  const byteLength = safeInteger(result.byteLength);
-  if (byteLength !== undefined) metadata.byteLength = byteLength;
-  if (offset !== undefined) metadata.offset = offset;
-  if (returnedLines !== undefined) metadata.returnedLines = returnedLines;
-  if (totalLines !== undefined) metadata.totalLines = totalLines;
-  return metadata;
-}
-
-function workspaceReadSnapshot(
-  session: RuntimeSession,
-  callId: string,
-  requestedPath: string,
-  remainingChars: number
-): ReviewerWorkspaceRead | null {
-  const receipt = session.durable.state.receipts.find((item) => item.callId === callId);
-  const result = record(receipt?.result);
-  if (!receipt?.ok || !result || result.status !== "read" || result.scope !== "workspace") return null;
-  const available = Math.min(
-    MAX_REVIEW_WORKSPACE_READ_CHARS_PER_FILE,
-    Math.max(0, remainingChars)
-  );
-  if (available === 0) return null;
-  const content = receipt.output.slice(0, available);
-  const metadata = workspaceReadMetadata(result, requestedPath);
-  return {
-    ...metadata,
-    complete: metadata.complete && content.length === receipt.output.length,
-    content
-  };
-}
-
-export function goalReferencedWorkspaceReads(session: RuntimeSession): ReviewerWorkspaceRead[] {
-  const goal = session.durable.state.plan.goal;
-  const snapshots: ReviewerWorkspaceRead[] = [];
-  const seen = new Set<string>();
-  let characters = 0;
-  for (const message of session.durable.state.messages) {
-    if (message.role !== "assistant") continue;
-    for (const call of message.toolCalls ?? []) {
-      if (call.name !== "read" || snapshots.length >= MAX_REVIEW_WORKSPACE_READS) continue;
-      const argumentsValue = record(call.arguments);
-      const requestedPath = typeof argumentsValue?.path === "string" ? argumentsValue.path : "";
-      const normalized = normalizedWorkspacePath(requestedPath);
-      if (!normalized || seen.has(normalized.toLowerCase()) || !goalMentionsPath(goal, normalized)) continue;
-      const snapshot = workspaceReadSnapshot(
-        session,
-        call.id,
-        normalized,
-        MAX_REVIEW_WORKSPACE_READ_CHARS - characters
-      );
-      if (!snapshot) continue;
-      snapshots.push(snapshot);
-      seen.add(normalized.toLowerCase());
-      characters += snapshot.content.length;
-    }
-  }
-  return snapshots;
 }
 
 function normalizeReview(session: RuntimeSession, raw: ReviewEvidence, basisDigest: string): ReviewEvidence {

--- a/packages/agent-runtime/src/review-coordinator.ts
+++ b/packages/agent-runtime/src/review-coordinator.ts
@@ -1,4 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
+import path from "node:path";
 import type {
   BudgetReservation,
   InputAccessEvidence,
@@ -24,15 +25,113 @@ import {
   reviewInputFailureEvidence,
   type AccountableReviewerPort,
   type ReviewerInput,
-  type ReviewerPort
+  type ReviewerPort,
+  type ReviewerWorkspaceRead
 } from "./reviewer.js";
 import type { RuntimeEventEmitter } from "./runtime-event-emitter.js";
 import { reviewerWaivedDeltaIds } from "./review-waiver-policy.js";
 import { deadlineForecast } from "./convergence-policy.js";
 import { assuranceRequirement } from "./assurance-engine.js";
 
+const MAX_REVIEW_WORKSPACE_READS = 8;
+const MAX_REVIEW_WORKSPACE_READ_CHARS = 64_000;
+const MAX_REVIEW_WORKSPACE_READ_CHARS_PER_FILE = 24_000;
+
 function profileReviewMode(session: RuntimeSession): "off" | "advisory" | "required" {
   return session.services.profile?.profile.mutationPolicy.reviewMode ?? "advisory";
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown> : null;
+}
+
+function normalizedWorkspacePath(value: string): string {
+  return value.replaceAll("\\", "/").replace(/^(?:\.\/)+/u, "");
+}
+
+function goalMentionsPath(goal: string, candidate: string): boolean {
+  const normalizedGoal = goal.replaceAll("\\", "/").toLowerCase();
+  const normalized = normalizedWorkspacePath(candidate).toLowerCase();
+  const basename = path.posix.basename(normalized);
+  return normalized.length >= 3 && normalizedGoal.includes(normalized)
+    || basename.length >= 3 && normalizedGoal.includes(basename);
+}
+
+function safeInteger(value: unknown): number | undefined {
+  return Number.isSafeInteger(value) ? Number(value) : undefined;
+}
+
+function workspaceReadMetadata(
+  result: Record<string, unknown>,
+  requestedPath: string
+): Omit<ReviewerWorkspaceRead, "content"> {
+  const offset = safeInteger(result.offset);
+  const returnedLines = safeInteger(result.returnedLines);
+  const totalLines = safeInteger(result.totalLines);
+  const metadata: Omit<ReviewerWorkspaceRead, "content"> = {
+    path: normalizedWorkspacePath(typeof result.path === "string" ? result.path : requestedPath),
+    complete: offset === 0 && returnedLines !== undefined
+      && totalLines !== undefined && returnedLines === totalLines
+  };
+  if (typeof result.sha256 === "string") metadata.sha256 = result.sha256;
+  const byteLength = safeInteger(result.byteLength);
+  if (byteLength !== undefined) metadata.byteLength = byteLength;
+  if (offset !== undefined) metadata.offset = offset;
+  if (returnedLines !== undefined) metadata.returnedLines = returnedLines;
+  if (totalLines !== undefined) metadata.totalLines = totalLines;
+  return metadata;
+}
+
+function workspaceReadSnapshot(
+  session: RuntimeSession,
+  callId: string,
+  requestedPath: string,
+  remainingChars: number
+): ReviewerWorkspaceRead | null {
+  const receipt = session.durable.state.receipts.find((item) => item.callId === callId);
+  const result = record(receipt?.result);
+  if (!receipt?.ok || !result || result.status !== "read" || result.scope !== "workspace") return null;
+  const available = Math.min(
+    MAX_REVIEW_WORKSPACE_READ_CHARS_PER_FILE,
+    Math.max(0, remainingChars)
+  );
+  if (available === 0) return null;
+  const content = receipt.output.slice(0, available);
+  const metadata = workspaceReadMetadata(result, requestedPath);
+  return {
+    ...metadata,
+    complete: metadata.complete && content.length === receipt.output.length,
+    content
+  };
+}
+
+export function goalReferencedWorkspaceReads(session: RuntimeSession): ReviewerWorkspaceRead[] {
+  const goal = session.durable.state.plan.goal;
+  const snapshots: ReviewerWorkspaceRead[] = [];
+  const seen = new Set<string>();
+  let characters = 0;
+  for (const message of session.durable.state.messages) {
+    if (message.role !== "assistant") continue;
+    for (const call of message.toolCalls ?? []) {
+      if (call.name !== "read" || snapshots.length >= MAX_REVIEW_WORKSPACE_READS) continue;
+      const argumentsValue = record(call.arguments);
+      const requestedPath = typeof argumentsValue?.path === "string" ? argumentsValue.path : "";
+      const normalized = normalizedWorkspacePath(requestedPath);
+      if (!normalized || seen.has(normalized.toLowerCase()) || !goalMentionsPath(goal, normalized)) continue;
+      const snapshot = workspaceReadSnapshot(
+        session,
+        call.id,
+        normalized,
+        MAX_REVIEW_WORKSPACE_READ_CHARS - characters
+      );
+      if (!snapshot) continue;
+      snapshots.push(snapshot);
+      seen.add(normalized.toLowerCase());
+      characters += snapshot.content.length;
+    }
+  }
+  return snapshots;
 }
 
 function normalizeReview(session: RuntimeSession, raw: ReviewEvidence, basisDigest: string): ReviewEvidence {
@@ -200,6 +299,7 @@ function reviewerInput(
     } : {}),
     workspaceDeltas: attempt.eligible,
     validations: attempt.relevantValidations,
+    goalReferencedWorkspaceReads: goalReferencedWorkspaceReads(session),
     inputAccesses: session.durable.state.evidence.filter((item): item is InputAccessEvidence =>
       item.kind === "input_access" && item.runId === session.durable.runId)
   };

--- a/packages/agent-runtime/src/reviewer-workspace-reads.ts
+++ b/packages/agent-runtime/src/reviewer-workspace-reads.ts
@@ -1,0 +1,181 @@
+import path from "node:path";
+import type { RuntimeSession } from "./types.js";
+import type { ReviewerWorkspaceRead } from "./reviewer.js";
+
+const MAX_REVIEW_WORKSPACE_READS = 8;
+const MAX_REVIEW_WORKSPACE_READ_CHARS = 64_000;
+const MAX_REVIEW_WORKSPACE_READ_CHARS_PER_FILE = 24_000;
+
+interface WorkspaceReadCandidate {
+  key: string;
+  snapshot: ReviewerWorkspaceRead;
+  receiptIndex: number;
+}
+
+interface RecordedToolCall {
+  id: string;
+  name: string;
+  arguments: unknown;
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown> : null;
+}
+
+function normalizedWorkspacePath(value: string): string {
+  return value.replaceAll("\\", "/").replace(/^(?:\.\/)+/u, "");
+}
+
+function goalMentionsPath(goal: string, candidate: string): boolean {
+  const normalizedGoal = goal.replaceAll("\\", "/").toLowerCase();
+  const normalized = normalizedWorkspacePath(candidate).toLowerCase();
+  const basename = path.posix.basename(normalized);
+  return normalized.length >= 3 && normalizedGoal.includes(normalized)
+    || basename.length >= 3 && normalizedGoal.includes(basename);
+}
+
+function safeInteger(value: unknown): number | undefined {
+  return Number.isSafeInteger(value) ? Number(value) : undefined;
+}
+
+function workspaceReadMetadata(
+  result: Record<string, unknown>,
+  requestedPath: string
+): Omit<ReviewerWorkspaceRead, "content"> {
+  const offset = safeInteger(result.offset);
+  const returnedLines = safeInteger(result.returnedLines);
+  const totalLines = safeInteger(result.totalLines);
+  const metadata: Omit<ReviewerWorkspaceRead, "content"> = {
+    path: normalizedWorkspacePath(typeof result.path === "string" ? result.path : requestedPath),
+    complete: offset === 0 && returnedLines !== undefined
+      && totalLines !== undefined && returnedLines === totalLines
+  };
+  if (typeof result.sha256 === "string") metadata.sha256 = result.sha256;
+  const byteLength = safeInteger(result.byteLength);
+  if (byteLength !== undefined) metadata.byteLength = byteLength;
+  if (offset !== undefined) metadata.offset = offset;
+  if (returnedLines !== undefined) metadata.returnedLines = returnedLines;
+  if (totalLines !== undefined) metadata.totalLines = totalLines;
+  return metadata;
+}
+
+function workspaceReadSnapshot(
+  session: RuntimeSession,
+  callId: string,
+  requestedPath: string
+): ReviewerWorkspaceRead | null {
+  const receipt = session.durable.state.receipts.find((item) => item.callId === callId);
+  const result = record(receipt?.result);
+  if (!receipt?.ok || !result || result.status !== "read" || result.scope !== "workspace") return null;
+  const content = receipt.output.slice(0, MAX_REVIEW_WORKSPACE_READ_CHARS_PER_FILE);
+  const metadata = workspaceReadMetadata(result, requestedPath);
+  return {
+    ...metadata,
+    complete: metadata.complete && content.length === receipt.output.length,
+    content
+  };
+}
+
+function lastWorkspaceMutationByPath(session: RuntimeSession): Map<string, number> {
+  const lastMutationByPath = new Map<string, number>();
+  for (const [index, receipt] of session.durable.state.receipts.entries()) {
+    const delta = receipt.workspaceDelta;
+    for (const changedPath of [
+      ...(delta?.added ?? []),
+      ...(delta?.modified ?? []),
+      ...(delta?.deleted ?? [])
+    ]) {
+      lastMutationByPath.set(normalizedWorkspacePath(changedPath).toLowerCase(), index);
+    }
+  }
+  return lastMutationByPath;
+}
+
+function recordedAssistantToolCalls(session: RuntimeSession): RecordedToolCall[] {
+  const calls: RecordedToolCall[] = [];
+  for (const message of session.durable.state.messages) {
+    if (message.role !== "assistant") continue;
+    calls.push(...(message.toolCalls ?? []));
+  }
+  return calls;
+}
+
+function workspaceReadCandidate(
+  session: RuntimeSession,
+  call: RecordedToolCall,
+  goal: string,
+  receiptPositions: ReadonlyMap<string, number>
+): WorkspaceReadCandidate | null {
+  if (call.name !== "read") return null;
+  const argumentsValue = record(call.arguments);
+  const requestedPath = typeof argumentsValue?.path === "string" ? argumentsValue.path : "";
+  const normalized = normalizedWorkspacePath(requestedPath);
+  if (!normalized || !goalMentionsPath(goal, normalized)) return null;
+  const snapshot = workspaceReadSnapshot(session, call.id, normalized);
+  const receiptIndex = receiptPositions.get(call.id);
+  if (!snapshot || receiptIndex === undefined) return null;
+  return {
+    key: normalizedWorkspacePath(snapshot.path).toLowerCase(),
+    snapshot,
+    receiptIndex
+  };
+}
+
+function preferredWorkspaceRead(
+  previous: WorkspaceReadCandidate | undefined,
+  candidate: WorkspaceReadCandidate
+): WorkspaceReadCandidate {
+  if (!previous || candidate.receiptIndex <= previous.receiptIndex) return previous ?? candidate;
+  const sameContent = previous.snapshot.sha256 !== undefined
+    && previous.snapshot.sha256 === candidate.snapshot.sha256;
+  // A later partial read can prove that an earlier complete snapshot is
+  // still current when both receipts carry the same authenticated digest.
+  // Otherwise the latest read must win, even when it is incomplete.
+  return sameContent && previous.snapshot.complete && !candidate.snapshot.complete
+    ? { ...previous, receiptIndex: candidate.receiptIndex }
+    : candidate;
+}
+
+function boundedCurrentWorkspaceReads(
+  selected: ReadonlyMap<string, WorkspaceReadCandidate>,
+  lastMutationByPath: ReadonlyMap<string, number>
+): ReviewerWorkspaceRead[] {
+  const current = [...selected.values()]
+    .filter((candidate) =>
+      candidate.receiptIndex > (lastMutationByPath.get(candidate.key) ?? -1))
+    .sort((left, right) => right.receiptIndex - left.receiptIndex)
+    .slice(0, MAX_REVIEW_WORKSPACE_READS);
+  const snapshots: ReviewerWorkspaceRead[] = [];
+  let remainingChars = MAX_REVIEW_WORKSPACE_READ_CHARS;
+  for (const candidate of current) {
+    if (remainingChars === 0) break;
+    const content = candidate.snapshot.content.slice(0, remainingChars);
+    snapshots.push({
+      ...candidate.snapshot,
+      complete: candidate.snapshot.complete
+        && content.length === candidate.snapshot.content.length,
+      content
+    });
+    remainingChars -= content.length;
+  }
+  return snapshots;
+}
+
+export function goalReferencedWorkspaceReads(session: RuntimeSession): ReviewerWorkspaceRead[] {
+  const receiptPositions = new Map(
+    session.durable.state.receipts.map((receipt, index) => [receipt.callId, index])
+  );
+  const selected = new Map<string, WorkspaceReadCandidate>();
+  for (const call of recordedAssistantToolCalls(session)) {
+    const candidate = workspaceReadCandidate(
+      session,
+      call,
+      session.durable.state.plan.goal,
+      receiptPositions
+    );
+    if (!candidate) continue;
+    selected.set(candidate.key, preferredWorkspaceRead(selected.get(candidate.key), candidate));
+  }
+  return boundedCurrentWorkspaceReads(selected, lastWorkspaceMutationByPath(session));
+}

--- a/packages/agent-runtime/src/reviewer.ts
+++ b/packages/agent-runtime/src/reviewer.ts
@@ -36,6 +36,18 @@ export interface ReviewerInput {
   workspaceDeltas: WorkspaceDeltaEvidence[];
   validations: ValidationEvidence[];
   inputAccesses?: InputAccessEvidence[];
+  goalReferencedWorkspaceReads?: ReviewerWorkspaceRead[];
+}
+
+export interface ReviewerWorkspaceRead {
+  path: string;
+  sha256?: string;
+  byteLength?: number;
+  offset?: number;
+  returnedLines?: number;
+  totalLines?: number;
+  complete: boolean;
+  content: string;
 }
 
 export interface ReviewerPort {
@@ -223,7 +235,7 @@ export class ModelReviewer implements ReviewerPort {
 function reviewMessages(input: ReviewerInput): ModelMessage[] {
   return [{
     role: "system",
-    content: "You are Sigma's independent read-only code reviewer. Review only the supplied goal, durable workspace delta, input-access evidence, validation evidence, and optional completion candidate. Evaluate every explicit goal dimension in one pass, including correctness, performance, format, and delivery behavior when the goal mentions them; do not stop after the first missing proof. A failed validation is a real correctness signal: never describe it as passed or treat review approval as validation_passed. In completion mode, an exited failed validation may prove that a user-requested check was executed and honestly reported; approve only when the goal is satisfied by observing/reporting that result and the completion candidate accurately states the failure. If the goal requires working behavior or a passing check, request repair instead. Absence of input-access evidence is not itself a failure; only a recorded failed access to a required user-declared input is actionable. Never accept a run-created sample or fixture as a substitute for a user-declared external input whose access failed. A user-visible configuration or policy value that was neither specified by the goal nor supported by supplied workspace evidence is an actionable error with code user_decision_required; direct the agent to restore speculative changes and ask one focused question. Check that each validation command plausibly exercises every workspace delta linked to it; a file-specific syntax check cannot establish unrelated files or runtime behavior. Complete opaque or content-omitted artifacts are reviewable by workspace path, SHA-256, size, checkpoint-bound delta, and passed validation, but their hidden content must not be claimed as inspected. Return strict JSON: {\"verdict\":\"approved\"|\"changes_requested\",\"findings\":[{\"actionable\":boolean,\"severity\":\"error\"|\"warning\"|\"info\",\"summary\":string,\"code\":string optional}]}. Set changes_requested only when at least one finding is both actionable=true and severity=error. Positive observations must be non-actionable info findings. Never claim to have edited files."
+    content: "You are Sigma's independent read-only code reviewer. Review only the supplied goal, durable workspace delta, input-access evidence, goal-referenced workspace read snapshots, validation evidence, and optional completion candidate. Evaluate every explicit goal dimension in one pass, including correctness, performance, format, and delivery behavior when the goal mentions them; do not stop after the first missing proof. When the goal constrains changes by another workspace file, use complete goal-referenced read snapshots to verify the final delta against that file; if required snapshot evidence is absent or incomplete, request a focused validation instead of assuming compliance. In completion mode, compare factual claims in the completion candidate with the full supplied delta; materially omitting or understating changes is actionable. A failed validation is a real correctness signal: never describe it as passed or treat review approval as validation_passed. In completion mode, an exited failed validation may prove that a user-requested check was executed and honestly reported; approve only when the goal is satisfied by observing/reporting that result and the completion candidate accurately states the failure. If the goal requires working behavior or a passing check, request repair instead. Absence of input-access evidence is not itself a failure; only a recorded failed access to a required user-declared input is actionable. Never accept a run-created sample or fixture as a substitute for a user-declared external input whose access failed. A user-visible configuration or policy value that was neither specified by the goal nor supported by supplied workspace evidence is an actionable error with code user_decision_required; direct the agent to restore speculative changes and ask one focused question. Check that each validation command plausibly exercises every workspace delta linked to it; a file-specific syntax check cannot establish unrelated files or runtime behavior. Complete opaque or content-omitted artifacts are reviewable by workspace path, SHA-256, size, checkpoint-bound delta, and passed validation, but their hidden content must not be claimed as inspected. Return strict JSON: {\"verdict\":\"approved\"|\"changes_requested\",\"findings\":[{\"actionable\":boolean,\"severity\":\"error\"|\"warning\"|\"info\",\"summary\":string,\"code\":string optional}]}. Set changes_requested only when at least one finding is both actionable=true and severity=error. Positive observations must be non-actionable info findings. Never claim to have edited files."
   }, {
     role: "user",
     content: JSON.stringify({
@@ -239,6 +251,7 @@ function reviewMessages(input: ReviewerInput): ModelMessage[] {
           }
         : {}),
       inputAccesses: input.inputAccesses ?? [],
+      goalReferencedWorkspaceReads: input.goalReferencedWorkspaceReads ?? [],
       workspaceDeltas: input.workspaceDeltas.map((item) => ({
         evidenceId: item.evidenceId,
         checkpointId: item.data.checkpointId,

--- a/packages/agent-runtime/src/semantic-validation-command.ts
+++ b/packages/agent-runtime/src/semantic-validation-command.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import type { ValidationClaimKindV1 } from "agent-protocol";
+import { shellSemanticValidation } from "./semantic-validation-shell.js";
 
 export interface SemanticValidationCommand {
   executable: string;
@@ -216,83 +217,23 @@ function inlinePythonScript(args: string[]): string | undefined {
   return index >= 0 ? args[index + 1] : undefined;
 }
 
-function pythonLiteralPathCandidates(script: string): string[] {
-  const candidates: string[] = [];
-  const patterns = [
-    /\b(?:open|Path|compile)\s*\(\s*(["'])((?:\\.|(?!\1)[^\\])*?)\1/gu,
-    /\bpy_compile\.compile\s*\(\s*(["'])((?:\\.|(?!\1)[^\\])*?)\1/gu
-  ];
-  for (const pattern of patterns) {
-    for (const match of script.matchAll(pattern)) {
-      const quote = match[1];
-      const raw = match[2];
-      if (!quote || raw === undefined) continue;
-      const value = decodeLiteralPath(raw, quote);
-      if (value !== undefined && /\.(?:py|pyw)$/iu.test(value)) candidates.push(value);
-    }
-  }
-  return [...new Set(candidates)].sort();
-}
-
 function pythonClaimKind(args: string[]): ValidationClaimKindV1 | undefined {
+  // Inline Python is an open-ended program. A text scan cannot distinguish
+  // executable assertions from comments or string literals, nor prove that a
+  // caught exception affects the process exit status. Structured module and
+  // file invocations remain classifiable below.
+  if (inlinePythonScript(args) !== undefined) return undefined;
   const moduleIndex = args.findIndex((item) => item === "-m");
   const moduleName = moduleIndex >= 0 ? args[moduleIndex + 1]?.toLowerCase() : undefined;
   if (moduleName === "pytest" || moduleName === "unittest") return "unit";
   if (moduleName === "py_compile" || moduleName === "compileall") return "syntax";
-  const inline = inlinePythonScript(args);
-  if (inline !== undefined) {
-    if (/\b(?:assert|raise)\b|\bsys\.exit\s*\(\s*(?!0\b)/u.test(inline)) return "unit";
-    if (/\b(?:py_compile\.compile|compileall\.compile_(?:file|dir))\b/u.test(inline)) return "syntax";
-    return undefined;
-  }
   const script = args.find((item) => !item.startsWith("-") && /\.(?:py|pyw)$/iu.test(item));
   return script ? nodeScriptClaimKind(script) : undefined;
 }
 
 function pythonExactPathCandidates(args: string[]): string[] {
-  const inline = inlinePythonScript(args);
-  if (inline !== undefined) return pythonLiteralPathCandidates(inline);
+  if (inlinePythonScript(args) !== undefined) return [];
   return args.filter((item) => !item.startsWith("-") && /\.(?:py|pyw)$/iu.test(item));
-}
-
-function shellWorkingDirectory(script: string): string | undefined {
-  const match = script.match(/^\s*cd\s+(?:"([^"]+)"|'([^']+)'|([^\s;&|]+))\s*&&/u);
-  return match?.[1] ?? match?.[2] ?? match?.[3];
-}
-
-function shellExecutedSourceCandidates(script: string): string[] {
-  const directory = shellWorkingDirectory(script);
-  const candidates: string[] = [];
-  const invocation = /\b(?:python(?:\d+(?:\.\d+)*)?|node|ruby|perl|php)\s+(?:-[A-Za-z]+\s+)*(?:"([^"]+)"|'([^']+)'|([^\s;&|()<>]+))/gu;
-  for (const match of script.matchAll(invocation)) {
-    const candidate = match[1] ?? match[2] ?? match[3];
-    if (!candidate || !/\.(?:py|pyw|[cm]?js|mjs|cjs|rb|pl|php)$/iu.test(candidate)) continue;
-    candidates.push(directory && !path.isAbsolute(candidate) ? path.join(directory, candidate) : candidate);
-  }
-  return [...new Set(candidates)].sort();
-}
-
-function shellRunsUnitFramework(script: string): boolean {
-  return /(?:^|[;&|()]\s*|\s)(?:pytest|python(?:\d+(?:\.\d+)*)?\s+-m\s+(?:pytest|unittest)|node\s+--test|vitest|jest|mocha)(?:\s|$)/iu
-    .test(script);
-}
-
-function strictShellComparison(script: string): boolean {
-  if (script.includes("||") || script.includes(";")) return false;
-  return script.includes("&&")
-    && /(?:^|&&|\|)\s*(?:diff|cmp)(?:\s|$)/u.test(script);
-}
-
-function shellSemanticValidation(script: string): {
-  kind?: ValidationClaimKindV1;
-  exactPathCandidates: string[];
-} {
-  const exactPathCandidates = shellExecutedSourceCandidates(script);
-  if (shellRunsUnitFramework(script)) return { kind: "unit", exactPathCandidates };
-  if (exactPathCandidates.length > 0 && strictShellComparison(script)) {
-    return { kind: "unit", exactPathCandidates };
-  }
-  return { exactPathCandidates: [] };
 }
 
 function nodeClaimKind(args: string[]): ValidationClaimKindV1 | undefined {

--- a/packages/agent-runtime/src/semantic-validation-command.ts
+++ b/packages/agent-runtime/src/semantic-validation-command.ts
@@ -4,11 +4,115 @@ import type { ValidationClaimKindV1 } from "agent-protocol";
 export interface SemanticValidationCommand {
   executable: string;
   kind: ValidationClaimKindV1;
-  inlineExactPathCandidates: string[];
+  exactPathCandidates: string[];
 }
 
 function executableName(value: string): string {
   return path.basename(value).toLowerCase().replace(/\.(?:exe|cmd|bat|ps1)$/u, "");
+}
+
+const DIRECT_COMPILER_INPUTS: Readonly<Record<string, RegExp>> = {
+  coqc: /\.v$/iu,
+  cobc: /\.(?:cbl|cob|cpy)$/iu,
+  cc: /\.(?:c|cc|cpp|cxx|m|mm|s|asm)$/iu,
+  "c++": /\.(?:c|cc|cpp|cxx|m|mm|s|asm)$/iu,
+  gcc: /\.(?:c|cc|cpp|cxx|m|mm|s|asm)$/iu,
+  "g++": /\.(?:c|cc|cpp|cxx|m|mm|s|asm)$/iu,
+  clang: /\.(?:c|cc|cpp|cxx|m|mm|s|asm)$/iu,
+  "clang++": /\.(?:c|cc|cpp|cxx|m|mm|s|asm)$/iu,
+  rustc: /\.rs$/iu,
+  javac: /\.java$/iu,
+  kotlinc: /\.(?:kt|kts)$/iu,
+  swiftc: /\.swift$/iu,
+  scalac: /\.scala$/iu,
+  ghc: /\.(?:hs|lhs)$/iu,
+  ocamlc: /\.(?:ml|mli)$/iu,
+  ocamlopt: /\.(?:ml|mli)$/iu,
+  csc: /\.cs$/iu,
+  mcs: /\.cs$/iu,
+  fpc: /\.(?:pas|pp)$/iu,
+  gfortran: /\.(?:f|for|f77|f90|f95|f03|f08)$/iu,
+  flang: /\.(?:f|for|f77|f90|f95|f03|f08)$/iu,
+  erlc: /\.erl$/iu
+};
+
+const TRANSITIVE_COMPILER_INPUTS: Readonly<Record<string, RegExp>> = {
+  latex: /\.(?:tex|dtx|ins)$/iu,
+  pdflatex: /\.(?:tex|dtx|ins)$/iu,
+  xelatex: /\.(?:tex|dtx|ins)$/iu,
+  lualatex: /\.(?:tex|dtx|ins)$/iu,
+  latexmk: /\.(?:tex|dtx|ins)$/iu,
+  tectonic: /\.(?:tex|dtx|ins)$/iu
+};
+
+function sourcePathCandidates(args: string[], pattern: RegExp | undefined): string[] {
+  if (!pattern) return [];
+  return [...new Set(args.flatMap((argument) => {
+    if (!argument || argument.startsWith("-")) return [];
+    const candidate = argument.replace(/[;|]+$/u, "");
+    return pattern.test(candidate) ? [candidate] : [];
+  }))].sort();
+}
+
+function explicitOutputPathCandidates(args: string[]): string[] {
+  const candidates: string[] = [];
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index] ?? "";
+    if (argument === "-o" || argument === "--output") {
+      const value = args[index + 1];
+      if (value && !value.startsWith("-")) candidates.push(value);
+      index += 1;
+      continue;
+    }
+    const long = argument.match(/^--output=(.+)$/u);
+    if (long?.[1]) {
+      candidates.push(long[1]);
+      continue;
+    }
+    const short = argument.match(/^-o(.+)$/u);
+    if (short?.[1]) {
+      candidates.push(short[1]);
+      continue;
+    }
+    const colon = argument.match(/^(?:\/out:|-out:)(.+)$/iu);
+    if (colon?.[1]) candidates.push(colon[1]);
+  }
+  return candidates;
+}
+
+function replaceExtension(value: string, extension: string): string {
+  const parsed = path.parse(value);
+  return path.join(parsed.dir, `${parsed.name}${extension}`);
+}
+
+function conventionalCompilerOutputPathCandidates(
+  executable: string,
+  sources: readonly string[]
+): string[] {
+  if (executable !== "coqc") return [];
+  return sources.flatMap((source) => [
+    replaceExtension(source, ".vo"),
+    replaceExtension(source, ".vok"),
+    replaceExtension(source, ".vos"),
+    replaceExtension(source, ".glob"),
+    path.join(path.dirname(source), `.${path.parse(source).name}.aux`)
+  ]);
+}
+
+function compilerExactPathCandidates(executable: string, args: string[]): string[] {
+  const sources = sourcePathCandidates(args, DIRECT_COMPILER_INPUTS[executable]);
+  if (sources.length === 0) return [];
+  return [...new Set([
+    ...sources,
+    ...explicitOutputPathCandidates(args),
+    ...conventionalCompilerOutputPathCandidates(executable, sources)
+  ])].sort();
+}
+
+function compilerClaimKind(executable: string, args: string[]): ValidationClaimKindV1 | undefined {
+  if (compilerExactPathCandidates(executable, args).length > 0) return "acceptance";
+  return sourcePathCandidates(args, TRANSITIVE_COMPILER_INPUTS[executable]).length > 0
+    ? "acceptance" : undefined;
 }
 
 function scriptName(executable: string, args: string[]): string | undefined {
@@ -107,6 +211,90 @@ function inlineExactPathCandidates(args: string[]): string[] {
   }))].sort();
 }
 
+function inlinePythonScript(args: string[]): string | undefined {
+  const index = args.findIndex((item) => item === "-c");
+  return index >= 0 ? args[index + 1] : undefined;
+}
+
+function pythonLiteralPathCandidates(script: string): string[] {
+  const candidates: string[] = [];
+  const patterns = [
+    /\b(?:open|Path|compile)\s*\(\s*(["'])((?:\\.|(?!\1)[^\\])*?)\1/gu,
+    /\bpy_compile\.compile\s*\(\s*(["'])((?:\\.|(?!\1)[^\\])*?)\1/gu
+  ];
+  for (const pattern of patterns) {
+    for (const match of script.matchAll(pattern)) {
+      const quote = match[1];
+      const raw = match[2];
+      if (!quote || raw === undefined) continue;
+      const value = decodeLiteralPath(raw, quote);
+      if (value !== undefined && /\.(?:py|pyw)$/iu.test(value)) candidates.push(value);
+    }
+  }
+  return [...new Set(candidates)].sort();
+}
+
+function pythonClaimKind(args: string[]): ValidationClaimKindV1 | undefined {
+  const moduleIndex = args.findIndex((item) => item === "-m");
+  const moduleName = moduleIndex >= 0 ? args[moduleIndex + 1]?.toLowerCase() : undefined;
+  if (moduleName === "pytest" || moduleName === "unittest") return "unit";
+  if (moduleName === "py_compile" || moduleName === "compileall") return "syntax";
+  const inline = inlinePythonScript(args);
+  if (inline !== undefined) {
+    if (/\b(?:assert|raise)\b|\bsys\.exit\s*\(\s*(?!0\b)/u.test(inline)) return "unit";
+    if (/\b(?:py_compile\.compile|compileall\.compile_(?:file|dir))\b/u.test(inline)) return "syntax";
+    return undefined;
+  }
+  const script = args.find((item) => !item.startsWith("-") && /\.(?:py|pyw)$/iu.test(item));
+  return script ? nodeScriptClaimKind(script) : undefined;
+}
+
+function pythonExactPathCandidates(args: string[]): string[] {
+  const inline = inlinePythonScript(args);
+  if (inline !== undefined) return pythonLiteralPathCandidates(inline);
+  return args.filter((item) => !item.startsWith("-") && /\.(?:py|pyw)$/iu.test(item));
+}
+
+function shellWorkingDirectory(script: string): string | undefined {
+  const match = script.match(/^\s*cd\s+(?:"([^"]+)"|'([^']+)'|([^\s;&|]+))\s*&&/u);
+  return match?.[1] ?? match?.[2] ?? match?.[3];
+}
+
+function shellExecutedSourceCandidates(script: string): string[] {
+  const directory = shellWorkingDirectory(script);
+  const candidates: string[] = [];
+  const invocation = /\b(?:python(?:\d+(?:\.\d+)*)?|node|ruby|perl|php)\s+(?:-[A-Za-z]+\s+)*(?:"([^"]+)"|'([^']+)'|([^\s;&|()<>]+))/gu;
+  for (const match of script.matchAll(invocation)) {
+    const candidate = match[1] ?? match[2] ?? match[3];
+    if (!candidate || !/\.(?:py|pyw|[cm]?js|mjs|cjs|rb|pl|php)$/iu.test(candidate)) continue;
+    candidates.push(directory && !path.isAbsolute(candidate) ? path.join(directory, candidate) : candidate);
+  }
+  return [...new Set(candidates)].sort();
+}
+
+function shellRunsUnitFramework(script: string): boolean {
+  return /(?:^|[;&|()]\s*|\s)(?:pytest|python(?:\d+(?:\.\d+)*)?\s+-m\s+(?:pytest|unittest)|node\s+--test|vitest|jest|mocha)(?:\s|$)/iu
+    .test(script);
+}
+
+function strictShellComparison(script: string): boolean {
+  if (script.includes("||") || script.includes(";")) return false;
+  return script.includes("&&")
+    && /(?:^|&&|\|)\s*(?:diff|cmp)(?:\s|$)/u.test(script);
+}
+
+function shellSemanticValidation(script: string): {
+  kind?: ValidationClaimKindV1;
+  exactPathCandidates: string[];
+} {
+  const exactPathCandidates = shellExecutedSourceCandidates(script);
+  if (shellRunsUnitFramework(script)) return { kind: "unit", exactPathCandidates };
+  if (exactPathCandidates.length > 0 && strictShellComparison(script)) {
+    return { kind: "unit", exactPathCandidates };
+  }
+  return { exactPathCandidates: [] };
+}
+
 function nodeClaimKind(args: string[]): ValidationClaimKindV1 | undefined {
   if (args.some((item) => item === "--test" || item.startsWith("--test="))) return "unit";
   if (args[0] === "--check") return "syntax";
@@ -115,12 +303,7 @@ function nodeClaimKind(args: string[]): ValidationClaimKindV1 | undefined {
   return script ? nodeScriptClaimKind(script) : undefined;
 }
 
-function claimKind(executable: string, args: string[]): ValidationClaimKindV1 {
-  if (executable === "node") return nodeClaimKind(args) ?? "probe";
-  if (executable === "tsc" || args.some((item) => executableName(item) === "tsc")) return "typecheck";
-  if (["eslint", "biome", "stylelint", "ruff"].includes(executable)) return "lint";
-  if (["vitest", "jest", "mocha", "pytest", "cargo-test"].includes(executable)) return "unit";
-  if (executable === "cargo") return cargoClaimKind(args) ?? "probe";
+function packageScriptClaimKind(executable: string, args: string[]): ValidationClaimKindV1 {
   const script = scriptName(executable, args);
   if (!script) return "probe";
   if (/integration|e2e/u.test(script)) return "integration";
@@ -131,14 +314,35 @@ function claimKind(executable: string, args: string[]): ValidationClaimKindV1 {
   return "probe";
 }
 
+function claimKind(executable: string, args: string[]): ValidationClaimKindV1 {
+  if (executable === "node") return nodeClaimKind(args) ?? "probe";
+  if (/^python(?:\d+(?:\.\d+)*)?$/u.test(executable)) return pythonClaimKind(args) ?? "probe";
+  if (executable === "tsc" || args.some((item) => executableName(item) === "tsc")) return "typecheck";
+  if (["eslint", "biome", "stylelint", "ruff"].includes(executable)) return "lint";
+  if (["vitest", "jest", "mocha", "pytest", "cargo-test"].includes(executable)) return "unit";
+  if (executable === "cargo") return cargoClaimKind(args) ?? "probe";
+  return compilerClaimKind(executable, args) ?? packageScriptClaimKind(executable, args);
+}
+
 export function semanticValidationCommand(
   executableValue: string,
-  args: string[]
+  args: string[],
+  shellScript?: string
 ): SemanticValidationCommand {
   const executable = executableName(executableValue);
+  const shell = shellScript ? shellSemanticValidation(shellScript) : undefined;
+  const pythonKind = /^python(?:\d+(?:\.\d+)*)?$/u.test(executable)
+    ? pythonClaimKind(args) : undefined;
+  const pythonCandidates = pythonKind ? pythonExactPathCandidates(args) : [];
   return {
     executable,
-    kind: claimKind(executable, args),
-    inlineExactPathCandidates: executable === "node" ? inlineExactPathCandidates(args) : []
+    kind: shell?.kind ?? claimKind(executable, args),
+    exactPathCandidates: shell?.kind
+      ? shell.exactPathCandidates
+      : executable === "node"
+        ? inlineExactPathCandidates(args)
+        : pythonCandidates.length > 0
+          ? pythonCandidates
+          : compilerExactPathCandidates(executable, args)
   };
 }

--- a/packages/agent-runtime/src/semantic-validation-shell.ts
+++ b/packages/agent-runtime/src/semantic-validation-shell.ts
@@ -1,0 +1,208 @@
+import path from "node:path";
+import type { ValidationClaimKindV1 } from "agent-protocol";
+
+type ShellQuote = "'" | "\"" | null;
+
+function executableName(value: string): string {
+  return path.basename(value).toLowerCase().replace(/\.(?:exe|cmd|bat|ps1)$/u, "");
+}
+
+function quotedShellCharacter(
+  script: string,
+  index: number,
+  quote: Exclude<ShellQuote, null>
+): { text: string; nextIndex: number; quote: ShellQuote } {
+  const character = script[index]!;
+  if (character === quote) return { text: character, nextIndex: index, quote: null };
+  if (character === "\\" && quote === "\"" && index + 1 < script.length) {
+    return {
+      text: character + script[index + 1]!,
+      nextIndex: index + 1,
+      quote
+    };
+  }
+  return { text: character, nextIndex: index, quote };
+}
+
+function unsafeUnquotedShellCharacter(script: string, index: number): boolean {
+  const character = script[index]!;
+  return character === "\r" || character === "\n" || character === ";"
+    || character === "|" || character === "(" || character === ")"
+    || character === "`" || script.startsWith("$(", index);
+}
+
+function escapedShellCharacter(
+  script: string,
+  index: number
+): { text: string; nextIndex: number } | null {
+  const next = script[index + 1];
+  if (next === "\r" || next === "\n") return null;
+  return {
+    text: next === undefined ? "\\" : `\\${next}`,
+    nextIndex: next === undefined ? index : index + 1
+  };
+}
+
+function shellAmpersandKind(
+  script: string,
+  index: number,
+  hasCurrentSegment: boolean
+): "literal" | "separator" | "invalid" {
+  const previous = script[index - 1];
+  const next = script[index + 1];
+  if (previous === ">" || previous === "<" || next === ">") return "literal";
+  return next === "&" && hasCurrentSegment ? "separator" : "invalid";
+}
+
+/** Return commands joined only by unmasked `&&`. Other shell control forms can
+ * replace a failing command's status, so they are never semantic validation. */
+function strictAndShellSegments(script: string): string[] | null {
+  const segments: string[] = [];
+  let current = "";
+  let quote: ShellQuote = null;
+  for (let index = 0; index < script.length; index += 1) {
+    const character = script[index]!;
+    if (quote) {
+      const scanned = quotedShellCharacter(script, index, quote);
+      current += scanned.text;
+      quote = scanned.quote;
+      index = scanned.nextIndex;
+      continue;
+    }
+    if (character === "'" || character === "\"") {
+      quote = character;
+      current += character;
+      continue;
+    }
+    if (unsafeUnquotedShellCharacter(script, index)) return null;
+    if (character === "\\") {
+      const scanned = escapedShellCharacter(script, index);
+      if (!scanned) return null;
+      current += scanned.text;
+      index = scanned.nextIndex;
+      continue;
+    }
+    if (character === "&") {
+      const kind = shellAmpersandKind(script, index, Boolean(current.trim()));
+      if (kind === "literal") {
+        current += character;
+        continue;
+      }
+      if (kind === "invalid") return null;
+      segments.push(current.trim());
+      current = "";
+      index += 1;
+      continue;
+    }
+    current += character;
+  }
+  if (quote || !current.trim()) return null;
+  segments.push(current.trim());
+  return segments;
+}
+
+function shellSegmentWords(command: string): string[] {
+  const words: string[] = [];
+  const pattern = /"([^"\\]*(?:\\.[^"\\]*)*)"|'([^']*)'|([^\s]+)/gu;
+  for (const match of command.matchAll(pattern)) words.push(match[1] ?? match[2] ?? match[3] ?? "");
+  return words.filter(Boolean);
+}
+
+function shellSegmentExecutableIndex(words: readonly string[]): number {
+  let executableIndex = 0;
+  while (/^[A-Za-z_][A-Za-z0-9_]*=/u.test(words[executableIndex] ?? "")) executableIndex += 1;
+  if (executableName(words[executableIndex] ?? "") === "env") {
+    executableIndex += 1;
+    while ((words[executableIndex] ?? "").startsWith("-")
+      || /^[A-Za-z_][A-Za-z0-9_]*=/u.test(words[executableIndex] ?? "")) executableIndex += 1;
+  } else if ((words[executableIndex] ?? "") === "command") {
+    executableIndex += 1;
+    while ((words[executableIndex] ?? "").startsWith("-")) executableIndex += 1;
+  }
+  return executableIndex;
+}
+
+function shellSegmentInvocation(segment: string): { executable: string; args: string[] } {
+  const words = shellSegmentWords(segment);
+  const executableIndex = shellSegmentExecutableIndex(words);
+  return {
+    executable: executableName(words[executableIndex] ?? ""),
+    args: words.slice(executableIndex + 1)
+  };
+}
+
+function updatedShellWorkingDirectory(
+  directory: string | undefined,
+  args: readonly string[]
+): string | undefined {
+  const requested = args.find((item) => item && !item.startsWith("-"));
+  if (!requested) return directory;
+  return directory && !path.isAbsolute(requested)
+    ? path.join(directory, requested) : requested;
+}
+
+function shellInvocationSourceCandidates(
+  invocation: { executable: string; args: string[] }
+): string[] {
+  if (!/^(?:python(?:\d+(?:\.\d+)*)?|node|ruby|perl|php)$/u.test(invocation.executable)) return [];
+  if (invocation.args.some((item) => ["-c", "-e", "--eval", "-m"].includes(item))) return [];
+  const candidates: string[] = [];
+  for (const candidate of invocation.args) {
+    if (/^(?:\d*[<>]|[<>])/u.test(candidate)) break;
+    if (candidate.startsWith("-")
+      || !/\.(?:py|pyw|[cm]?js|mjs|cjs|rb|pl|php)$/iu.test(candidate)) continue;
+    candidates.push(candidate);
+  }
+  return candidates;
+}
+
+function shellExecutedSourceCandidates(segments: readonly string[]): string[] {
+  let directory: string | undefined;
+  const candidates: string[] = [];
+  for (const segment of segments) {
+    const invocation = shellSegmentInvocation(segment);
+    if (invocation.executable === "cd") {
+      directory = updatedShellWorkingDirectory(directory, invocation.args);
+      continue;
+    }
+    for (const candidate of shellInvocationSourceCandidates(invocation)) {
+      candidates.push(directory && !path.isAbsolute(candidate)
+        ? path.join(directory, candidate) : candidate);
+    }
+  }
+  return [...new Set(candidates)].sort();
+}
+
+function shellRunsUnitFramework(segments: readonly string[]): boolean {
+  return segments.some((segment) => {
+    const { executable, args } = shellSegmentInvocation(segment);
+    if (["pytest", "vitest", "jest", "mocha"].includes(executable)) return true;
+    if (/^python(?:\d+(?:\.\d+)*)?$/u.test(executable)) {
+      const moduleIndex = args.indexOf("-m");
+      return moduleIndex >= 0 && ["pytest", "unittest"].includes(
+        (args[moduleIndex + 1] ?? "").toLowerCase()
+      );
+    }
+    return executable === "node"
+      && args.some((item) => item === "--test" || item.startsWith("--test="));
+  });
+}
+
+function strictShellComparison(segments: readonly string[]): boolean {
+  return segments.length > 1 && segments.some((segment) =>
+    ["diff", "cmp"].includes(shellSegmentInvocation(segment).executable));
+}
+
+export function shellSemanticValidation(script: string): {
+  kind?: ValidationClaimKindV1;
+  exactPathCandidates: string[];
+} {
+  const segments = strictAndShellSegments(script);
+  if (!segments) return { kind: "probe", exactPathCandidates: [] };
+  const exactPathCandidates = shellExecutedSourceCandidates(segments);
+  if (shellRunsUnitFramework(segments)) return { kind: "unit", exactPathCandidates };
+  if (exactPathCandidates.length > 0 && strictShellComparison(segments)) {
+    return { kind: "unit", exactPathCandidates };
+  }
+  return { exactPathCandidates: [] };
+}

--- a/packages/agent-runtime/src/tool-approval-coordinator.ts
+++ b/packages/agent-runtime/src/tool-approval-coordinator.ts
@@ -88,6 +88,62 @@ function containsOnlyInternalTerminalEffects(
   return effects.length > 0 && effects.every((effect) => internalTerminalEffects.has(effect));
 }
 
+function callArguments(call: ModelToolCall): Record<string, unknown> {
+  return call.arguments && typeof call.arguments === "object" && !Array.isArray(call.arguments)
+    ? call.arguments as Record<string, unknown> : {};
+}
+
+function boundConflictContinuation(
+  input: Record<string, unknown>,
+  scopePaths: readonly string[]
+): boolean {
+  if (!Array.isArray(input.operations) || input.operations.length === 0) return false;
+  const allowed = new Set(scopePaths);
+  return input.operations.every((value) => {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+    const operation = value as Record<string, unknown>;
+    return operation.op === "add" && Array.isArray(operation.paths)
+      && operation.paths.length > 0
+      && operation.paths.every((item) => typeof item === "string" && allowed.has(item));
+  });
+}
+
+function brokerBoundLocalRepositoryPlan(
+  descriptor: ToolDescriptor,
+  effects: readonly ToolEffect[],
+  plan: ToolCallPlan
+): boolean {
+  return descriptor.name === "git_transaction"
+    && descriptor.brokerMutationAuthority === "repository_transaction_v2"
+    && plan.mutationAuthority === "broker_repository_transaction_v2"
+    && plan.network === "none"
+    && !effects.some((effect) => effect === "filesystem.read.external"
+      || effect === "open_world" || effect === "process.handoff");
+}
+
+function runtimeBoundRepositoryRecovery(
+  session: RuntimeSession,
+  call: ModelToolCall,
+  descriptor: ToolDescriptor,
+  effects: readonly ToolEffect[],
+  plan: ToolCallPlan
+): boolean {
+  const obligation = session.durable.state.taskControl.obligation;
+  const input = callArguments(call);
+  if (!brokerBoundLocalRepositoryPlan(descriptor, effects, plan)
+    || obligation?.kind !== "repository_recovery"
+    || obligation.stage !== "transact") return false;
+  if (!obligation.transactionId) {
+    return input.action === "recover"
+      && input.candidateId === obligation.candidateId
+      && input.selectionEvidenceId === obligation.selectionEvidenceId;
+  }
+  if (input.transactionHandle !== obligation.transactionId) return false;
+  if (input.action === "abort") return true;
+  return input.action === "continue" && Boolean(obligation.scopePaths?.length)
+    && boundConflictContinuation(input, obligation.scopePaths!);
+}
+
 function mandatoryApprovalDecision(
   descriptor: ToolDescriptor,
   effects: ToolDescriptor["possibleEffects"],
@@ -105,6 +161,7 @@ function mandatoryApprovalDecision(
 
 function immediateApprovalDecision(
   session: RuntimeSession,
+  call: ModelToolCall,
   descriptor: ToolDescriptor,
   effects: ToolDescriptor["possibleEffects"],
   permissionMode: ReturnType<typeof profilePermissionMode>,
@@ -115,6 +172,8 @@ function immediateApprovalDecision(
   const perCall = requiresPerCallApproval(plan);
   const effectGrant = effects.slice().sort().join("\0");
   if (permissionMode === "auto" && !effects.includes("open_world")) return "allow";
+  if (permissionMode === "workspace-auto"
+    && runtimeBoundRepositoryRecovery(session, call, descriptor, effects, plan)) return "allow";
   if (permissionMode === "workspace-auto" && !perCall) return "allow";
   return !perCall && (descriptor.approval === "auto"
     || session.interaction.alwaysAllowedEffects.has(effectGrant)) ? "allow" : undefined;
@@ -250,7 +309,7 @@ export class ToolApprovalCoordinator {
     const immediate = forcePrompt
       ? undefined
       : immediateApprovalDecision(
-          session, descriptor, effects, permissionMode, plan
+          session, request, descriptor, effects, permissionMode, plan
         );
     if (immediate) {
       return requiresPerCallApproval(plan)

--- a/packages/agent-runtime/src/tool-approval-coordinator.ts
+++ b/packages/agent-runtime/src/tool-approval-coordinator.ts
@@ -2,200 +2,34 @@ import type {
   ModelToolCall,
   ToolCallApproval,
   ToolCallPlan,
-  ToolDescriptor,
-  ToolEffect
+  ToolDescriptor
 } from "agent-protocol";
 import type { ActiveModelTurn } from "agent-kernel";
 import { abortable, steeringRestart } from "./effect-helpers.js";
 import { turnPayload } from "./effect-runner-helpers.js";
 import type { EffectRunnerOptions } from "./effect-runner.js";
 import { profilePermissionMode } from "./profile-policy.js";
-import type { ApprovalWaiter, CallApprovalGrant, RuntimeSession } from "./types.js";
+import type { ApprovalWaiter, RuntimeSession } from "./types.js";
 import { armRunDeadline, pauseRunDeadline, resumedDeadlineAt } from "./run-deadline.js";
 import {
   approvalEffectsForPlan,
   createApprovalBinding,
   sameApprovalBinding
 } from "./approval-binding.js";
-
-const internalTerminalEffects: ReadonlySet<ToolEffect> = new Set([
-  "outcome.propose",
-  "outcome.report_blocked",
-  "outcome.request_input"
-]);
-
-function approvalCommand(call: ModelToolCall): string {
-  const value = call.arguments && typeof call.arguments === "object" && !Array.isArray(call.arguments)
-    ? call.arguments as Record<string, unknown> : {};
-  if (typeof value.executable === "string") {
-    const args = Array.isArray(value.args)
-      ? value.args.filter((item): item is string => typeof item === "string") : [];
-    return [value.executable, ...args].join(" ");
-  }
-  if (typeof value.command === "string") return value.command;
-  return call.name;
-}
-
-function approvalRisk(effects: readonly ToolEffect[], plan: ToolCallPlan): { level: string; reason: string } {
-  if (effects.includes("destructive") || effects.includes("repository.write") || plan.network === "full") {
-    return { level: "high", reason: "repository, destructive, or full-network capability" };
-  }
-  if (effects.includes("filesystem.write") || effects.includes("filesystem.read.external")) {
-    return { level: "medium", reason: "workspace mutation or external read capability" };
-  }
-  return { level: "low", reason: "read-only local capability" };
-}
-
-function semanticApprovalReason(
-  call: ModelToolCall,
-  effects: readonly ToolEffect[],
-  plan: ToolCallPlan,
-  backend: "native" | "oci",
-  automatic = false
-): string {
-  const risk = approvalRisk(effects, plan);
-  const read = plan.readPaths.join(", ") || "none";
-  const write = plan.writePaths.join(", ") || "none";
-  return `command=${approvalCommand(call)}; read=${read}; write=${write}; network=${plan.network}; `
-    + `backend=${backend}; risk=${risk.level} (${risk.reason})${automatic ? "; decision=automatic" : ""}`;
-}
+import {
+  immediateApprovalDecision,
+  mandatoryApprovalDecision,
+  requiresFreshRecoveredApproval,
+  requiresPerCallApproval,
+  semanticApprovalReason,
+  validApprovalGrant
+} from "./tool-approval-policy.js";
 
 export interface ApprovalRequest {
   call: ModelToolCall;
   modelTurn: ActiveModelTurn;
   descriptor: ToolDescriptor;
   plan: ToolCallPlan;
-}
-
-function requiresPerCallApproval(plan: ToolCallPlan): boolean {
-  return plan.network === "full"
-    || plan.exactEffects.includes("filesystem.read.external")
-    || plan.exactEffects.includes("repository.write")
-    || plan.exactEffects.includes("destructive")
-    || plan.exactEffects.includes("checkpoint.restore")
-    || plan.exactEffects.includes("process.handoff")
-    || plan.exactEffects.includes("open_world");
-}
-
-function requiresFreshRecoveredApproval(plan: ToolCallPlan): boolean {
-  return plan.exactEffects.some((effect) =>
-    ["filesystem.write", "repository.write", "destructive", "checkpoint.restore", "open_world"].includes(effect));
-}
-
-function containsOnlyInternalTerminalEffects(
-  effects: readonly ToolEffect[]
-): boolean {
-  return effects.length > 0 && effects.every((effect) => internalTerminalEffects.has(effect));
-}
-
-function callArguments(call: ModelToolCall): Record<string, unknown> {
-  return call.arguments && typeof call.arguments === "object" && !Array.isArray(call.arguments)
-    ? call.arguments as Record<string, unknown> : {};
-}
-
-function boundConflictContinuation(
-  input: Record<string, unknown>,
-  scopePaths: readonly string[]
-): boolean {
-  if (!Array.isArray(input.operations) || input.operations.length === 0) return false;
-  const allowed = new Set(scopePaths);
-  return input.operations.every((value) => {
-    if (!value || typeof value !== "object" || Array.isArray(value)) return false;
-    const operation = value as Record<string, unknown>;
-    return operation.op === "add" && Array.isArray(operation.paths)
-      && operation.paths.length > 0
-      && operation.paths.every((item) => typeof item === "string" && allowed.has(item));
-  });
-}
-
-function brokerBoundLocalRepositoryPlan(
-  descriptor: ToolDescriptor,
-  effects: readonly ToolEffect[],
-  plan: ToolCallPlan
-): boolean {
-  return descriptor.name === "git_transaction"
-    && descriptor.brokerMutationAuthority === "repository_transaction_v2"
-    && plan.mutationAuthority === "broker_repository_transaction_v2"
-    && plan.network === "none"
-    && !effects.some((effect) => effect === "filesystem.read.external"
-      || effect === "open_world" || effect === "process.handoff");
-}
-
-function runtimeBoundRepositoryRecovery(
-  session: RuntimeSession,
-  call: ModelToolCall,
-  descriptor: ToolDescriptor,
-  effects: readonly ToolEffect[],
-  plan: ToolCallPlan
-): boolean {
-  const obligation = session.durable.state.taskControl.obligation;
-  const input = callArguments(call);
-  if (!brokerBoundLocalRepositoryPlan(descriptor, effects, plan)
-    || obligation?.kind !== "repository_recovery"
-    || obligation.stage !== "transact") return false;
-  if (!obligation.transactionId) {
-    return input.action === "recover"
-      && input.candidateId === obligation.candidateId
-      && input.selectionEvidenceId === obligation.selectionEvidenceId;
-  }
-  if (input.transactionHandle !== obligation.transactionId) return false;
-  if (input.action === "abort") return true;
-  return input.action === "continue" && Boolean(obligation.scopePaths?.length)
-    && boundConflictContinuation(input, obligation.scopePaths!);
-}
-
-function mandatoryApprovalDecision(
-  descriptor: ToolDescriptor,
-  effects: ToolDescriptor["possibleEffects"],
-  permissionMode: ReturnType<typeof profilePermissionMode>
-): "allow" | "deny" | undefined {
-  if (descriptor.approval === "deny") return "deny";
-  if (permissionMode !== "deny") return undefined;
-  const maximumEffects = descriptor.maximumEffects ?? descriptor.possibleEffects;
-  return containsOnlyInternalTerminalEffects(descriptor.possibleEffects)
-    && containsOnlyInternalTerminalEffects(maximumEffects)
-    && containsOnlyInternalTerminalEffects(effects)
-    ? "allow"
-    : "deny";
-}
-
-function immediateApprovalDecision(
-  session: RuntimeSession,
-  call: ModelToolCall,
-  descriptor: ToolDescriptor,
-  effects: ToolDescriptor["possibleEffects"],
-  permissionMode: ReturnType<typeof profilePermissionMode>,
-  plan: ToolCallPlan
-): "allow" | "deny" | undefined {
-  const mandatory = mandatoryApprovalDecision(descriptor, effects, permissionMode);
-  if (mandatory) return mandatory;
-  const perCall = requiresPerCallApproval(plan);
-  const effectGrant = effects.slice().sort().join("\0");
-  if (permissionMode === "auto" && !effects.includes("open_world")) return "allow";
-  if (permissionMode === "workspace-auto"
-    && runtimeBoundRepositoryRecovery(session, call, descriptor, effects, plan)) return "allow";
-  if (permissionMode === "workspace-auto" && !perCall) return "allow";
-  return !perCall && (descriptor.approval === "auto"
-    || session.interaction.alwaysAllowedEffects.has(effectGrant)) ? "allow" : undefined;
-}
-
-function validApprovalGrant(
-  grant: CallApprovalGrant | undefined,
-  expectedBinding: ReturnType<typeof createApprovalBinding>,
-  plan: ToolCallPlan
-): grant is CallApprovalGrant {
-  if (!grant) return false;
-  const approvalSatisfied = (required: boolean, approved: boolean | undefined): boolean =>
-    !required || approved === true;
-  return sameApprovalBinding(grant, expectedBinding)
-    && grant.callId === expectedBinding.callId
-    && (grant.authority === "user" || grant.authority === "runtime")
-    && approvalSatisfied(plan.network === "full", grant.networkApproved)
-    && approvalSatisfied(
-      plan.exactEffects.includes("filesystem.read.external"), grant.externalReadApproved
-    )
-    && approvalSatisfied(plan.exactEffects.includes("process.handoff"), grant.processHandoffApproved)
-    && approvalSatisfied(plan.exactEffects.includes("open_world"), grant.openWorldApproved);
 }
 
 async function cleanUpFailedApprovalRequest(

--- a/packages/agent-runtime/src/tool-approval-policy.ts
+++ b/packages/agent-runtime/src/tool-approval-policy.ts
@@ -1,0 +1,183 @@
+import type {
+  ModelToolCall,
+  ToolCallPlan,
+  ToolDescriptor,
+  ToolEffect
+} from "agent-protocol";
+import {
+  createApprovalBinding,
+  sameApprovalBinding
+} from "./approval-binding.js";
+import { profilePermissionMode } from "./profile-policy.js";
+import type { CallApprovalGrant, RuntimeSession } from "./types.js";
+
+const internalTerminalEffects: ReadonlySet<ToolEffect> = new Set([
+  "outcome.propose",
+  "outcome.report_blocked",
+  "outcome.request_input"
+]);
+
+function approvalCommand(call: ModelToolCall): string {
+  const value = call.arguments && typeof call.arguments === "object" && !Array.isArray(call.arguments)
+    ? call.arguments as Record<string, unknown> : {};
+  if (typeof value.executable === "string") {
+    const args = Array.isArray(value.args)
+      ? value.args.filter((item): item is string => typeof item === "string") : [];
+    return [value.executable, ...args].join(" ");
+  }
+  if (typeof value.command === "string") return value.command;
+  return call.name;
+}
+
+function approvalRisk(effects: readonly ToolEffect[], plan: ToolCallPlan): { level: string; reason: string } {
+  if (effects.includes("destructive") || effects.includes("repository.write") || plan.network === "full") {
+    return { level: "high", reason: "repository, destructive, or full-network capability" };
+  }
+  if (effects.includes("filesystem.write") || effects.includes("filesystem.read.external")) {
+    return { level: "medium", reason: "workspace mutation or external read capability" };
+  }
+  return { level: "low", reason: "read-only local capability" };
+}
+
+export function semanticApprovalReason(
+  call: ModelToolCall,
+  effects: readonly ToolEffect[],
+  plan: ToolCallPlan,
+  backend: "native" | "oci",
+  automatic = false
+): string {
+  const risk = approvalRisk(effects, plan);
+  const read = plan.readPaths.join(", ") || "none";
+  const write = plan.writePaths.join(", ") || "none";
+  return `command=${approvalCommand(call)}; read=${read}; write=${write}; network=${plan.network}; `
+    + `backend=${backend}; risk=${risk.level} (${risk.reason})${automatic ? "; decision=automatic" : ""}`;
+}
+
+export function requiresPerCallApproval(plan: ToolCallPlan): boolean {
+  return plan.network === "full"
+    || plan.exactEffects.includes("filesystem.read.external")
+    || plan.exactEffects.includes("repository.write")
+    || plan.exactEffects.includes("destructive")
+    || plan.exactEffects.includes("checkpoint.restore")
+    || plan.exactEffects.includes("process.handoff")
+    || plan.exactEffects.includes("open_world");
+}
+
+export function requiresFreshRecoveredApproval(plan: ToolCallPlan): boolean {
+  return plan.exactEffects.some((effect) =>
+    ["filesystem.write", "repository.write", "destructive", "checkpoint.restore", "open_world"].includes(effect));
+}
+
+function containsOnlyInternalTerminalEffects(effects: readonly ToolEffect[]): boolean {
+  return effects.length > 0 && effects.every((effect) => internalTerminalEffects.has(effect));
+}
+
+function callArguments(call: ModelToolCall): Record<string, unknown> {
+  return call.arguments && typeof call.arguments === "object" && !Array.isArray(call.arguments)
+    ? call.arguments as Record<string, unknown> : {};
+}
+
+function boundConflictContinuation(
+  input: Record<string, unknown>,
+  scopePaths: readonly string[]
+): boolean {
+  if (!Array.isArray(input.operations) || input.operations.length === 0) return false;
+  const allowed = new Set(scopePaths);
+  return input.operations.every((value) => {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+    const operation = value as Record<string, unknown>;
+    return operation.op === "add" && Array.isArray(operation.paths)
+      && operation.paths.length > 0
+      && operation.paths.every((item) => typeof item === "string" && allowed.has(item));
+  });
+}
+
+function brokerBoundLocalRepositoryPlan(
+  descriptor: ToolDescriptor,
+  effects: readonly ToolEffect[],
+  plan: ToolCallPlan
+): boolean {
+  return descriptor.name === "git_transaction"
+    && descriptor.brokerMutationAuthority === "repository_transaction_v2"
+    && plan.mutationAuthority === "broker_repository_transaction_v2"
+    && plan.network === "none"
+    && !effects.some((effect) => effect === "filesystem.read.external"
+      || effect === "open_world" || effect === "process.handoff");
+}
+
+function runtimeBoundRepositoryRecovery(
+  session: RuntimeSession,
+  call: ModelToolCall,
+  descriptor: ToolDescriptor,
+  effects: readonly ToolEffect[],
+  plan: ToolCallPlan
+): boolean {
+  const obligation = session.durable.state.taskControl.obligation;
+  const input = callArguments(call);
+  if (!brokerBoundLocalRepositoryPlan(descriptor, effects, plan)
+    || obligation?.kind !== "repository_recovery"
+    || obligation.stage !== "transact") return false;
+  if (!obligation.transactionId) {
+    return input.action === "recover"
+      && input.candidateId === obligation.candidateId
+      && input.selectionEvidenceId === obligation.selectionEvidenceId;
+  }
+  if (input.transactionHandle !== obligation.transactionId) return false;
+  if (input.action === "abort") return true;
+  return input.action === "continue" && Boolean(obligation.scopePaths?.length)
+    && boundConflictContinuation(input, obligation.scopePaths!);
+}
+
+export function mandatoryApprovalDecision(
+  descriptor: ToolDescriptor,
+  effects: ToolDescriptor["possibleEffects"],
+  permissionMode: ReturnType<typeof profilePermissionMode>
+): "allow" | "deny" | undefined {
+  if (descriptor.approval === "deny") return "deny";
+  if (permissionMode !== "deny") return undefined;
+  const maximumEffects = descriptor.maximumEffects ?? descriptor.possibleEffects;
+  return containsOnlyInternalTerminalEffects(descriptor.possibleEffects)
+    && containsOnlyInternalTerminalEffects(maximumEffects)
+    && containsOnlyInternalTerminalEffects(effects)
+    ? "allow"
+    : "deny";
+}
+
+export function immediateApprovalDecision(
+  session: RuntimeSession,
+  call: ModelToolCall,
+  descriptor: ToolDescriptor,
+  effects: ToolDescriptor["possibleEffects"],
+  permissionMode: ReturnType<typeof profilePermissionMode>,
+  plan: ToolCallPlan
+): "allow" | "deny" | undefined {
+  const mandatory = mandatoryApprovalDecision(descriptor, effects, permissionMode);
+  if (mandatory) return mandatory;
+  const perCall = requiresPerCallApproval(plan);
+  const effectGrant = effects.slice().sort().join("\0");
+  if (permissionMode === "auto" && !effects.includes("open_world")) return "allow";
+  if (permissionMode === "workspace-auto"
+    && runtimeBoundRepositoryRecovery(session, call, descriptor, effects, plan)) return "allow";
+  if (permissionMode === "workspace-auto" && !perCall) return "allow";
+  return !perCall && (descriptor.approval === "auto"
+    || session.interaction.alwaysAllowedEffects.has(effectGrant)) ? "allow" : undefined;
+}
+
+export function validApprovalGrant(
+  grant: CallApprovalGrant | undefined,
+  expectedBinding: ReturnType<typeof createApprovalBinding>,
+  plan: ToolCallPlan
+): grant is CallApprovalGrant {
+  if (!grant) return false;
+  const approvalSatisfied = (required: boolean, approved: boolean | undefined): boolean =>
+    !required || approved === true;
+  return sameApprovalBinding(grant, expectedBinding)
+    && grant.callId === expectedBinding.callId
+    && (grant.authority === "user" || grant.authority === "runtime")
+    && approvalSatisfied(plan.network === "full", grant.networkApproved)
+    && approvalSatisfied(
+      plan.exactEffects.includes("filesystem.read.external"), grant.externalReadApproved
+    )
+    && approvalSatisfied(plan.exactEffects.includes("process.handoff"), grant.processHandoffApproved)
+    && approvalSatisfied(plan.exactEffects.includes("open_world"), grant.openWorldApproved);
+}

--- a/packages/agent-runtime/src/tool-evidence.ts
+++ b/packages/agent-runtime/src/tool-evidence.ts
@@ -223,6 +223,12 @@ function sanitizeRepositorySelection(
   return {
     ...raw,
     ...evidenceBase(scope, receipt),
+    // This identifier is also the opaque key into the in-memory recovery
+    // capability store. Replacing it would sever a legitimate selection from
+    // that store. Retaining it cannot mint recovery authority: resolution
+    // still requires a live record plus matching session, run, goal,
+    // repository, and candidate bindings.
+    evidenceId: raw.evidenceId,
     producer: { authority: "runtime", id: receipt.callId },
     data: { ...raw.data }
   };

--- a/packages/agent-runtime/src/tool-plan-enforcement.ts
+++ b/packages/agent-runtime/src/tool-plan-enforcement.ts
@@ -80,7 +80,26 @@ function shellWords(command: string): string[] {
   return words.filter(Boolean);
 }
 
-function invocation(call: ModelToolCall): { executable: string; args: string[]; display: string } {
+function shellExecutableIndex(words: readonly string[]): number {
+  let executableIndex = 0;
+  while (/^[A-Za-z_][A-Za-z0-9_]*=/u.test(words[executableIndex] ?? "")) executableIndex += 1;
+  if (path.basename(words[executableIndex] ?? "").toLowerCase() === "env") {
+    executableIndex += 1;
+    while ((words[executableIndex] ?? "").startsWith("-")
+      || /^[A-Za-z_][A-Za-z0-9_]*=/u.test(words[executableIndex] ?? "")) executableIndex += 1;
+  } else if ((words[executableIndex] ?? "") === "command") {
+    executableIndex += 1;
+    while ((words[executableIndex] ?? "").startsWith("-")) executableIndex += 1;
+  }
+  return executableIndex;
+}
+
+function invocation(call: ModelToolCall): {
+  executable: string;
+  args: string[];
+  display: string;
+  shellScript?: string;
+} {
   const input = argumentObject(call.arguments);
   if (typeof input.executable === "string") {
     const args = Array.isArray(input.args)
@@ -89,10 +108,16 @@ function invocation(call: ModelToolCall): { executable: string; args: string[]; 
   }
   const command = typeof input.command === "string" ? input.command : "";
   const words = shellWords(command);
-  return { executable: words[0] ?? "", args: words.slice(1), display: command };
+  const executableIndex = shellExecutableIndex(words);
+  return {
+    executable: words[executableIndex] ?? "",
+    args: words.slice(executableIndex + 1),
+    display: command,
+    shellScript: command
+  };
 }
 
-function inlineNodeExactFiles(
+function exactCandidateFiles(
   workspaceRoot: string,
   projectRoot: string,
   candidates: readonly string[]
@@ -120,21 +145,24 @@ function validationClaim(
   call: ModelToolCall
 ): Omit<ValidationClaimV1, "status"> {
   const command = invocation(call);
-  const semantic = semanticValidationCommand(command.executable, command.args);
+  const semantic = semanticValidationCommand(command.executable, command.args, command.shellScript);
   const executable = semantic.executable;
   // Registered non-process validators are trusted semantic adapters. Process
   // tools still derive their exact strength from the executable and args.
   const adaptedKind = !executable && call.name !== "validate"
     ? "acceptance" as const : semantic.kind;
   const project = projectRootForCall(workspaceRoot, call);
-  const inlineExactFiles = executable === "node"
-    ? inlineNodeExactFiles(workspaceRoot, project.absolute, semantic.inlineExactPathCandidates) : [];
-  const kind = adaptedKind === "probe" && inlineExactFiles.length > 0
-    ? inlineExactFiles.some((item) => assurancePathsForClaim([item], "unit").includes(item))
+  const exactFiles = exactCandidateFiles(
+    workspaceRoot,
+    project.absolute,
+    semantic.exactPathCandidates
+  );
+  const kind = adaptedKind === "probe" && exactFiles.length > 0
+    ? exactFiles.some((item) => assurancePathsForClaim([item], "unit").includes(item))
       ? "unit" as const : "acceptance" as const
     : adaptedKind;
-  const exactFiles = inlineExactFiles.length > 0
-    ? inlineExactFiles
+  const scopedExactFiles = exactFiles.length > 0
+    ? exactFiles
     : kind === "syntax"
     ? command.args.slice(1, 2).flatMap((item) => workspaceSubjectPath(workspaceRoot, project.absolute, item) ?? [])
     : [];
@@ -156,7 +184,7 @@ function validationClaim(
       projectId: project.portable,
       configPaths,
       selectedTests,
-      exactFiles
+      exactFiles: scopedExactFiles
     }
   };
 }

--- a/packages/agent-runtime/src/tool-turn-policy.ts
+++ b/packages/agent-runtime/src/tool-turn-policy.ts
@@ -1,8 +1,9 @@
-import type { ToolDescriptor, ToolEffect } from "agent-protocol";
+import type { JsonValue, ToolDescriptor, ToolEffect } from "agent-protocol";
 import type { RuntimeSession } from "./types.js";
 
 export type CompletionRepairPhase =
   | "none"
+  | "protocol_repair"
   | "focused"
   | "generic_repair"
   | "completion_evidence"
@@ -51,6 +52,11 @@ export function completionRepairPhase(session: RuntimeSession): CompletionRepair
   const control = session.durable.state.taskControl;
   const obligationPhase = obligationRepairPhase(session);
   if (obligationPhase) return obligationPhase;
+  if (control.phase === "focused"
+    && control.episode.noProgressBatches < 2
+    && control.policyCorrection?.failureCode === "tool_arguments_invalid") {
+    return "protocol_repair";
+  }
   if (control.phase === "terminal") return "terminal";
   if (control.phase === "repair_only") return "generic_repair";
   return control.phase === "focused" ? "focused" : "none";
@@ -75,6 +81,7 @@ function baseDescriptorAllowedForRepair(
 ): boolean {
   switch (phase) {
     case "none":
+    case "protocol_repair":
     case "focused": return descriptor.name !== "environment_prepare";
     case "generic_repair": return descriptor.possibleEffects.some((effect) =>
       effect === "filesystem.write" || effect === "repository.write"
@@ -140,6 +147,7 @@ function baseEffectsAllowedForRepair(
 ): boolean {
   switch (phase) {
     case "none":
+    case "protocol_repair":
     case "focused": return true;
     case "generic_repair": return effects.some((effect) =>
       effect === "filesystem.write" || effect === "repository.write"
@@ -194,9 +202,75 @@ export function descriptorsAllowedForRepair(
   descriptors: readonly ToolDescriptor[],
   phase = completionRepairPhase(session)
 ): ToolDescriptor[] {
-  return descriptors.filter((descriptor) => descriptorAllowedForRepair(session, descriptor, phase));
+  return descriptors
+    .filter((descriptor) => descriptorAllowedForRepair(session, descriptor, phase))
+    .map((descriptor) => projectedDirectedDescriptor(session, descriptor, phase));
+}
+
+function schemaObject(value: JsonValue | undefined): Record<string, JsonValue> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, JsonValue> : null;
+}
+
+function projectedConflictMutationDescriptor(
+  descriptor: ToolDescriptor,
+  scopePaths: readonly string[]
+): ToolDescriptor {
+  if (!descriptor.possibleEffects.includes("filesystem.write")) return descriptor;
+  const description = `${descriptor.description} During repository conflict resolution, writes are limited to: ${scopePaths.join(", ")}.`;
+  const properties = schemaObject(descriptor.inputSchema.properties);
+  const pathSchema = schemaObject(properties?.path);
+  if (!properties || !pathSchema) return { ...descriptor, description };
+  const { const: _priorConst, enum: _priorEnum, ...basePathSchema } = pathSchema;
+  const projectedPath: Record<string, JsonValue> = scopePaths.length === 1
+    ? { ...basePathSchema, const: scopePaths[0]! }
+    : { ...basePathSchema, enum: [...scopePaths] };
+  return {
+    ...descriptor,
+    description,
+    inputSchema: {
+      ...descriptor.inputSchema,
+      properties: { ...properties, path: projectedPath }
+    }
+  };
+}
+
+function projectedDirectedDescriptor(
+  session: RuntimeSession,
+  descriptor: ToolDescriptor,
+  phase: CompletionRepairPhase
+): ToolDescriptor {
+  if (phase !== "repository_transact") return descriptor;
+  const obligation = session.durable.state.taskControl.obligation;
+  if (obligation?.kind !== "repository_recovery") return descriptor;
+  if (obligation.transactionId && obligation.scopePaths?.length) {
+    if (descriptor.name !== "git_transaction") {
+      return projectedConflictMutationDescriptor(descriptor, obligation.scopePaths);
+    }
+    return {
+      ...descriptor,
+      description: "Continue or abort only the active broker-journaled recovery transaction. Continue accepts add operations only for the broker-observed conflict paths; non-conflicting changes are already applied."
+    };
+  }
+  if (descriptor.name !== "git_transaction"
+    || !obligation.candidateId || !obligation.selectionEvidenceId) return descriptor;
+  return {
+    ...descriptor,
+    description: "Recover the runtime-selected Git candidate with its bound selection evidence. The action and evidence fields are fixed by task control; call git_transaction exactly as projected.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        action: { type: "string", const: "recover" },
+        candidateId: { type: "string", const: obligation.candidateId },
+        selectionEvidenceId: { type: "string", const: obligation.selectionEvidenceId }
+      },
+      required: ["action", "candidateId", "selectionEvidenceId"],
+      additionalProperties: false
+    }
+  };
 }
 
 export function maximumTaskControlCalls(session: RuntimeSession): number {
-  return completionRepairPhase(session) === "none" ? Number.MAX_SAFE_INTEGER : 1;
+  return ["none", "protocol_repair"].includes(completionRepairPhase(session))
+    ? Number.MAX_SAFE_INTEGER : 1;
 }

--- a/packages/agent-tools/src/repository-git-inspection-probes.ts
+++ b/packages/agent-tools/src/repository-git-inspection-probes.ts
@@ -258,7 +258,12 @@ async function recoveryCandidates(
   }));
   const seen = new Set<string>();
   const selected = entries.filter((entry) => {
-    if (!unreachableCommits.has(entry.object) || entry.object === head || seen.has(entry.object)) return false;
+    // A clone reflog entry records repository bootstrap state, not work
+    // created in the local repository. If that bootstrap ref later becomes
+    // unreachable (for example after a branch reset and remote removal),
+    // presenting it as lost local work creates a false recovery ambiguity.
+    if (entry.action.trim().toLowerCase() === "clone"
+      || !unreachableCommits.has(entry.object) || entry.object === head || seen.has(entry.object)) return false;
     seen.add(entry.object);
     return true;
   }).slice(0, MAX_RECOVERY_CANDIDATES);

--- a/portable/harbor/sigma_harbor_agent.py
+++ b/portable/harbor/sigma_harbor_agent.py
@@ -576,6 +576,7 @@ class SigmaCliHarborAgent(BaseAgent):
         provider: str = "deepseek",
         model: str | None = None,
         agent_profile: str = "standard",
+        permission_mode: str = "auto",
         network_mode: str = "full",
         execution_mode: str = "sandboxed",
         managed_environment_mode: str = "disabled",
@@ -608,6 +609,11 @@ class SigmaCliHarborAgent(BaseAgent):
         if agent_profile not in {"standard", "strict"}:
             raise ValueError("agent_profile must be one of: standard, strict")
         self.agent_profile = agent_profile
+        if permission_mode not in {"workspace-auto", "ask", "auto", "deny"}:
+            raise ValueError(
+                "permission_mode must be one of: workspace-auto, ask, auto, deny"
+            )
+        self.permission_mode = permission_mode
         if network_mode not in {"none", "loopback", "full"}:
             raise ValueError("network_mode must be one of: none, loopback, full")
         self.network_mode = network_mode
@@ -966,12 +972,12 @@ class SigmaCliHarborAgent(BaseAgent):
             raise RuntimeError(f"{failure_kind}: {error_message or 'agent exited unsuccessfully.'}")
 
     def _permission_mode(self) -> str:
-        # A required managed environment is disposable, isolated, and
-        # launcher-attested before the first model turn. Once its strict
-        # doctor contract has passed, asking a non-interactive Harbor process
-        # for human approval cannot add authority; it can only deadlock the
-        # run. Other topologies retain the narrower workspace-auto policy.
-        return "auto" if self._managed_environment_verified else "workspace-auto"
+        # Harbor evaluation is non-interactive and runs inside a disposable
+        # task environment. A human prompt cannot be answered there, so the
+        # adapter defaults to automatic approval while the configured sandbox,
+        # network policy, and broker-enforced transaction boundaries remain
+        # authoritative. Callers can still request a narrower mode explicitly.
+        return self.permission_mode
 
     def _agent_command(self, context: AgentContext | None = None) -> list[str]:
         if self._workspace is None:

--- a/tests/agent-kernel.semantic-failure.test.ts
+++ b/tests/agent-kernel.semantic-failure.test.ts
@@ -118,7 +118,7 @@ describe("semantic fact ledger", () => {
     expect(state.taskControl.semanticFacts.entries).toEqual([]);
   });
 
-  it("deduplicates new output from successful runtime-confirmed read-only processes", () => {
+  it("does not count changing read-only process output as workspace progress", () => {
     const diagnostic = (callId: string, output: string): ToolReceipt => receipt({
       callId,
       output,
@@ -127,10 +127,8 @@ describe("semantic fact ledger", () => {
     });
     let state = recordSemanticToolResult(initial(), diagnostic("one", "first observation"), "shell").state;
     state = recordSemanticToolResult(state, diagnostic("two", "first observation"), "shell").state;
-    expect(state.taskControl.semanticFacts.entries).toHaveLength(1);
-
     state = recordSemanticToolResult(state, diagnostic("three", "second observation"), "shell").state;
-    expect(state.taskControl.semanticFacts.entries).toHaveLength(2);
+    expect(state.taskControl.semanticFacts.entries).toEqual([]);
   });
 
   it("rejects failed or mutating process output as semantic progress", () => {

--- a/tests/agent-kernel.semantic-failure.test.ts
+++ b/tests/agent-kernel.semantic-failure.test.ts
@@ -118,6 +118,35 @@ describe("semantic fact ledger", () => {
     expect(state.taskControl.semanticFacts.entries).toEqual([]);
   });
 
+  it("deduplicates new output from successful runtime-confirmed read-only processes", () => {
+    const diagnostic = (callId: string, output: string): ToolReceipt => receipt({
+      callId,
+      output,
+      observedEffects: ["process.spawn.readonly"],
+      actualEffects: ["process.spawn.readonly"]
+    });
+    let state = recordSemanticToolResult(initial(), diagnostic("one", "first observation"), "shell").state;
+    state = recordSemanticToolResult(state, diagnostic("two", "first observation"), "shell").state;
+    expect(state.taskControl.semanticFacts.entries).toHaveLength(1);
+
+    state = recordSemanticToolResult(state, diagnostic("three", "second observation"), "shell").state;
+    expect(state.taskControl.semanticFacts.entries).toHaveLength(2);
+  });
+
+  it("rejects failed or mutating process output as semantic progress", () => {
+    let state = recordSemanticToolResult(initial(), receipt({
+      ok: false,
+      observedEffects: ["process.spawn.readonly"],
+      actualEffects: ["process.spawn.readonly"]
+    }), "shell").state;
+    state = recordSemanticToolResult(state, receipt({
+      callId: "mutating",
+      observedEffects: ["process.spawn", "filesystem.write"],
+      actualEffects: ["process.spawn", "filesystem.write"]
+    }), "shell").state;
+    expect(state.taskControl.semanticFacts.entries).toEqual([]);
+  });
+
   it("deduplicates exact content facts while accepting a genuinely new content digest", () => {
     const read = (callId: string, sha256: string): ToolReceipt => receipt({
       callId,

--- a/tests/agent-kernel.task-control.test.ts
+++ b/tests/agent-kernel.task-control.test.ts
@@ -8,6 +8,7 @@ import {
   type JsonValue,
   type ToolReceipt
 } from "../packages/agent-protocol/src/index.js";
+import { failedTerminalRepairState } from "../packages/agent-kernel/src/model-convergence.js";
 import {
   advanceReviewRepair,
   advanceRepositoryEvidenceObligation,
@@ -35,10 +36,12 @@ import {
   taskControlAnswer,
   taskControlFailureMessage,
   terminalResolutionObligation,
+  toolPolicyCorrectionExhausted,
   userDecisionObligation,
   type KernelState,
   type TaskControlStateV1
 } from "../packages/agent-kernel/src/index.js";
+import { completedToolBatchProgress } from "../packages/agent-kernel/src/tool-batch-progress.js";
 
 const NOW = "2026-07-22T00:00:00.000Z";
 const DIGEST_A = "a".repeat(64);
@@ -232,6 +235,94 @@ describe("TaskControlStateV1", () => {
       phase: "terminal",
       obligation: { kind: "terminal_resolution", failureCode: "action_convergence_no_progress" }
     });
+  });
+
+  it("treats a compliant tool batch as acceptance of the pending policy correction", () => {
+    const state = initial();
+    const first = recordToolPolicyViolation(
+      state.taskControl,
+      "model_tool_policy_violation",
+      state.revision
+    );
+    const accepted = completedToolBatchProgress({
+      ...state,
+      taskControl: first,
+      messages: [{
+        role: "assistant",
+        content: "",
+        toolCalls: [{ id: "exec-call", name: "read", arguments: { path: "README.md" } }]
+      }],
+      receipts: [receipt("read succeeded")]
+    }).taskControl;
+
+    expect(accepted.policyCorrection).toBeUndefined();
+    const later = recordToolPolicyViolation(
+      accepted,
+      "tool_unavailable_for_repair",
+      state.revision + 1
+    );
+    expect(later.policyCorrection).toMatchObject({ attempts: 1 });
+    expect(later.obligation).toBeUndefined();
+  });
+
+  it("offers one real correction even when another obligation is already terminal", () => {
+    const state = initial();
+    const terminal = {
+      ...state,
+      taskControl: terminalResolutionObligation(
+        state.taskControl,
+        state.revision,
+        "action_convergence_no_progress"
+      )
+    };
+    const rejected: ToolReceipt = {
+      callId: "terminal-rejection",
+      ok: false,
+      output: "not offered",
+      outcome: {
+        status: "failed",
+        output: "not offered",
+        diagnosticCodes: ["tool_unavailable_for_repair"]
+      },
+      observedEffects: [],
+      actualEffects: [],
+      artifacts: [],
+      diagnostics: ["tool_unavailable_for_repair"],
+      startedAt: NOW,
+      completedAt: NOW
+    };
+
+    const correction = failedTerminalRepairState(terminal, true, true, rejected, 0);
+    expect(correction).toMatchObject({
+      phase: "ready_model",
+      taskControl: {
+        obligation: { kind: "terminal_resolution" },
+        policyCorrection: { attempts: 1 }
+      }
+    });
+    expect(correction?.proposedOutcome).toBeUndefined();
+  });
+
+  it("does not treat an initially terminal user decision as an exhausted correction", () => {
+    const decision = userDecisionObligation(
+      createTaskControlState(),
+      1,
+      "choose_recovery_candidate"
+    );
+    const first = recordToolPolicyViolation(decision, "model_tool_policy_violation", 2);
+    expect(first).toMatchObject({
+      phase: "terminal",
+      obligation: { kind: "user_decision" },
+      policyCorrection: { attempts: 1 }
+    });
+    expect(toolPolicyCorrectionExhausted(first)).toBe(false);
+
+    const second = recordToolPolicyViolation(first, "model_tool_policy_violation", 3);
+    expect(second).toMatchObject({
+      obligation: { kind: "terminal_resolution", failureCode: "user_decision_action_required" },
+      policyCorrection: { attempts: 2 }
+    });
+    expect(toolPolicyCorrectionExhausted(second)).toBe(true);
   });
 
   it("preserves the unresolved completion prerequisite when correction is exhausted", () => {

--- a/tests/agent-repository-inspection-v2.test.ts
+++ b/tests/agent-repository-inspection-v2.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type { ToolExecutionContext } from "../packages/agent-protocol/src/index.js";
@@ -50,6 +50,69 @@ async function recoveryRepository(): Promise<{
   const newestUnreachable = git(root, ["rev-parse", "HEAD"]);
   git(root, ["reset", "--hard", base]);
   return { root, newestUnreachable, olderUnreachable };
+}
+
+async function clonedBaselineRecoveryRepository(): Promise<{
+  root: string;
+  localRecovery: string;
+  cloneTip: string;
+}> {
+  const parent = await mkdtemp(path.join(os.tmpdir(), "sigma-clone-baseline-"));
+  workspaces.push(parent);
+  const source = path.join(parent, "source");
+  const root = path.join(parent, "clone");
+  await mkdir(source);
+  git(source, ["init", "-q", "--initial-branch=main"]);
+  git(source, ["config", "user.email", "sigma@example.invalid"]);
+  git(source, ["config", "user.name", "Sigma"]);
+  await writeFile(path.join(source, "base.txt"), "base\n", "utf8");
+  git(source, ["add", "base.txt"]);
+  git(source, ["commit", "-qm", "base"]);
+  const base = git(source, ["rev-parse", "HEAD"]);
+  await writeFile(path.join(source, "upstream.txt"), "upstream\n", "utf8");
+  git(source, ["add", "upstream.txt"]);
+  git(source, ["commit", "-qm", "upstream baseline"]);
+
+  git(parent, ["clone", "-q", source, root]);
+  git(root, ["config", "user.email", "sigma@example.invalid"]);
+  git(root, ["config", "user.name", "Sigma"]);
+  const cloneTip = git(root, ["rev-parse", "HEAD"]);
+  git(root, ["remote", "remove", "origin"]);
+  git(root, ["reset", "--hard", base]);
+  git(root, ["checkout", "-q", "--detach", base]);
+  await writeFile(path.join(root, "local.txt"), "local recovery\n", "utf8");
+  git(root, ["add", "local.txt"]);
+  git(root, ["commit", "-qm", "local recovery"]);
+  const localRecovery = git(root, ["rev-parse", "HEAD"]);
+  git(root, ["checkout", "-q", "main"]);
+  return { root, localRecovery, cloneTip };
+}
+
+async function divergedRecoveryRepository(): Promise<{
+  root: string;
+  currentHead: string;
+  recoveryHead: string;
+}> {
+  const root = await mkdtemp(path.join(os.tmpdir(), "sigma-diverged-recovery-"));
+  workspaces.push(root);
+  git(root, ["init", "-q", "--initial-branch=main"]);
+  git(root, ["config", "user.email", "sigma@example.invalid"]);
+  git(root, ["config", "user.name", "Sigma"]);
+  await writeFile(path.join(root, "base.txt"), "base\n", "utf8");
+  git(root, ["add", "base.txt"]);
+  git(root, ["commit", "-qm", "base"]);
+  git(root, ["checkout", "-qb", "lost-work"]);
+  await writeFile(path.join(root, "recovered.txt"), "recovered\n", "utf8");
+  git(root, ["add", "recovered.txt"]);
+  git(root, ["commit", "-qm", "recover this work"]);
+  const recoveryHead = git(root, ["rev-parse", "HEAD"]);
+  git(root, ["checkout", "-q", "main"]);
+  await writeFile(path.join(root, "current.txt"), "current\n", "utf8");
+  git(root, ["add", "current.txt"]);
+  git(root, ["commit", "-qm", "current main work"]);
+  const currentHead = git(root, ["rev-parse", "HEAD"]);
+  git(root, ["branch", "-D", "lost-work"]);
+  return { root, currentHead, recoveryHead };
 }
 
 function registry(
@@ -105,6 +168,25 @@ afterEach(async () => {
 });
 
 describe("RepositoryInspectionV2", () => {
+  it("does not treat an unreachable clone baseline as lost local work", async () => {
+    const fixture = await clonedBaselineRecoveryRepository();
+    const broker = createHostExecutionBroker();
+    brokers.push(broker);
+    const tools = registry(broker, new RepositoryRecoverySelectionStore());
+
+    const receipt = await execute(tools, fixture.root, "repository_inspect", {}, 1);
+    expect(receipt.ok).toBe(true);
+    const result = receipt.result as any;
+    expect(result.recoveryCandidates.map((item: any) => item.object))
+      .toEqual([fixture.localRecovery]);
+    expect(result.recoveryCandidates.map((item: any) => item.object))
+      .not.toContain(fixture.cloneTip);
+    expect(result.selectionStatus).toMatchObject({
+      status: "selected",
+      selectionKind: "unique"
+    });
+  });
+
   it("preserves newest-first reflog order and treats subjects as untrusted metadata", async () => {
     const fixture = await recoveryRepository();
     const broker = createHostExecutionBroker();
@@ -183,6 +265,56 @@ describe("RepositoryInspectionV2", () => {
           }
         }
       });
+  }, 60_000);
+
+  it("merges a diverged recovery candidate without discarding the current branch", async () => {
+    const fixture = await divergedRecoveryRepository();
+    const broker = createHostExecutionBroker();
+    brokers.push(broker);
+    const selections = new RepositoryRecoverySelectionStore();
+    const tools = registry(broker, selections);
+    const inspected = await execute(tools, fixture.root, "repository_inspect", {}, 1);
+    const candidate = (inspected.result as any).recoveryCandidates[0] as {
+      candidateId: string;
+      relationToHead: string;
+    };
+    const selectionEvidenceId =
+      (inspected.result as any).selectionStatus.selectionEvidenceId as string;
+    expect(candidate.relationToHead).toBe("diverged");
+
+    const recovered = await execute(tools, fixture.root, "git_transaction", {
+      action: "recover",
+      repository: ".",
+      candidateId: candidate.candidateId,
+      selectionEvidenceId
+    }, 1);
+
+    expect(recovered.ok).toBe(true);
+    const finalHead = git(fixture.root, ["rev-parse", "HEAD"]);
+    expect(finalHead).not.toBe(fixture.currentHead);
+    expect(finalHead).not.toBe(fixture.recoveryHead);
+    expect(() => git(fixture.root, [
+      "merge-base", "--is-ancestor", fixture.currentHead, finalHead
+    ])).not.toThrow();
+    expect(() => git(fixture.root, [
+      "merge-base", "--is-ancestor", fixture.recoveryHead, finalHead
+    ])).not.toThrow();
+    expect(recovered.evidence?.find((item) => item.kind === "repository_delta"))
+      .toMatchObject({ data: {
+        operations: ["merge"],
+        semanticAssertions: {
+          head: finalHead,
+          targetAssertions: {
+            selectedHead: fixture.recoveryHead,
+            selectedSymbolicRef: "refs/heads/main",
+            requiredReachableObjects: expect.arrayContaining([
+              fixture.currentHead,
+              fixture.recoveryHead
+            ]),
+            satisfied: true
+          }
+        }
+      } });
   }, 60_000);
 
   it("rejects a stale selection before acquiring a write transaction", async () => {

--- a/tests/agent-runtime.configured-runtime-capabilities.test.ts
+++ b/tests/agent-runtime.configured-runtime-capabilities.test.ts
@@ -264,7 +264,9 @@ function configured(workspace: string): RuntimeCompositionConfig {
     provider: "deepseek",
     model: "deepseek-v4-pro",
     permissionMode: "deny",
-    runDeadlineSec: 30,
+    // Capability projection is the subject of these tests; keep the first
+    // turn outside the deadline-convergence window.
+    runDeadlineSec: 60,
     modelDeadlineSec: 10,
     streamIdleSec: 5,
     maxParallelTools: 1,

--- a/tests/agent-runtime.evidence.test.ts
+++ b/tests/agent-runtime.evidence.test.ts
@@ -8,6 +8,7 @@ import type {
   EvidenceRecord,
   JsonValue,
   ModelToolCall,
+  RepositoryRecoverySelectionEvidenceV1,
   RepositoryDeltaEvidence,
   ReviewEvidence,
   ToolCallPlan,
@@ -370,6 +371,151 @@ describe("V5 assurance-coordinated mutation completion", () => {
     expect(acceptance).toMatchObject({
       coveredPaths: ["native/sigma-exec/src/main.rs", "docs/readme.md"],
       claim: { kind: "acceptance" }
+    });
+  });
+
+  it("binds direct compiler acceptance to the source files named by the command", () => {
+    const active = frontierSession();
+    active.durable.state.mutationFrontier.changedPaths = [
+      "proofs/theorem.v",
+      "proofs/.theorem.aux",
+      "proofs/theorem.glob",
+      "proofs/theorem.vo",
+      "proofs/theorem.vok",
+      "proofs/theorem.vos",
+      "legacy/program.cbl",
+      "program",
+      "docs/readme.md"
+    ];
+
+    expect(validationScope(active, {
+      id: "coq-compile", name: "validate",
+      arguments: { shell: "bash", command: "/usr/bin/coqc -q proofs/theorem.v 2>&1" }
+    }, validationPlan)).toMatchObject({
+      coveredPaths: [
+        "proofs/theorem.v",
+        "proofs/.theorem.aux",
+        "proofs/theorem.glob",
+        "proofs/theorem.vo",
+        "proofs/theorem.vok",
+        "proofs/theorem.vos"
+      ],
+      claim: {
+        kind: "acceptance",
+        subject: {
+          exactFiles: [
+            "proofs/.theorem.aux",
+            "proofs/theorem.glob",
+            "proofs/theorem.v",
+            "proofs/theorem.vo",
+            "proofs/theorem.vok",
+            "proofs/theorem.vos"
+          ]
+        }
+      }
+    });
+    expect(validationScope(active, {
+      id: "cobol-compile", name: "validate",
+      arguments: {
+        executable: "cobc",
+        args: ["-x", "-o", "program", "legacy/program.cbl"]
+      }
+    }, validationPlan)).toMatchObject({
+      coveredPaths: ["legacy/program.cbl", "program"],
+      claim: {
+        kind: "acceptance",
+        subject: { exactFiles: ["legacy/program.cbl", "program"] }
+      }
+    });
+    expect(validationScope(active, {
+      id: "compiler-version", name: "validate",
+      arguments: { executable: "coqc", args: ["--version"] }
+    }, validationPlan)).toMatchObject({
+      coveredPaths: [],
+      claim: { kind: "probe", subject: { exactFiles: [] } }
+    });
+  });
+
+  it("treats a transitive document build with environment prefixes as project acceptance", () => {
+    const active = frontierSession();
+    active.durable.state.mutationFrontier.changedPaths = [
+      "main.tex", "chapters/input.tex"
+    ];
+
+    expect(validationScope(active, {
+      id: "document-build", name: "validate",
+      arguments: {
+        shell: "bash",
+        command: "TEXMFVAR=/tmp/tex-var TEXMFCONFIG=/tmp/tex-config pdflatex -interaction=nonstopmode main.tex"
+      }
+    }, validationPlan)).toMatchObject({
+      coveredPaths: ["main.tex", "chapters/input.tex"],
+      claim: {
+        kind: "acceptance",
+        subject: { projectId: ".", exactFiles: [] }
+      }
+    });
+  });
+
+  it("binds strict shell comparison tests to the source programs they execute", () => {
+    const active = frontierSession();
+    active.durable.state.mutationFrontier.changedPaths = [
+      "program.py", "reference.py", "notes.txt"
+    ];
+
+    expect(validationScope(active, {
+      id: "behavior-comparison", name: "validate",
+      arguments: {
+        shell: "bash",
+        command: [
+          "cd .",
+          "python3 program.py > /tmp/actual",
+          "python3 reference.py > /tmp/expected",
+          "diff /tmp/actual /tmp/expected",
+          "echo PASS"
+        ].join(" && ")
+      }
+    }, validationPlan)).toMatchObject({
+      coveredPaths: ["program.py", "reference.py"],
+      claim: {
+        kind: "unit",
+        subject: { exactFiles: ["program.py", "reference.py"] }
+      }
+    });
+  });
+
+  it("does not trust shell comparisons whose failure is explicitly masked", () => {
+    const active = frontierSession();
+    active.durable.state.mutationFrontier.changedPaths = ["program.py"];
+
+    expect(validationScope(active, {
+      id: "masked-comparison", name: "validate",
+      arguments: {
+        shell: "bash",
+        command: "python3 program.py > /tmp/actual && diff /tmp/actual /tmp/expected || echo FAIL"
+      }
+    }, validationPlan)).toMatchObject({
+      coveredPaths: [],
+      claim: { kind: "probe", subject: { exactFiles: [] } }
+    });
+  });
+
+  it("recognizes direct Python syntax checks without upgrading them to unit evidence", () => {
+    const active = frontierSession();
+    active.durable.state.mutationFrontier.changedPaths = ["program.py"];
+
+    expect(validationScope(active, {
+      id: "python-syntax", name: "validate",
+      arguments: {
+        executable: "/usr/bin/python3",
+        args: ["-c", "import py_compile; py_compile.compile('program.py', doraise=True)"]
+      }
+    }, validationPlan)).toMatchObject({
+      coveredPaths: ["program.py"],
+      claim: {
+        kind: "syntax",
+        subject: { exactFiles: ["program.py"] }
+      }
     });
   });
 
@@ -1272,6 +1418,73 @@ describe.skip("V3 run-scoped completion evidence", () => {
     expect(normalized.evidence?.[0]?.evidenceId).not.toBe("attacker-id");
     expect(() => assertToolReceiptIdentity(receipt("forged-call"), "requested-call"))
       .toThrow("does not match requested callId");
+  });
+
+  it("preserves a repository selection capability key while restamping its runtime authority", () => {
+    const capabilityId = "repository-recovery-selection:capability";
+    const selection: RepositoryRecoverySelectionEvidenceV1 = {
+      evidenceId: capabilityId,
+      sessionId: "session",
+      runId: "run",
+      kind: "repository_recovery_selection",
+      status: "passed",
+      createdAt: now,
+      producer: { authority: "runtime", id: "inspect-call" },
+      summary: "selected",
+      data: {
+        schemaVersion: 1,
+        goalEpoch: 7,
+        repositoryRoot: ".",
+        candidateId: "c".repeat(64),
+        selectedObject: "d".repeat(40),
+        selectionKind: "unique",
+        inspectionBasisDigest: "1".repeat(64),
+        inspectedHead: "2".repeat(40),
+        inspectedSymbolicRef: "refs/heads/main",
+        statusDigest: "3".repeat(64),
+        refsDigest: "4".repeat(64),
+        reflogDigest: "5".repeat(64),
+        repositoryStateDigest: "6".repeat(64)
+      }
+    };
+    const plan: ToolCallPlan = {
+      exactEffects: ["filesystem.read", "process.spawn.readonly"],
+      readPaths: ["."], writePaths: [], network: "none", processMode: "pipe",
+      checkpointScope: [], idempotence: "read_only"
+    };
+    const inspection = {
+      ...receipt("inspect-call"),
+      observedEffects: ["filesystem.read", "process.spawn.readonly"] as const,
+      actualEffects: ["filesystem.read", "process.spawn.readonly"] as const,
+      evidence: [selection]
+    };
+    const normalized = normalizeReceiptEvidence(inspection, "repository_inspect", plan, {
+      sessionId: "session",
+      runId: "run",
+      workspaceDeltas: [],
+      repositoryScope: {
+        goalEpoch: 7,
+        frontier: {
+          revision: 0,
+          baselineManifestDigest: "0".repeat(64),
+          currentStateDigest: "0".repeat(64),
+          changedPaths: [],
+          sourceCheckpointIds: []
+        },
+        mutationEvidence: []
+      }
+    });
+    expect(normalized.evidence).toMatchObject([{
+      evidenceId: capabilityId,
+      sessionId: "session",
+      runId: "run",
+      kind: "repository_recovery_selection",
+      producer: { authority: "runtime", id: "inspect-call" }
+    }]);
+    const rejected = normalizeReceiptEvidence(inspection, "external_tool", plan, {
+      sessionId: "session", runId: "run", workspaceDeltas: []
+    });
+    expect(rejected.evidence?.some((item) => item.evidenceId === capabilityId)).toBe(false);
   });
 
   it("issues repository acceptance only for broker-proved recovery targets in the current goal epoch", () => {

--- a/tests/agent-runtime.evidence.test.ts
+++ b/tests/agent-runtime.evidence.test.ts
@@ -488,19 +488,43 @@ describe("V5 assurance-coordinated mutation completion", () => {
     const active = frontierSession();
     active.durable.state.mutationFrontier.changedPaths = ["program.py"];
 
+    for (const command of [
+      "python3 program.py > /tmp/actual && diff /tmp/actual /tmp/expected || echo FAIL",
+      "python3 program.py > /tmp/actual && diff /tmp/actual /tmp/expected | cat"
+    ]) {
+      expect(validationScope(active, {
+        id: "masked-comparison", name: "validate",
+        arguments: { shell: "bash", command }
+      }, validationPlan)).toMatchObject({
+        coveredPaths: [],
+        claim: { kind: "probe", subject: { exactFiles: [] } }
+      });
+    }
+  });
+
+  it("does not infer tests from shell arguments or failure-masked commands", () => {
+    const active = frontierSession();
+    active.durable.state.mutationFrontier.changedPaths = ["program.py"];
+
+    for (const command of ["echo pytest", "pytest || true", "pytest | cat"]) {
+      expect(validationScope(active, {
+        id: "masked-test", name: "validate",
+        arguments: { shell: "bash", command }
+      }, validationPlan)).toMatchObject({
+        coveredPaths: [],
+        claim: { kind: "probe", subject: { exactFiles: [] } }
+      });
+    }
     expect(validationScope(active, {
-      id: "masked-comparison", name: "validate",
-      arguments: {
-        shell: "bash",
-        command: "python3 program.py > /tmp/actual && diff /tmp/actual /tmp/expected || echo FAIL"
-      }
+      id: "strict-test", name: "validate",
+      arguments: { shell: "bash", command: "cd . && pytest tests/test_program.py && echo PASS" }
     }, validationPlan)).toMatchObject({
-      coveredPaths: [],
-      claim: { kind: "probe", subject: { exactFiles: [] } }
+      coveredPaths: ["program.py"],
+      claim: { kind: "unit" }
     });
   });
 
-  it("recognizes direct Python syntax checks without upgrading them to unit evidence", () => {
+  it("recognizes structured Python syntax checks but not inline source text", () => {
     const active = frontierSession();
     active.durable.state.mutationFrontier.changedPaths = ["program.py"];
 
@@ -508,7 +532,7 @@ describe("V5 assurance-coordinated mutation completion", () => {
       id: "python-syntax", name: "validate",
       arguments: {
         executable: "/usr/bin/python3",
-        args: ["-c", "import py_compile; py_compile.compile('program.py', doraise=True)"]
+        args: ["-m", "py_compile", "program.py"]
       }
     }, validationPlan)).toMatchObject({
       coveredPaths: ["program.py"],
@@ -517,6 +541,19 @@ describe("V5 assurance-coordinated mutation completion", () => {
         subject: { exactFiles: ["program.py"] }
       }
     });
+    for (const script of [
+      "print('assert')",
+      "print(\"py_compile.compile('program.py')\")",
+      "# assert program behavior"
+    ]) {
+      expect(validationScope(active, {
+        id: "python-inline", name: "validate",
+        arguments: { executable: "/usr/bin/python3", args: ["-c", script] }
+      }, validationPlan)).toMatchObject({
+        coveredPaths: [],
+        claim: { kind: "probe", subject: { exactFiles: [] } }
+      });
+    }
   });
 
   it("recognizes direct Node test and check runners as semantic validation", () => {

--- a/tests/agent-runtime.measured-budget.test.ts
+++ b/tests/agent-runtime.measured-budget.test.ts
@@ -159,7 +159,7 @@ describe("provider-measured model budget settlement", () => {
       .toBe(false);
   });
 
-  it("forces a bounded tool action during deadline convergence", async () => {
+  it("projects only terminal tools during deadline convergence", async () => {
     const workspace = await mkdtemp(path.join(os.tmpdir(), "sigma-deadline-converge-workspace-"));
     const state = await mkdtemp(path.join(os.tmpdir(), "sigma-deadline-converge-state-"));
     const gateway = new InspectableGateway([requestInputResponse()]);
@@ -177,7 +177,10 @@ describe("provider-measured model budget settlement", () => {
 
     await expect(runtime.waitForOutcome(session.sessionId)).resolves.toMatchObject({ kind: "needs_input" });
     expect(gateway.requests[0]).toMatchObject({ maxOutputTokens: 2_048, toolChoice: "required" });
-    expect(gateway.requests[0].messages.some((message) => message.content.includes("Deadline stage is converge")))
+    expect(gateway.requests[0].tools.map((tool) => tool.name).sort()).toEqual([
+      "report_blocked", "request_user_input"
+    ]);
+    expect(gateway.requests[0].messages.some((message) => message.content.includes("Budget stage is terminal")))
       .toBe(true);
   });
 

--- a/tests/agent-runtime.measured-budget.test.ts
+++ b/tests/agent-runtime.measured-budget.test.ts
@@ -159,7 +159,7 @@ describe("provider-measured model budget settlement", () => {
       .toBe(false);
   });
 
-  it("projects only terminal tools during deadline convergence", async () => {
+  it("projects only terminal tools while preserving natural completion during deadline convergence", async () => {
     const workspace = await mkdtemp(path.join(os.tmpdir(), "sigma-deadline-converge-workspace-"));
     const state = await mkdtemp(path.join(os.tmpdir(), "sigma-deadline-converge-state-"));
     const gateway = new InspectableGateway([requestInputResponse()]);
@@ -176,12 +176,16 @@ describe("provider-measured model budget settlement", () => {
     await runtime.command({ type: "submit", sessionId: session.sessionId, text: "finish promptly" });
 
     await expect(runtime.waitForOutcome(session.sessionId)).resolves.toMatchObject({ kind: "needs_input" });
-    expect(gateway.requests[0]).toMatchObject({ maxOutputTokens: 2_048, toolChoice: "required" });
+    expect(gateway.requests[0]).toMatchObject({ maxOutputTokens: 2_048 });
+    expect(gateway.requests[0].toolChoice).toBeUndefined();
     expect(gateway.requests[0].tools.map((tool) => tool.name).sort()).toEqual([
       "report_blocked", "request_user_input"
     ]);
     expect(gateway.requests[0].messages.some((message) => message.content.includes("Budget stage is terminal")))
       .toBe(true);
+    expect(gateway.requests[0].messages.some((message) => message.content.includes(
+      "If the task is complete, stop naturally"
+    ))).toBe(true);
   });
 
   it("keeps a successful response when provider usage exceeds the admission reservation", async () => {
@@ -238,7 +242,7 @@ describe("provider-measured model budget settlement", () => {
 
     await expect(runtime.waitForOutcome(session.sessionId)).resolves.toMatchObject({ kind: "needs_input" });
     expect(gateway.requests).toHaveLength(1);
-    expect(gateway.requests[0].toolChoice).toBe("required");
+    expect(gateway.requests[0].toolChoice).toBeUndefined();
     expect(gateway.requests[0].tools.map((tool) => tool.name).sort()).toEqual([
       "report_blocked", "request_user_input"
     ]);

--- a/tests/agent-runtime.repository-recovery-policy.test.ts
+++ b/tests/agent-runtime.repository-recovery-policy.test.ts
@@ -2,13 +2,25 @@ import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { repositoryRecoveryObligation } from "../packages/agent-kernel/src/index.js";
+import {
+  recordToolPolicyViolation,
+  repositoryRecoveryObligation
+} from "../packages/agent-kernel/src/index.js";
 import type { ToolCallPlan, ToolDescriptor } from "../packages/agent-protocol/src/index.js";
 import {
   assertTaskControlCallAllowed,
   assertTaskControlPlanAllowed
 } from "../packages/agent-runtime/src/tool-plan-enforcement.js";
-import { descriptorAllowedForRepair } from "../packages/agent-runtime/src/tool-turn-policy.js";
+import {
+  deadlineBudgetStage,
+  prepareBudgetedModelTurn
+} from "../packages/agent-runtime/src/model-budget-convergence.js";
+import {
+  completionRepairPhase,
+  descriptorAllowedForRepair,
+  descriptorsAllowedForRepair,
+  maximumTaskControlCalls
+} from "../packages/agent-runtime/src/tool-turn-policy.js";
 import { runtimeSessionFixture } from "./testkit/runtime-session-fixture.js";
 
 function descriptor(name: string, effects: ToolDescriptor["possibleEffects"]): ToolDescriptor {
@@ -45,8 +57,21 @@ describe("repository recovery task-control projection", () => {
   const read = descriptor("read", ["filesystem.read"]);
   const patch = descriptor("apply_patch", ["filesystem.read", "filesystem.write"]);
   const exec = descriptor("exec", ["filesystem.read", "process.spawn"]);
+  const complete = descriptor("complete_task", ["outcome.propose"]);
 
-  it("binds a selected recovery candidate to one structured transaction", () => {
+  it("makes deadline convergence terminal when possible without hiding an active prerequisite", () => {
+    const forecast = {
+      stage: "converge" as const,
+      remainingMs: 40_000,
+      usableMs: 30_000,
+      nextModelEstimateMs: 15_000,
+      settlementReserveMs: 10_000
+    };
+    expect(deadlineBudgetStage(forecast, [read, complete])).toBe("terminal");
+    expect(deadlineBudgetStage(forecast, [transaction])).toBe("converge");
+  });
+
+  it("binds and projects a selected recovery candidate as one exact transaction", async () => {
     const session = runtimeSessionFixture();
     const candidateId = "c".repeat(64);
     session.durable.state.taskControl = repositoryRecoveryObligation(
@@ -69,6 +94,51 @@ describe("repository recovery task-control projection", () => {
       name: "git_transaction",
       arguments: { action: "recover", candidateId, selectionEvidenceId: "selection" }
     })).not.toThrow();
+    const projected = descriptorsAllowedForRepair(session, [transaction]);
+    expect(projected).toEqual([{
+      ...transaction,
+      description: "Recover the runtime-selected Git candidate with its bound selection evidence. The action and evidence fields are fixed by task control; call git_transaction exactly as projected.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          action: { type: "string", const: "recover" },
+          candidateId: { type: "string", const: candidateId },
+          selectionEvidenceId: { type: "string", const: "selection" }
+        },
+        required: ["action", "candidateId", "selectionEvidenceId"],
+        additionalProperties: false
+      }
+    }]);
+    const prepared = await prepareBudgetedModelTurn({
+      session,
+      forecast: {
+        stage: "normal", remainingMs: 60_000, usableMs: 50_000,
+        nextModelEstimateMs: 15_000, settlementReserveMs: 10_000
+      },
+      turnId: 1,
+      descriptors: projected,
+      capabilities: { skillsAvailable: false, executableSkillResourcesLoaded: false },
+      dynamic: [],
+      hookContext: [],
+      ledger: {
+        id: "ledger", authority: "runtime", provenance: "test ledger",
+        content: "{}", tokenCount: 1, priority: 1
+      },
+      available: {
+        inputTokens: 100_000, outputTokens: 100_000, costMicroUsd: 10_000_000,
+        modelTurns: 10, toolCalls: 10, children: 10
+      },
+      repairPending: true,
+      budgetStage: "normal",
+      defaultOutputReserveTokens: 4_096
+    });
+    expect(prepared.turn.toolChoice).toBe("required");
+    expect(prepared.turn.tools.map((tool) => tool.name)).toEqual(["git_transaction"]);
+    expect(prepared.turn.messages.some((message) => message.content.includes(
+      `Call git_transaction with exactly these arguments: ${JSON.stringify({
+        action: "recover", candidateId, selectionEvidenceId: "selection"
+      })}`
+    ))).toBe(true);
   });
 
   it("offers only re-inspection while resolving a user selection", () => {
@@ -84,7 +154,7 @@ describe("repository recovery task-control projection", () => {
     expect(descriptorAllowedForRepair(session, read)).toBe(false);
   });
 
-  it("scopes conflict reads and mutations to broker-observed paths", async () => {
+  it("allows workspace context reads but scopes conflict mutations to broker-observed paths", async () => {
     const workspace = await mkdtemp(path.join(os.tmpdir(), "sigma-repository-repair-"));
     await mkdir(path.join(workspace, "src"));
     await writeFile(path.join(workspace, "src", "conflict.ts"), "conflict\n", "utf8");
@@ -100,6 +170,56 @@ describe("repository recovery task-control projection", () => {
     expect(descriptorAllowedForRepair(session, read)).toBe(true);
     expect(descriptorAllowedForRepair(session, patch)).toBe(true);
     expect(descriptorAllowedForRepair(session, exec)).toBe(false);
+    const conflictEdit: ToolDescriptor = {
+      ...patch,
+      name: "edit",
+      inputSchema: {
+        type: "object",
+        properties: {
+          path: { type: "string" },
+          oldText: { type: "string" },
+          newText: { type: "string" }
+        },
+        required: ["path", "oldText", "newText"],
+        additionalProperties: false
+      }
+    };
+    const projected = descriptorsAllowedForRepair(
+      session, [read, conflictEdit, transaction]
+    );
+    expect((projected.find((item) => item.name === "edit")!.inputSchema.properties as any).path)
+      .toMatchObject({ const: "src/conflict.ts" });
+    expect(projected.find((item) => item.name === "git_transaction")!.description)
+      .toContain("active broker-journaled recovery transaction");
+    const prepared = await prepareBudgetedModelTurn({
+      session,
+      forecast: {
+        stage: "normal", remainingMs: 60_000, usableMs: 50_000,
+        nextModelEstimateMs: 15_000, settlementReserveMs: 10_000
+      },
+      turnId: 2,
+      descriptors: projected,
+      capabilities: { skillsAvailable: false, executableSkillResourcesLoaded: false },
+      dynamic: [],
+      hookContext: [],
+      ledger: {
+        id: "ledger", authority: "runtime", provenance: "test ledger",
+        content: "{}", tokenCount: 1, priority: 1
+      },
+      available: {
+        inputTokens: 100_000, outputTokens: 100_000, costMicroUsd: 10_000_000,
+        modelTurns: 10, toolCalls: 10, children: 10
+      },
+      repairPending: true,
+      budgetStage: "normal",
+      defaultOutputReserveTokens: 4_096
+    });
+    expect(prepared.turn.messages.some((message) => message.content.includes(
+      "may modify only these conflict paths: [\"src/conflict.ts\"]"
+    ))).toBe(true);
+    expect(prepared.turn.messages.some((message) => message.content.includes(
+      "transactionHandle \"transaction\""
+    ))).toBe(true);
     expect(() => assertTaskControlCallAllowed(session, {
       id: "continue",
       name: "git_transaction",
@@ -114,7 +234,113 @@ describe("repository recovery task-control projection", () => {
       session, plan(["src/conflict.ts"], ["src/conflict.ts"])
     )).resolves.toBeUndefined();
     await expect(assertTaskControlPlanAllowed(
-      session, plan(["src/other.ts"], ["src/other.ts"])
+      session, plan(["src/other.ts"], [])
+    )).resolves.toBeUndefined();
+    await expect(assertTaskControlPlanAllowed(
+      session, plan(["src/other.ts"], ["src/conflict.ts"])
+    )).resolves.toBeUndefined();
+    await expect(assertTaskControlPlanAllowed(
+      session, plan(["src/conflict.ts"], ["src/other.ts"])
     )).rejects.toMatchObject({ code: "tool_unavailable_for_repair" });
+    await expect(assertTaskControlPlanAllowed(
+      session, plan(["../outside.ts"], [])
+    )).rejects.toMatchObject({ code: "tool_unavailable_for_repair" });
+  });
+});
+
+describe("generic task-control convergence projection", () => {
+  it("reports runtime-owned no-progress state and points completed work at a completion action", async () => {
+    const session = runtimeSessionFixture();
+    session.durable.state.taskControl.phase = "focused";
+    session.durable.state.taskControl.episode.noProgressBatches = 4;
+    const descriptors = [
+      descriptor("read", ["filesystem.read"]),
+      descriptor("validate", ["filesystem.read", "process.spawn.readonly", "validation"]),
+      descriptor("complete", ["outcome.propose"])
+    ];
+
+    const prepared = await prepareBudgetedModelTurn({
+      session,
+      forecast: {
+        stage: "normal", remainingMs: 60_000, usableMs: 50_000,
+        nextModelEstimateMs: 15_000, settlementReserveMs: 10_000
+      },
+      turnId: 3,
+      descriptors,
+      capabilities: { skillsAvailable: false, executableSkillResourcesLoaded: false },
+      dynamic: [],
+      hookContext: [],
+      ledger: {
+        id: "ledger", authority: "runtime", provenance: "test ledger",
+        content: "{}", tokenCount: 1, priority: 1
+      },
+      available: {
+        inputTokens: 100_000, outputTokens: 100_000, costMicroUsd: 10_000_000,
+        modelTurns: 10, toolCalls: 10, children: 10
+      },
+      repairPending: true,
+      budgetStage: "normal",
+      defaultOutputReserveTokens: 4_096
+    });
+
+    expect(prepared.turn.messages.some((message) =>
+      message.content.includes("last 4 completed tool batches produced no new trusted task facts")
+      && message.content.includes("Do not repeat a read or command whose result is already known")
+      && message.content.includes("use a completion action now (complete)")
+    )).toBe(true);
+  });
+
+  it("allows one corrected parallel batch after JSON-encoded tool arguments are rejected", async () => {
+    const session = runtimeSessionFixture();
+    session.durable.state.taskControl = recordToolPolicyViolation(
+      {
+        ...session.durable.state.taskControl,
+        episode: {
+          ...session.durable.state.taskControl.episode,
+          noProgressBatches: 1
+        }
+      },
+      "tool_arguments_invalid",
+      session.durable.state.revision
+    );
+    const descriptors = [
+      descriptor("read", ["filesystem.read"]),
+      descriptor("shell", ["filesystem.read", "process.spawn.readonly"])
+    ];
+
+    expect(completionRepairPhase(session)).toBe("protocol_repair");
+    expect(maximumTaskControlCalls(session)).toBe(Number.MAX_SAFE_INTEGER);
+    expect(descriptorsAllowedForRepair(session, descriptors).map((item) => item.name))
+      .toEqual(["read", "shell"]);
+
+    const prepared = await prepareBudgetedModelTurn({
+      session,
+      forecast: {
+        stage: "normal", remainingMs: 60_000, usableMs: 50_000,
+        nextModelEstimateMs: 15_000, settlementReserveMs: 10_000
+      },
+      turnId: 4,
+      descriptors,
+      capabilities: { skillsAvailable: false, executableSkillResourcesLoaded: false },
+      dynamic: [],
+      hookContext: [],
+      ledger: {
+        id: "ledger", authority: "runtime", provenance: "test ledger",
+        content: "{}", tokenCount: 1, priority: 1
+      },
+      available: {
+        inputTokens: 100_000, outputTokens: 100_000, costMicroUsd: 10_000_000,
+        modelTurns: 10, toolCalls: 10, children: 10
+      },
+      repairPending: true,
+      budgetStage: "normal",
+      defaultOutputReserveTokens: 4_096
+    });
+
+    expect(prepared.turn.messages.some((message) =>
+      message.content.includes("do not JSON-encode the arguments object")
+      && message.content.includes("Independent corrected calls may be submitted together")
+      && !message.content.includes("exactly one tool call")
+    )).toBe(true);
   });
 });

--- a/tests/agent-runtime.repository-recovery-policy.test.ts
+++ b/tests/agent-runtime.repository-recovery-policy.test.ts
@@ -71,6 +71,56 @@ describe("repository recovery task-control projection", () => {
     expect(deadlineBudgetStage(forecast, [transaction])).toBe("converge");
   });
 
+  it("leaves natural completion available when terminal tools only report failure or request input", async () => {
+    const session = runtimeSessionFixture();
+    const reportBlocked = descriptor("report_blocked", ["outcome.report_blocked"]);
+    const requestInput = descriptor("request_user_input", ["outcome.request_input"]);
+    const input = {
+      session,
+      forecast: {
+        stage: "converge" as const,
+        remainingMs: 40_000,
+        usableMs: 30_000,
+        nextModelEstimateMs: 15_000,
+        settlementReserveMs: 10_000
+      },
+      turnId: 1,
+      descriptors: [read, reportBlocked, requestInput],
+      capabilities: { skillsAvailable: false, executableSkillResourcesLoaded: false },
+      dynamic: [],
+      hookContext: [],
+      ledger: {
+        id: "ledger", authority: "runtime" as const, provenance: "test ledger",
+        content: "{}", tokenCount: 1, priority: 1
+      },
+      available: {
+        inputTokens: 100_000, outputTokens: 100_000, costMicroUsd: 10_000_000,
+        modelTurns: 10, toolCalls: 10, children: 10
+      },
+      repairPending: false,
+      budgetStage: "terminal" as const,
+      defaultOutputReserveTokens: 4_096
+    };
+
+    const prepared = await prepareBudgetedModelTurn(input);
+    expect(prepared.turn.tools.map((tool) => tool.name))
+      .toEqual(["report_blocked", "request_user_input"]);
+    expect(prepared.turn.toolChoice).toBeUndefined();
+    expect(prepared.turn.messages.some((message) =>
+      message.content.includes("If the task is complete, stop naturally")
+    )).toBe(true);
+
+    const repair = await prepareBudgetedModelTurn({
+      ...input,
+      turnId: 2,
+      repairPending: true
+    });
+    expect(repair.turn.toolChoice).toBe("required");
+    expect(repair.turn.messages.some((message) =>
+      message.content.includes("If the task is complete, stop naturally")
+    )).toBe(false);
+  });
+
   it("binds and projects a selected recovery candidate as one exact transaction", async () => {
     const session = runtimeSessionFixture();
     const candidateId = "c".repeat(64);

--- a/tests/agent-runtime.reviewer-budget.test.ts
+++ b/tests/agent-runtime.reviewer-budget.test.ts
@@ -15,12 +15,16 @@ import {
   type ModelStreamEvent,
   type ModelToolDefinition,
   type ReviewEvidence,
+  type ToolReceipt,
   type ValidationEvidence,
   type WorkspaceDeltaEvidence
 } from "../packages/agent-protocol/src/index.js";
 import type { ModelRouteConstraints } from "../packages/agent-model/src/index.js";
 import { BudgetController, BudgetExceededError } from "../packages/agent-runtime/src/budget-controller.js";
-import { ReviewCoordinator } from "../packages/agent-runtime/src/review-coordinator.js";
+import {
+  goalReferencedWorkspaceReads,
+  ReviewCoordinator
+} from "../packages/agent-runtime/src/review-coordinator.js";
 import { ModelReviewer, type ReviewerPort } from "../packages/agent-runtime/src/reviewer.js";
 import type { RuntimeSession } from "../packages/agent-runtime/src/types.js";
 import { runtimeSessionFixture } from "./testkit/runtime-session-fixture.js";
@@ -288,6 +292,86 @@ function harness(target: RuntimeSession, crashBeforeUsage = false): {
 }
 
 describe("independent reviewer budget accounting", () => {
+  it("supplies bounded snapshots only for workspace reads named in the goal", () => {
+    const target = runtimeSessionFixture();
+    target.durable.state.plan.goal = "Update config.txt according to rules.txt.";
+    target.durable.state.messages = [{
+      role: "assistant",
+      content: "",
+      toolCalls: [
+        { id: "rules-read", name: "read", arguments: { path: "rules.txt" } },
+        { id: "notes-read", name: "read", arguments: { path: "notes.txt" } }
+      ]
+    }];
+    const readReceipt = (callId: string, requestedPath: string, output: string): ToolReceipt => ({
+      callId,
+      ok: true,
+      output,
+      result: {
+        status: "read",
+        path: requestedPath,
+        scope: "workspace",
+        sha256: "a".repeat(64),
+        byteLength: output.length,
+        offset: 0,
+        returnedLines: 1,
+        totalLines: 1
+      },
+      outcome: { status: "succeeded", output, diagnosticCodes: [] },
+      observedEffects: ["filesystem.read"],
+      actualEffects: ["filesystem.read"],
+      artifacts: [],
+      diagnostics: [],
+      startedAt: now,
+      completedAt: now
+    });
+    target.durable.state.receipts = [
+      readReceipt("rules-read", "rules.txt", "1: allowed"),
+      readReceipt("notes-read", "notes.txt", "1: unrelated")
+    ];
+
+    expect(goalReferencedWorkspaceReads(target)).toEqual([expect.objectContaining({
+      path: "rules.txt",
+      complete: true,
+      content: "1: allowed"
+    })]);
+  });
+
+  it("places goal-referenced workspace snapshots in the independent review request", async () => {
+    const gateway = new ReviewerGateway();
+    await new ModelReviewer(gateway).review({
+      sessionId: "session",
+      runId: "run",
+      goal: "Constrain the change with rules.txt.",
+      frontierRevision: 1,
+      stateDigest: "a".repeat(64),
+      reviewBasisDigest: "b".repeat(64),
+      workspaceDeltas: [delta()],
+      validations: [validation()],
+      goalReferencedWorkspaceReads: [{
+        path: "rules.txt",
+        sha256: "c".repeat(64),
+        byteLength: 9,
+        offset: 0,
+        returnedLines: 1,
+        totalLines: 1,
+        complete: true,
+        content: "1: allowed"
+      }]
+    }, new AbortController().signal);
+
+    const request = gateway.requests[0]!;
+    const payload = JSON.parse(request.messages[1]!.content) as {
+      goalReferencedWorkspaceReads: Array<{ path: string; complete: boolean; content: string }>;
+    };
+    expect(request.messages[0]!.content).toContain("goal-referenced workspace read snapshots");
+    expect(payload.goalReferencedWorkspaceReads).toEqual([expect.objectContaining({
+      path: "rules.txt",
+      complete: true,
+      content: "1: allowed"
+    })]);
+  });
+
   it("rejects exhausted reviewer budget before invoking the model", async () => {
     const target = runtimeSession(limits({ inputTokens: 119 }));
     const gateway = new ReviewerGateway();

--- a/tests/agent-runtime.reviewer-budget.test.ts
+++ b/tests/agent-runtime.reviewer-budget.test.ts
@@ -31,6 +31,60 @@ import { runtimeSessionFixture } from "./testkit/runtime-session-fixture.js";
 
 const now = "2026-07-11T00:00:00.000Z";
 
+function workspaceReadReceipt(
+  callId: string,
+  requestedPath: string,
+  output: string,
+  options: {
+    sha256?: string;
+    offset?: number;
+    returnedLines?: number;
+    totalLines?: number;
+  } = {}
+): ToolReceipt {
+  const offset = options.offset ?? 0;
+  const returnedLines = options.returnedLines ?? 1;
+  const totalLines = options.totalLines ?? 1;
+  return {
+    callId,
+    ok: true,
+    output,
+    result: {
+      status: "read",
+      path: requestedPath,
+      scope: "workspace",
+      sha256: options.sha256 ?? "a".repeat(64),
+      byteLength: output.length,
+      offset,
+      returnedLines,
+      totalLines
+    },
+    outcome: { status: "succeeded", output, diagnosticCodes: [] },
+    observedEffects: ["filesystem.read"],
+    actualEffects: ["filesystem.read"],
+    artifacts: [],
+    diagnostics: [],
+    startedAt: now,
+    completedAt: now
+  };
+}
+
+function workspaceMutationReceipt(callId: string, modifiedPath: string): ToolReceipt {
+  return {
+    callId,
+    ok: true,
+    output: "updated",
+    outcome: { status: "succeeded", output: "updated", diagnosticCodes: [] },
+    observedEffects: ["filesystem.write"],
+    actualEffects: ["filesystem.write"],
+    workspaceDelta: { added: [], modified: [modifiedPath], deleted: [] },
+    artifacts: [],
+    diagnostics: [],
+    startedAt: now,
+    completedAt: now
+  };
+}
+
 class ReviewerGateway implements ModelGateway {
   readonly provider = "deepseek";
   readonly model = "deepseek-v4-pro";
@@ -303,37 +357,55 @@ describe("independent reviewer budget accounting", () => {
         { id: "notes-read", name: "read", arguments: { path: "notes.txt" } }
       ]
     }];
-    const readReceipt = (callId: string, requestedPath: string, output: string): ToolReceipt => ({
-      callId,
-      ok: true,
-      output,
-      result: {
-        status: "read",
-        path: requestedPath,
-        scope: "workspace",
-        sha256: "a".repeat(64),
-        byteLength: output.length,
-        offset: 0,
-        returnedLines: 1,
-        totalLines: 1
-      },
-      outcome: { status: "succeeded", output, diagnosticCodes: [] },
-      observedEffects: ["filesystem.read"],
-      actualEffects: ["filesystem.read"],
-      artifacts: [],
-      diagnostics: [],
-      startedAt: now,
-      completedAt: now
-    });
     target.durable.state.receipts = [
-      readReceipt("rules-read", "rules.txt", "1: allowed"),
-      readReceipt("notes-read", "notes.txt", "1: unrelated")
+      workspaceReadReceipt("rules-read", "rules.txt", "1: allowed"),
+      workspaceReadReceipt("notes-read", "notes.txt", "1: unrelated")
     ];
 
     expect(goalReferencedWorkspaceReads(target)).toEqual([expect.objectContaining({
       path: "rules.txt",
       complete: true,
       content: "1: allowed"
+    })]);
+  });
+
+  it("uses current complete snapshots and drops reads invalidated by later mutations", () => {
+    const target = runtimeSessionFixture();
+    target.durable.state.plan.goal = "Update config.txt according to rules.txt and policy.txt.";
+    target.durable.state.messages = [{
+      role: "assistant",
+      content: "",
+      toolCalls: [
+        { id: "rules-old", name: "read", arguments: { path: "rules.txt" } },
+        { id: "rules-current", name: "read", arguments: { path: "rules.txt" } },
+        { id: "rules-partial", name: "read", arguments: { path: "rules.txt" } },
+        { id: "policy-stale", name: "read", arguments: { path: "policy.txt" } }
+      ]
+    }];
+    const currentRules = "1: current\n2: retained";
+    target.durable.state.receipts = [
+      workspaceReadReceipt("rules-old", "rules.txt", "1: obsolete", {
+        sha256: "a".repeat(64)
+      }),
+      workspaceReadReceipt("rules-current", "rules.txt", currentRules, {
+        sha256: "b".repeat(64),
+        returnedLines: 2,
+        totalLines: 2
+      }),
+      workspaceReadReceipt("rules-partial", "rules.txt", "1: current", {
+        sha256: "b".repeat(64),
+        returnedLines: 1,
+        totalLines: 2
+      }),
+      workspaceReadReceipt("policy-stale", "policy.txt", "1: stale"),
+      workspaceMutationReceipt("policy-write", "policy.txt")
+    ];
+
+    expect(goalReferencedWorkspaceReads(target)).toEqual([expect.objectContaining({
+      path: "rules.txt",
+      sha256: "b".repeat(64),
+      complete: true,
+      content: currentRules
     })]);
   });
 

--- a/tests/agent-runtime.tool-approval-coordinator.test.ts
+++ b/tests/agent-runtime.tool-approval-coordinator.test.ts
@@ -5,6 +5,7 @@ import type {
   ToolEffect
 } from "../packages/agent-protocol/src/index.js";
 import { ToolApprovalCoordinator } from "../packages/agent-runtime/src/tool-approval-coordinator.js";
+import { repositoryRecoveryObligation } from "../packages/agent-kernel/src/index.js";
 import type { RuntimeSession } from "../packages/agent-runtime/src/types.js";
 import { runtimeSessionFixture } from "./testkit/runtime-session-fixture.js";
 import { describe, expect, it, vi } from "vitest";
@@ -121,6 +122,163 @@ describe("deny-mode internal terminal approval", () => {
 });
 
 describe("sensitive external-read and handoff approval", () => {
+  it("workspace-auto issues a bound automatic grant for an authenticated recovery transaction", async () => {
+    const emit = vi.fn(async () => ({}));
+    const coordinator = new ToolApprovalCoordinator({
+      runtime: { permissionMode: "workspace-auto", interactiveApprovals: false } as never,
+      emit: emit as never,
+      finish: vi.fn() as never
+    });
+    const session = runtimeSessionFixture();
+    const candidateId = "c".repeat(64);
+    const selectionEvidenceId = "repository-recovery-selection:selection";
+    session.durable.state.taskControl = repositoryRecoveryObligation(
+      session.durable.state.taskControl,
+      session.durable.state.revision,
+      "transact",
+      { candidateId, selectionEvidenceId },
+      { candidateId, selectionEvidenceId }
+    );
+    const recoveryCall: ModelToolCall = {
+      id: "recover",
+      name: "git_transaction",
+      arguments: { action: "recover", candidateId, selectionEvidenceId }
+    };
+    const recoveryDescriptor: ToolDescriptor = {
+      ...descriptor(["repository.write", "filesystem.write", "destructive"]),
+      name: "git_transaction",
+      brokerMutationAuthority: "repository_transaction_v2"
+    };
+    const recoveryPlan: ToolCallPlan = {
+      ...plan(["repository.write", "filesystem.write", "destructive"]),
+      mutationAuthority: "broker_repository_transaction_v2",
+      writePaths: ["."],
+      idempotence: "non_replayable"
+    };
+    const prepared = {
+      call: recoveryCall,
+      modelTurn: { turnId: 1, effectRevision: 1 },
+      descriptor: recoveryDescriptor,
+      plan: recoveryPlan
+    };
+
+    await expect(coordinator.decision(
+      session, prepared, new AbortController().signal
+    )).resolves.toBe("allow");
+    expect(coordinator.consume(session, prepared)).toMatchObject({ authority: "runtime" });
+    expect(emit).toHaveBeenCalledWith(
+      session,
+      "tool.approval_requested",
+      "runtime",
+      expect.objectContaining({ approvalMode: "automatic", toolName: "git_transaction" })
+    );
+  });
+
+  it("workspace-auto automatically continues only the bound recovery conflict paths", async () => {
+    const emit = vi.fn(async () => ({}));
+    const coordinator = new ToolApprovalCoordinator({
+      runtime: { permissionMode: "workspace-auto", interactiveApprovals: false } as never,
+      emit: emit as never,
+      finish: vi.fn() as never
+    });
+    const session = runtimeSessionFixture();
+    session.durable.state.taskControl = repositoryRecoveryObligation(
+      session.durable.state.taskControl,
+      session.durable.state.revision,
+      "transact",
+      { conflict: "pending" },
+      { transactionId: "bound-transaction", scopePaths: ["src/conflict.ts"] }
+    );
+    const continuationCall: ModelToolCall = {
+      id: "continue",
+      name: "git_transaction",
+      arguments: {
+        action: "continue",
+        transactionHandle: "bound-transaction",
+        operations: [{ op: "add", paths: ["src/conflict.ts"] }]
+      }
+    };
+    const continuationDescriptor: ToolDescriptor = {
+      ...descriptor(["repository.write", "filesystem.write"]),
+      name: "git_transaction",
+      brokerMutationAuthority: "repository_transaction_v2"
+    };
+    const continuationPlan: ToolCallPlan = {
+      ...plan(["repository.write", "filesystem.write"]),
+      mutationAuthority: "broker_repository_transaction_v2",
+      writePaths: ["."],
+      idempotence: "non_replayable"
+    };
+    const prepared = {
+      call: continuationCall,
+      modelTurn: { turnId: 1, effectRevision: 1 },
+      descriptor: continuationDescriptor,
+      plan: continuationPlan
+    };
+
+    await expect(coordinator.decision(
+      session, prepared, new AbortController().signal
+    )).resolves.toBe("allow");
+    expect(coordinator.consume(session, prepared)).toMatchObject({ authority: "runtime" });
+    expect(emit).toHaveBeenCalledWith(
+      session,
+      "tool.approval_requested",
+      "runtime",
+      expect.objectContaining({ approvalMode: "automatic", toolName: "git_transaction" })
+    );
+  });
+
+  it("workspace-auto does not auto-approve an off-scope recovery continuation", async () => {
+    const emit = vi.fn(async () => ({}));
+    const finish = vi.fn(async () => true);
+    const coordinator = new ToolApprovalCoordinator({
+      runtime: { permissionMode: "workspace-auto", interactiveApprovals: false } as never,
+      emit: emit as never,
+      finish: finish as never
+    });
+    const session = runtimeSessionFixture();
+    session.durable.state.taskControl = repositoryRecoveryObligation(
+      session.durable.state.taskControl,
+      session.durable.state.revision,
+      "transact",
+      { conflict: "pending" },
+      { transactionId: "bound-transaction", scopePaths: ["src/conflict.ts"] }
+    );
+    const prepared = {
+      call: {
+        id: "continue-off-scope",
+        name: "git_transaction",
+        arguments: {
+          action: "continue",
+          transactionHandle: "bound-transaction",
+          operations: [{ op: "add", paths: ["src/unrelated.ts"] }]
+        }
+      },
+      modelTurn: { turnId: 1, effectRevision: 1 },
+      descriptor: {
+        ...descriptor(["repository.write", "filesystem.write"]),
+        name: "git_transaction",
+        brokerMutationAuthority: "repository_transaction_v2" as const
+      },
+      plan: {
+        ...plan(["repository.write", "filesystem.write"]),
+        mutationAuthority: "broker_repository_transaction_v2" as const,
+        writePaths: ["."],
+        idempotence: "non_replayable" as const
+      }
+    };
+
+    await expect(coordinator.decision(
+      session, prepared, new AbortController().signal
+    )).rejects.toMatchObject({ code: "approval_needs_input" });
+    expect(finish).toHaveBeenCalledWith(
+      session,
+      expect.objectContaining({ kind: "needs_input" }),
+      undefined,
+      expect.any(Object)
+    );
+  });
+
   it("workspace-auto permits local writes but prompts for authority expansion", async () => {
     const emit = vi.fn(async () => ({}));
     const coordinator = new ToolApprovalCoordinator({

--- a/tests/test_harbor_agent.py
+++ b/tests/test_harbor_agent.py
@@ -114,6 +114,13 @@ class HarborAgentTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(module.SigmaCliHarborAgent(network_mode="loopback").network_mode, "loopback")
         with self.assertRaisesRegex(ValueError, "agent_profile"):
             module.SigmaCliHarborAgent(agent_profile="untrusted")
+        with self.assertRaisesRegex(ValueError, "permission_mode"):
+            module.SigmaCliHarborAgent(permission_mode="untrusted")
+        self.assertEqual(module.SigmaCliHarborAgent()._permission_mode(), "auto")
+        self.assertEqual(
+            module.SigmaCliHarborAgent(permission_mode="workspace-auto")._permission_mode(),
+            "workspace-auto",
+        )
         with self.assertRaisesRegex(ValueError, "managed_environment_mode"):
             module.SigmaCliHarborAgent(managed_environment_mode="optional")
         with self.assertRaisesRegex(ValueError, "harbor_topology"):
@@ -165,11 +172,11 @@ class HarborAgentTest(unittest.IsolatedAsyncioTestCase):
             self.assertIn("required", session_command)
             self.assertIn("--agent-profile", session_command)
             self.assertIn("standard", session_command)
-            self.assertIn("workspace-auto", command)
-            self.assertIn("workspace-auto", session_command)
+            self.assertIn("auto", command)
+            self.assertIn("auto", session_command)
             self.assertNotIn("HOME=/tmp/agent/disposable-home", command)
 
-    async def test_verified_managed_environment_uses_noninteractive_auto_approval(self):
+    async def test_managed_environment_keeps_noninteractive_auto_approval(self):
         module = import_portable_agent_module()
         with TemporaryDirectory() as tmp:
             agent = module.SigmaCliHarborAgent(
@@ -181,9 +188,7 @@ class HarborAgentTest(unittest.IsolatedAsyncioTestCase):
             )
             agent._workspace = "/app"
 
-            # Configuration alone is not authority. The strict managed doctor
-            # contract must have succeeded before Harbor can remove prompts.
-            self.assertEqual(agent._permission_mode(), "workspace-auto")
+            self.assertEqual(agent._permission_mode(), "auto")
             agent._managed_environment_verified = True
 
             command = agent._agent_command()
@@ -547,7 +552,7 @@ class HarborAgentTest(unittest.IsolatedAsyncioTestCase):
             command, kwargs = main_commands[0]
             self.assertIn("--prompt-file /tmp/agent/instruction.md", command)
             self.assertIn("--run-deadline-sec 600", command)
-            self.assertIn("--permission-mode workspace-auto", command)
+            self.assertIn("--permission-mode auto", command)
             self.assertIn("--agent-profile standard", command)
             self.assertIn("--output-format stream-json", command)
             self.assertIn("--output-schema 3", command)


### PR DESCRIPTION
## Summary

- harden broker-journaled Git recovery, selection evidence, transaction sealing, approval handling, and Harbor adapter behavior
- recognize compiler, Python, strict shell, Coq, COBOL, and TeX validation evidence against the current mutation frontier
- make tool-argument protocol repair and no-progress convergence deterministic without task-specific behavior
- mount standard Linux runtime state read-only so sandboxed compilers can load system data
- force terminal projection when deadline convergence begins and give the independent reviewer bounded snapshots of goal-referenced workspace reads

## Root cause

Several generic runtime policies did not compose correctly: repository recovery evidence could lose required state, corrected multi-call tool batches were projected as single-call repairs, successful semantic checks were classified as probes, deadline convergence was advisory rather than enforceable, and the reviewer lacked immutable reference-file content needed to check cross-file constraints.

## Impact

The agent can recover Git state safely, execute corrected tool batches, recognize meaningful validation, use system compiler data inside the sandbox, terminate before deadline exhaustion, and review constrained changes with better evidence. Evaluation permissions remain automatic while execution stays sandboxed and network-isolated.

## Validation

- `pnpm typecheck`
- ESLint on all touched TypeScript files
- related Vitest suites: 145 unique tests passed; 30 intentionally skipped; one timing-sensitive queue test was rerun alone and passed
- `cargo fmt --manifest-path native/sigma-exec/Cargo.toml -- --check`
- `cargo test --manifest-path native/sigma-exec/Cargo.toml` — 95 passed
- `uv run --with pytest pytest tests/test_harbor_agent.py -q` — 38 passed, 10 subtests passed
- `pnpm eval:fairness`
- `git diff --check`
- Terminal-Bench: `fix-git`, `prove-plus-comm`, and `cobol-modernization` passed; `overfull-hbox` completed and reached its verifier but did not pass the final verifier check
