### PR TITLE
Stabilize release property tests and verifier isolation

### DIFF
--- a/scripts/eval/runner.mjs
+++ b/scripts/eval/runner.mjs
@@ -894,6 +894,19 @@ async function runVerifierWitness(context, lifecycle, prepared, subjectResult, c
   return { verifier, verifierDelta };
 }
 
+export function verifierWitnessPaths(controllerDir, scratchLease, platform = process.platform) {
+  // Windows exposes the broker-issued scratch path as a host-writable ACL
+  // boundary. Linux exposes an in-sandbox mount destination instead, so host
+  // staging must stay in the attempt's unique controller directory.
+  const stagingRoot = platform === "win32" ? scratchLease.home : controllerDir;
+  const pathApi = platform === "win32" ? path.win32 : path.posix;
+  return {
+    verifierWorkspace: pathApi.join(stagingRoot, "verifier-workspace"),
+    verifierManifestDir: pathApi.join(stagingRoot, "verifier-manifest"),
+    verifierHome: scratchLease.home
+  };
+}
+
 async function verifyAttempt(context, lifecycle, prepared, subjectResult, collected) {
   const { scenario, verifierRuntime } = context;
   const { controllerDir } = prepared;
@@ -924,15 +937,12 @@ async function verifyAttempt(context, lifecycle, prepared, subjectResult, collec
       protocolVersion: 1,
       sessionId: verifierSessionId
     }, { timeoutMs: 5_000 });
-    const verifierWorkspace = path.join(scratchLease.home, "workspace");
-    const verifierManifestDir = path.join(scratchLease.home, "manifest");
+    const witnessPaths = verifierWitnessPaths(controllerDir, scratchLease);
     // Windows has no same-path COW mount. A broker-issued RuntimeSession
     // scratch lease supplies the equivalent ephemeral writable witness while
     // preserving Git metadata and host-workspace fail-closed defaults.
     return await runVerifierWitness(context, lifecycle, prepared, subjectResult, collected, {
-      verifierWorkspace,
-      verifierManifestDir,
-      verifierHome: scratchLease.home,
+      ...witnessPaths,
       scratchLease,
       broker
     });

