### PR TITLE
fix(release): pass repository to gh publish

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -354,4 +354,5 @@ jobs:
           if [[ "${RELEASE_LIVE_EVAL_OVERRIDE}" == "true" ]]; then
             assets+=("release-assets/release-live-evaluation-override.json")
           fi
-          gh release create "${GITHUB_REF_NAME}" "${assets[@]}" --notes "${release_notes}" "${options[@]}"
+          gh release create "${GITHUB_REF_NAME}" "${assets[@]}" \
+            --repo "${GITHUB_REPOSITORY}" --notes "${release_notes}" "${options[@]}"


### PR DESCRIPTION
## What changed

Pass `--repo "${GITHUB_REPOSITORY}"` to `gh release create` in the checkout-free publication job.

## Root cause

Release run 30316339551 completed both Linux and Windows verification jobs successfully, then the publish job failed because GitHub CLI tried to infer the repository from a local `.git` directory. That job intentionally downloads artifacts without checking out the repository, so no `.git` directory exists.

## Impact

Future tag workflows can create the GitHub Release from the already verified artifacts without adding an unnecessary checkout.

## Validation

- `git diff --check`
- official `actionlint` v1.7.12