--- a/scripts/eval/verifier.mjs
+++ b/scripts/eval/verifier.mjs
@@ -52,6 +52,10 @@ export function verifierNodeToolchain(nodePath, api, platform = process.platform
 
 async function execute(broker, executable, args, options) {
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  // A scratch lease's home is a broker-projected sandbox destination on
+  // Linux, not a host filesystem root. The capability mounts and authorizes
+  // it separately; only non-lease verifier homes belong in ordinary roots.
+  const homeRoots = options.scratchLease ? [] : [options.home];
   const result = await broker.execute({
     command: {
       executable,
@@ -71,8 +75,8 @@ async function execute(broker, executable, args, options) {
     policy: {
       sandbox: "required",
       network: "none",
-      readRoots: [...new Set([options.workspace, options.manifestDir, path.dirname(executable), options.home])],
-      writeRoots: [options.workspace, options.home],
+      readRoots: [...new Set([options.workspace, options.manifestDir, path.dirname(executable), ...homeRoots])],
+      writeRoots: [...new Set([options.workspace, ...homeRoots])],
       ...(options.scratchLease ? { scratchLease: options.scratchLease } : {})
     },
     timeoutMs,

--- a/tests/agent-eval-runner.test.ts
+++ b/tests/agent-eval-runner.test.ts
@@ -6,7 +6,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { artifactSecretValues, evalRootDir, loadEvalSecrets, subjectEnvironment } from "../scripts/eval/common.mjs";
 import {
   evaluatorDigestFromSnapshot, measureEvaluationToolchain, packageManagerInvocation,
-  resolveEvaluatorHost, runEvaluation, verifierSourceDigest
+  resolveEvaluatorHost, runEvaluation, verifierSourceDigest, verifierWitnessPaths
 } from "../scripts/eval/runner.mjs";
 import { breachedBudget, terminalBudgetCancellation } from "../scripts/eval/subject-cli.mjs";
 
@@ -102,6 +102,19 @@ async function manifest(options: {
 }
 
 describe("agent experience evaluation runner", () => {
+  it("stages verifier evidence in a host path appropriate to each scratch implementation", () => {
+    expect(verifierWitnessPaths("/tmp/controller", { home: "/home/runner" }, "linux")).toEqual({
+      verifierWorkspace: path.posix.join("/tmp/controller", "verifier-workspace"),
+      verifierManifestDir: path.posix.join("/tmp/controller", "verifier-manifest"),
+      verifierHome: "/home/runner"
+    });
+    expect(verifierWitnessPaths("C:\\controller", { home: "C:\\scratch\\home" }, "win32")).toEqual({
+      verifierWorkspace: path.win32.join("C:\\scratch\\home", "verifier-workspace"),
+      verifierManifestDir: path.win32.join("C:\\scratch\\home", "verifier-manifest"),
+      verifierHome: "C:\\scratch\\home"
+    });
+  });
+
   it("measures the pinned Node, pnpm, Rust, provider, and model environment", async () => {
     const measurement = await measureEvaluationToolchain();
     expect(measurement).toMatchObject({

--- a/tests/agent-eval-verifier.test.ts
+++ b/tests/agent-eval-verifier.test.ts
@@ -68,6 +68,74 @@ describe("agent evaluation verifier isolation", () => {
     expect(result.checks[0].message).toMatch(/symbolic link|junction/iu);
   });
 
+  it("keeps a broker-projected scratch home out of ordinary verifier roots", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "sigma-eval-verifier-policy-"));
+    temporary.push(root);
+    const workspace = path.join(root, "workspace");
+    const manifestDir = path.join(root, "manifest");
+    const artifactDir = path.join(root, "artifacts");
+    const nodePath = path.join(root, "runtime", "node");
+    const verifierHome = path.join(root, "sandbox-home");
+    await Promise.all([mkdir(workspace), mkdir(manifestDir), mkdir(artifactDir)]);
+    const scratchLease = {
+      protocolVersion: 1,
+      leaseId: "scratch-1",
+      sessionId: "verifier-1",
+      lifetime: "runtime_session",
+      isolation: "private",
+      persistentAcrossCalls: true,
+      home: verifierHome,
+      temp: path.join(root, "sandbox-temp")
+    };
+    const requests: Array<{
+      command: { environment: { overrides: Record<string, string> } };
+      policy: { readRoots: string[]; writeRoots: string[]; scratchLease?: typeof scratchLease };
+    }> = [];
+    const broker = {
+      execute: async (request: (typeof requests)[number]) => {
+        requests.push(request);
+        return {
+          exitCode: 0,
+          signal: null,
+          stdout: "",
+          stderr: "",
+          timedOut: false,
+          outputTruncated: false
+        };
+      }
+    };
+
+    const result = await runPostVerifier({
+      scenario: {
+        expectedTerminal: "completed",
+        verifier: { checks: [{ type: "command", argv: ["node", "verify.mjs"] }] }
+      },
+      workspace,
+      manifestDir,
+      delta: { added: [], modified: [], deleted: [] },
+      initialGit: { status: "", diff: "" },
+      finalGit: { status: "", diff: "" },
+      subjectResult: { result: { status: "completed" } },
+      events: [],
+      metrics: { terminal: { type: "run.completed" } },
+      artifactDir,
+      redactor: String,
+      verifierHome,
+      scratchLease,
+      broker,
+      nodePath
+    });
+
+    expect(result.status).toBe("pass");
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.policy).toMatchObject({
+      readRoots: [workspace, manifestDir, path.dirname(nodePath)],
+      writeRoots: [workspace],
+      scratchLease
+    });
+    expect(requests[0]?.command.environment.overrides.HOME).toBe(verifierHome);
+  });
+
   it("verifies one user interruption by event count even when the message has multiple question marks", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "sigma-eval-event-check-"));
     temporary.push(root);

--- a/tests/agent-runtime.property.test.ts
+++ b/tests/agent-runtime.property.test.ts
@@ -267,5 +267,5 @@ describe("plan and budget invariant properties", () => {
       });
       expect(frame.items.reduce((total, item) => total + item.tokenCount, 0)).toBeLessThanOrEqual(8_128);
     }
-  });
+  }, 30_000);
 });


### PR DESCRIPTION
## Summary
- give the deterministic 200-case runtime property stress test 30 seconds of CI headroom without reducing its iterations or assertions
- stage verifier evidence in host-safe paths instead of treating a Linux sandbox mount destination as a shared host directory
- keep broker-projected scratch HOME authority separate from ordinary verifier read/write roots
- add cross-platform regression coverage for witness placement and verifier policy

## Evidence
- `pnpm lint`
- `pnpm eval:fairness`
- `pnpm exec vitest run tests/agent-eval-runner.test.ts tests/agent-eval-verifier.test.ts` (36 passed)
- `pnpm test:coverage` (1458 passed, 26 skipped; statements/lines 84.92%, branches 81.03%, functions 89.02%)
- the pre-update PR run 30303158858 passed all four CI jobs, confirming the property-test timeout fix under Windows and Linux load

## Release dry-run diagnosis
Run 30302428682 reached release-ready packaging and passed the DeepSeek provider smoke. Its quick-five evidence was invalidated by verifier infrastructure: four attempts collided on `/home/runner/manifest`, while the first declared the projected HOME as an ordinary write root overlapping the verifier Node execution root. This patch fixes those general isolation defects without changing scenarios, verifier expectations, retries, or benchmark behavior.