### PR TITLE
feat(cli): serve Sigma Runtime over ACP v1

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,10 +85,11 @@
     "bench:tb:identity-archive": "node scripts/bench-task-identity-archive.mjs"
   },
   "devDependencies": {
+    "@agentclientprotocol/sdk": "1.3.0",
+    "@eslint/js": "^10.0.1",
     "@opentui/core": "0.4.3",
     "@stryker-mutator/core": "9.6.1",
     "@stryker-mutator/vitest-runner": "9.6.1",
-    "@eslint/js": "^10.0.1",
     "@types/node": "^24.0.0",
     "@vitest/coverage-v8": "3.2.6",
     "cross-env": "10.1.0",

--- a/packages/agent-cli/package.json
+++ b/packages/agent-cli/package.json
@@ -7,7 +7,8 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {
-    "agent": "./dist/index.js"
+    "agent": "./dist/index.js",
+    "sigma": "./dist/index.js"
   },
   "exports": {
     ".": {
@@ -22,6 +23,7 @@
     "clean": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\""
   },
   "dependencies": {
+    "@agentclientprotocol/sdk": "1.3.0",
     "agent-code-intel": "workspace:*",
     "agent-config": "workspace:*",
     "agent-execution": "workspace:*",

--- a/packages/agent-cli/src/acp/sigma-acp-agent.ts
+++ b/packages/agent-cli/src/acp/sigma-acp-agent.ts
@@ -1,236 +1,42 @@
 import { randomUUID } from "node:crypto";
-import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import path from "node:path";
 import * as acp from "@agentclientprotocol/sdk";
+import { SigmaAcpEventForwarder } from "./sigma-acp-events.js";
+import { SigmaAcpSessionRegistry } from "./sigma-acp-session-registry.js";
 import {
-  isAgentEventOf,
-  type AgentEventEnvelope,
-  type AgentEventOf,
-  type RunMode,
-  type RunOutcome,
-  type RuntimeClient
-} from "agent-protocol";
+  MODEL_CONFIG_ID,
+  expectedAbort,
+  listOffset,
+  modelConfig,
+  parseHealthRequest,
+  parseSigmaTextCommand,
+  promptText,
+  sessionModes,
+  stopReason,
+  titleFromPrompt,
+  type ForwardState,
+  type PersistedAcpSession,
+  type ResolvedSession,
+  type SigmaAcpAgentOptions,
+  type SigmaTextCommand
+} from "./sigma-acp-shared.js";
 
-const SESSION_INDEX_FILE = "acp-sessions.json";
-const MODEL_CONFIG_ID = "sigma.model";
-const INDEX_VERSION = 1;
-
-export interface SigmaAcpRuntimeHandle {
-  runtime: RuntimeClient;
-  workspace: string;
-  storeRootDir: string;
-  close(): Promise<void>;
-}
-
-export interface SigmaAcpModelOption {
-  id: string;
-  name: string;
-  description?: string;
-}
-
-export interface SigmaAcpModelCatalog {
-  currentModelId: string;
-  options: SigmaAcpModelOption[];
-}
-
-export interface SigmaAcpAgentOptions {
-  agentVersion: string;
-  runtimeFactory(cwd: string, modelId: string): Promise<SigmaAcpRuntimeHandle>;
-  modelCatalog(cwd: string): Promise<SigmaAcpModelCatalog>;
-  stderr?: NodeJS.WritableStream;
-}
-
-interface PersistedAcpSession {
-  sessionId: string;
-  runtimeSessionId: string;
-  cwd: string;
-  modelId: string;
-  mode: RunMode;
-  title?: string;
-  createdAt: string;
-  updatedAt: string;
-  started: boolean;
-  lastSeq: number;
-}
-
-interface PersistedAcpIndex {
-  version: typeof INDEX_VERSION;
-  sessions: PersistedAcpSession[];
-}
-
-interface ResolvedSession {
-  record: PersistedAcpSession;
-  handle: SigmaAcpRuntimeHandle;
-}
-
-interface ForwardState {
-  modelText: Map<number, string>;
-  reasoningText: Map<number, string>;
-}
-
-interface SigmaTextCommand {
-  sessionId: string;
-  text: string;
-}
-
-function parseSigmaTextCommand(value: unknown): SigmaTextCommand {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    throw new Error("Sigma ACP command params must be an object.");
-  }
-  const params = value as Record<string, unknown>;
-  if (typeof params.sessionId !== "string" || !params.sessionId) {
-    throw new Error("Sigma ACP command requires sessionId.");
-  }
-  if (typeof params.text !== "string" || !params.text) {
-    throw new Error("Sigma ACP command requires text.");
-  }
-  return { sessionId: params.sessionId, text: params.text };
-}
-
-function parseHealthRequest(value: unknown): Record<string, never> {
-  if (value === undefined || value === null) return {};
-  if (typeof value !== "object" || Array.isArray(value) || Object.keys(value).length > 0) {
-    throw new Error("Sigma ACP health params must be empty.");
-  }
-  return {};
-}
-
-function sessionModes(mode: RunMode): acp.SessionModeState {
-  return {
-    currentModeId: mode,
-    availableModes: [
-      { id: "change", name: "Agent", description: "Analyze and modify the workspace." },
-      { id: "analyze", name: "Plan", description: "Analyze the workspace without writes." }
-    ]
-  };
-}
-
-function modelConfig(catalog: SigmaAcpModelCatalog, currentModelId: string): acp.SessionConfigOption[] {
-  return [{
-    id: MODEL_CONFIG_ID,
-    name: "Model",
-    description: "Model used by Sigma Runtime.",
-    category: "model",
-    type: "select",
-    currentValue: currentModelId,
-    options: catalog.options.map((option) => ({
-      value: option.id,
-      name: option.name,
-      ...(option.description ? { description: option.description } : {})
-    }))
-  }];
-}
-
-function normalizeIndex(value: unknown): PersistedAcpIndex {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return { version: INDEX_VERSION, sessions: [] };
-  }
-  const input = value as Record<string, unknown>;
-  if (input.version !== INDEX_VERSION || !Array.isArray(input.sessions)) {
-    return { version: INDEX_VERSION, sessions: [] };
-  }
-  const sessions = input.sessions.filter((item): item is PersistedAcpSession => {
-    if (!item || typeof item !== "object" || Array.isArray(item)) return false;
-    const record = item as Record<string, unknown>;
-    return typeof record.sessionId === "string"
-      && typeof record.runtimeSessionId === "string"
-      && typeof record.cwd === "string"
-      && typeof record.modelId === "string"
-      && (record.mode === "analyze" || record.mode === "change")
-      && typeof record.createdAt === "string"
-      && typeof record.updatedAt === "string"
-      && typeof record.started === "boolean"
-      && Number.isSafeInteger(record.lastSeq)
-      && Number(record.lastSeq) >= 0;
-  });
-  return { version: INDEX_VERSION, sessions };
-}
-
-function promptText(prompt: acp.ContentBlock[]): string {
-  const unsupported = prompt.find((block) => block.type !== "text");
-  if (unsupported) {
-    throw new Error(`Sigma ACP currently accepts text prompts; received '${unsupported.type}'.`);
-  }
-  const text = prompt.map((block) => block.type === "text" ? block.text : "").join("");
-  if (!text) throw new Error("Sigma ACP prompt text must not be empty.");
-  return text;
-}
-
-function titleFromPrompt(text: string): string {
-  const firstLine = text.split(/\r?\n/u, 1)[0]?.trim() ?? "";
-  return firstLine.length > 96 ? `${firstLine.slice(0, 93)}...` : firstLine;
-}
-
-function listOffset(cursor: string | null | undefined): number {
-  if (!cursor) return 0;
-  const match = /^sigma:(0|[1-9]\d*)$/u.exec(cursor);
-  const offset = match ? Number(match[1]) : Number.NaN;
-  if (!Number.isSafeInteger(offset)) throw new Error(`Invalid Sigma session cursor '${cursor}'.`);
-  return offset;
-}
-
-function toolKind(name: string, effects: readonly string[] = []): acp.ToolKind {
-  if (effects.some((effect) => effect === "filesystem.write" || effect === "repository.write")) return "edit";
-  if (effects.some((effect) => effect.startsWith("process."))) return "execute";
-  if (effects.includes("network")) return "fetch";
-  if (/search|find|grep/iu.test(name)) return "search";
-  if (/read|list|inspect|status/iu.test(name)) return "read";
-  return "other";
-}
-
-function textContent(text: string): acp.ToolCallContent[] {
-  return text ? [{ type: "content", content: { type: "text", text } }] : [];
-}
-
-function stopReason(outcome: RunOutcome): acp.StopReason {
-  if (outcome.kind === "cancelled") return "cancelled";
-  if (outcome.kind === "fatal" || outcome.kind === "recoverable_failure") return "refusal";
-  return "end_turn";
-}
-
-function expectedAbort(error: unknown, signal: AbortSignal): boolean {
-  if (!signal.aborted) return false;
-  return error === signal.reason
-    || (error instanceof Error && (error.name === "AbortError" || /cancel|abort/iu.test(error.message)));
-}
-
-async function abortable<T>(operation: Promise<T>, signal: AbortSignal): Promise<T> {
-  if (signal.aborted) throw signal.reason ?? new Error("Operation aborted.");
-  return await new Promise<T>((resolve, reject) => {
-    const onAbort = (): void => {
-      signal.removeEventListener("abort", onAbort);
-      reject(signal.reason ?? new Error("Operation aborted."));
-    };
-    signal.addEventListener("abort", onAbort, { once: true });
-    void operation.then(
-      (value) => {
-        signal.removeEventListener("abort", onAbort);
-        resolve(value);
-      },
-      (error: unknown) => {
-        signal.removeEventListener("abort", onAbort);
-        reject(error);
-      }
-    );
-  });
-}
-
-function approvalDecision(response: acp.RequestPermissionResponse): "allow" | "always_allow" | "deny" {
-  if (response.outcome.outcome !== "selected") return "deny";
-  if (response.outcome.optionId === "always_allow") return "always_allow";
-  return response.outcome.optionId === "allow" ? "allow" : "deny";
-}
+export type {
+  SigmaAcpAgentOptions,
+  SigmaAcpModelCatalog,
+  SigmaAcpModelOption,
+  SigmaAcpRuntimeHandle
+} from "./sigma-acp-shared.js";
 
 export class SigmaAcpAgent {
-  private readonly handles = new Map<string, Promise<SigmaAcpRuntimeHandle>>();
-  private readonly indexes = new Map<string, PersistedAcpIndex>();
-  private readonly indexWrites = new Map<string, Promise<void>>();
-  private readonly sessionRoots = new Map<string, string>();
-  private readonly attached = new Set<string>();
+  private readonly sessions: SigmaAcpSessionRegistry;
+  private readonly events = new SigmaAcpEventForwarder();
   private readonly activePrompts = new Map<string, AbortController>();
   private readonly activeRuntimeSessions = new Map<string, ResolvedSession>();
 
-  constructor(private readonly options: SigmaAcpAgentOptions) {}
+  constructor(private readonly options: SigmaAcpAgentOptions) {
+    this.sessions = new SigmaAcpSessionRegistry(options);
+  }
 
   app(): acp.AgentApp {
     return acp.agent({ name: "sigma" })
@@ -247,8 +53,7 @@ export class SigmaAcpAgent {
       .onRequest(acp.methods.agent.session.prompt, (context) =>
         this.prompt(context.params, context.client, context.signal))
       .onNotification(acp.methods.agent.session.cancel, (context) => this.cancel(context.params))
-      .onRequest("_sigma/steer", parseSigmaTextCommand, (context) =>
-        this.steer(context.params))
+      .onRequest("_sigma/steer", parseSigmaTextCommand, (context) => this.steer(context.params))
       .onRequest("_sigma/health", parseHealthRequest, () => ({
         ok: true,
         name: "Sigma",
@@ -258,7 +63,9 @@ export class SigmaAcpAgent {
   }
 
   async close(): Promise<void> {
-    for (const controller of this.activePrompts.values()) controller.abort(new Error("ACP connection closed."));
+    for (const controller of this.activePrompts.values()) {
+      controller.abort(new Error("ACP connection closed."));
+    }
     const cancellations = await Promise.allSettled(
       [...this.activeRuntimeSessions.values()].map(async (resolved) =>
         await resolved.handle.runtime.command({
@@ -272,11 +79,7 @@ export class SigmaAcpAgent {
     }
     this.activePrompts.clear();
     this.activeRuntimeSessions.clear();
-    const handles = await Promise.allSettled(this.handles.values());
-    await Promise.all(handles.flatMap((result) =>
-      result.status === "fulfilled" ? [result.value.close()] : []
-    ));
-    this.handles.clear();
+    await this.sessions.close();
   }
 
   private initialize(): acp.InitializeResponse {
@@ -284,16 +87,8 @@ export class SigmaAcpAgent {
       protocolVersion: acp.PROTOCOL_VERSION,
       agentCapabilities: {
         loadSession: true,
-        promptCapabilities: {
-          image: false,
-          audio: false,
-          embeddedContext: false
-        },
-        sessionCapabilities: {
-          list: {},
-          resume: {},
-          close: {}
-        }
+        promptCapabilities: { image: false, audio: false, embeddedContext: false },
+        sessionCapabilities: { list: {}, resume: {}, close: {} }
       },
       agentInfo: {
         name: "Sigma",
@@ -306,7 +101,7 @@ export class SigmaAcpAgent {
   private async newSession(params: acp.NewSessionRequest): Promise<acp.NewSessionResponse> {
     const cwd = path.resolve(params.cwd);
     const catalog = await this.options.modelCatalog(cwd);
-    const handle = await this.handle(cwd, catalog.currentModelId);
+    const handle = await this.sessions.handle(cwd, catalog.currentModelId);
     const created = await handle.runtime.createSession({
       workspacePath: handle.workspace,
       mode: "change"
@@ -323,8 +118,8 @@ export class SigmaAcpAgent {
       started: false,
       lastSeq: 0
     };
-    this.attached.add(this.attachmentKey(record));
-    await this.upsert(handle.storeRootDir, record);
+    this.sessions.markAttached(record);
+    await this.sessions.upsert(handle.storeRootDir, record);
     return {
       sessionId: record.sessionId,
       modes: sessionModes(record.mode),
@@ -336,11 +131,11 @@ export class SigmaAcpAgent {
     params: acp.LoadSessionRequest,
     client: acp.AgentContext
   ): Promise<acp.LoadSessionResponse> {
-    const resolved = await this.resolveSession(params.sessionId, params.cwd);
-    await this.ensureAttached(resolved);
+    const resolved = await this.sessions.resolveSession(params.sessionId, params.cwd);
+    await this.sessions.ensureAttached(resolved);
     const state: ForwardState = { modelText: new Map(), reasoningText: new Map() };
     for await (const event of resolved.handle.runtime.sessionEvents(resolved.record.runtimeSessionId)) {
-      await this.forwardEvent(resolved, event, client, state, true);
+      await this.events.forwardEvent(resolved, event, client, state, true);
     }
     const catalog = await this.options.modelCatalog(resolved.record.cwd);
     return {
@@ -350,8 +145,8 @@ export class SigmaAcpAgent {
   }
 
   private async resumeSession(params: acp.ResumeSessionRequest): Promise<acp.ResumeSessionResponse> {
-    const resolved = await this.resolveSession(params.sessionId, params.cwd);
-    await this.ensureAttached(resolved);
+    const resolved = await this.sessions.resolveSession(params.sessionId, params.cwd);
+    await this.sessions.ensureAttached(resolved);
     const catalog = await this.options.modelCatalog(resolved.record.cwd);
     return {
       modes: sessionModes(resolved.record.mode),
@@ -362,8 +157,8 @@ export class SigmaAcpAgent {
   private async listSessions(params: acp.ListSessionsRequest): Promise<acp.ListSessionsResponse> {
     const cwd = path.resolve(params.cwd ?? process.cwd());
     const catalog = await this.options.modelCatalog(cwd);
-    const handle = await this.handle(cwd, catalog.currentModelId);
-    const index = await this.index(handle.storeRootDir);
+    const handle = await this.sessions.handle(cwd, catalog.currentModelId);
+    const index = await this.sessions.index(handle.storeRootDir);
     const offset = listOffset(params.cursor);
     const nativeSessions = (await handle.runtime.listSessions(Number.MAX_SAFE_INTEGER))
       .filter((session) => path.resolve(session.workspacePath) === cwd);
@@ -418,7 +213,7 @@ export class SigmaAcpAgent {
   }
 
   private async closeSession(params: acp.CloseSessionRequest): Promise<void> {
-    const resolved = await this.resolveSession(params.sessionId);
+    const resolved = await this.sessions.resolveSession(params.sessionId);
     const controller = this.activePrompts.get(params.sessionId);
     if (controller) {
       controller.abort(new Error("ACP session closed."));
@@ -429,17 +224,17 @@ export class SigmaAcpAgent {
       });
     }
     await resolved.handle.runtime.releaseSession?.(resolved.record.runtimeSessionId);
-    this.attached.delete(this.attachmentKey(resolved.record));
+    this.sessions.detach(resolved.record);
   }
 
   private async setMode(params: acp.SetSessionModeRequest): Promise<void> {
     if (params.modeId !== "analyze" && params.modeId !== "change") {
       throw new Error(`Unsupported Sigma mode '${params.modeId}'.`);
     }
-    const resolved = await this.resolveSession(params.sessionId);
+    const resolved = await this.sessions.resolveSession(params.sessionId);
     resolved.record.mode = params.modeId;
     resolved.record.updatedAt = new Date().toISOString();
-    await this.upsert(resolved.handle.storeRootDir, resolved.record);
+    await this.sessions.upsert(resolved.handle.storeRootDir, resolved.record);
   }
 
   private async setConfigOption(
@@ -448,7 +243,7 @@ export class SigmaAcpAgent {
     if (params.configId !== MODEL_CONFIG_ID || typeof params.value !== "string") {
       throw new Error(`Unsupported Sigma session configuration '${params.configId}'.`);
     }
-    const resolved = await this.resolveSession(params.sessionId);
+    const resolved = await this.sessions.resolveSession(params.sessionId);
     const catalog = await this.options.modelCatalog(resolved.record.cwd);
     if (!catalog.options.some((option) => option.id === params.value)) {
       throw new Error(`Unknown Sigma model '${params.value}'.`);
@@ -457,20 +252,20 @@ export class SigmaAcpAgent {
       if (resolved.record.started) {
         throw new Error("Sigma model can only be changed before the first prompt in a session.");
       }
-      const replacement = await this.handle(resolved.record.cwd, params.value);
+      const replacement = await this.sessions.handle(resolved.record.cwd, params.value);
       const created = await replacement.runtime.createSession({
         workspacePath: replacement.workspace,
         mode: resolved.record.mode
       });
       await resolved.handle.runtime.releaseSession?.(resolved.record.runtimeSessionId);
-      this.attached.delete(this.attachmentKey(resolved.record));
+      this.sessions.detach(resolved.record);
       resolved.record.runtimeSessionId = created.sessionId;
       resolved.record.modelId = params.value;
       resolved.record.cwd = replacement.workspace;
       resolved.record.lastSeq = 0;
       resolved.record.updatedAt = new Date().toISOString();
-      this.attached.add(this.attachmentKey(resolved.record));
-      await this.upsert(replacement.storeRootDir, resolved.record);
+      this.sessions.markAttached(resolved.record);
+      await this.sessions.upsert(replacement.storeRootDir, resolved.record);
     }
     return { configOptions: modelConfig(catalog, resolved.record.modelId) };
   }
@@ -484,7 +279,7 @@ export class SigmaAcpAgent {
     resolved.record.started = true;
     resolved.record.title ??= titleFromPrompt(text);
     resolved.record.updatedAt = new Date().toISOString();
-    await this.upsert(resolved.handle.storeRootDir, resolved.record);
+    await this.sessions.upsert(resolved.handle.storeRootDir, resolved.record);
     signal.throwIfAborted();
     await resolved.handle.runtime.command(firstPrompt
       ? {
@@ -507,8 +302,8 @@ export class SigmaAcpAgent {
   ): Promise<acp.PromptResponse> {
     const text = promptText(params.prompt);
     if (this.activePrompts.has(params.sessionId)) {
-      const resolved = await this.resolveSession(params.sessionId);
-      await this.ensureAttached(resolved);
+      const resolved = await this.sessions.resolveSession(params.sessionId);
+      await this.sessions.ensureAttached(resolved);
       await resolved.handle.runtime.command({
         type: "steer",
         sessionId: resolved.record.runtimeSessionId,
@@ -516,7 +311,6 @@ export class SigmaAcpAgent {
       });
       return { stopReason: "end_turn", _meta: { "sigma.command": "steer" } };
     }
-
     const controller = new AbortController();
     this.activePrompts.set(params.sessionId, controller);
     let resolved: ResolvedSession | undefined;
@@ -534,13 +328,13 @@ export class SigmaAcpAgent {
     if (signal.aborted) onRequestAbort();
     else signal.addEventListener("abort", onRequestAbort, { once: true });
     try {
-      resolved = await this.resolveSession(params.sessionId);
+      resolved = await this.sessions.resolveSession(params.sessionId);
       this.activeRuntimeSessions.set(params.sessionId, resolved);
-      await this.ensureAttached(resolved);
+      await this.sessions.ensureAttached(resolved);
       controller.signal.throwIfAborted();
       const state: ForwardState = { modelText: new Map(), reasoningText: new Map() };
       await this.dispatchPrompt(resolved, text, controller.signal);
-      forwarding = this.forwardLive(resolved, client, state, controller.signal);
+      forwarding = this.events.forwardLive(resolved, client, state, controller.signal);
       const outcome = await Promise.race([
         resolved.handle.runtime.waitForOutcome(resolved.record.runtimeSessionId, controller.signal),
         forwarding.then(() => {
@@ -552,7 +346,7 @@ export class SigmaAcpAgent {
         if (!expectedAbort(error, controller.signal)) throw error;
       });
       resolved.record.updatedAt = new Date().toISOString();
-      await this.upsert(resolved.handle.storeRootDir, resolved.record);
+      await this.sessions.upsert(resolved.handle.storeRootDir, resolved.record);
       return {
         stopReason: stopReason(outcome),
         _meta: {
@@ -580,7 +374,7 @@ export class SigmaAcpAgent {
 
   private async cancel(params: acp.CancelNotification): Promise<void> {
     this.activePrompts.get(params.sessionId)?.abort(new Error("Cancelled by ACP client."));
-    const resolved = await this.resolveSession(params.sessionId);
+    const resolved = await this.sessions.resolveSession(params.sessionId);
     await resolved.handle.runtime.command({
       type: "cancel",
       sessionId: resolved.record.runtimeSessionId,
@@ -589,394 +383,14 @@ export class SigmaAcpAgent {
   }
 
   private async steer(params: SigmaTextCommand): Promise<object> {
-    const resolved = await this.resolveSession(params.sessionId);
-    await this.ensureAttached(resolved);
+    const resolved = await this.sessions.resolveSession(params.sessionId);
+    await this.sessions.ensureAttached(resolved);
     await resolved.handle.runtime.command({
       type: "steer",
       sessionId: resolved.record.runtimeSessionId,
       text: params.text
     });
     return {};
-  }
-
-  private async forwardLive(
-    resolved: ResolvedSession,
-    client: acp.AgentContext,
-    state: ForwardState,
-    signal: AbortSignal
-  ): Promise<void> {
-    for await (const event of resolved.handle.runtime.subscribe(
-      resolved.record.runtimeSessionId,
-      signal
-    )) {
-      if (event.seq <= resolved.record.lastSeq) continue;
-      await this.forwardEvent(resolved, event, client, state, false, signal);
-      resolved.record.lastSeq = event.seq;
-    }
-  }
-
-  private async forwardEvent(
-    resolved: ResolvedSession,
-    event: AgentEventEnvelope,
-    client: acp.AgentContext,
-    state: ForwardState,
-    replay: boolean,
-    signal?: AbortSignal
-  ): Promise<void> {
-    if (await this.forwardUserEvent(resolved, event, client, replay)) return;
-    if (await this.forwardModelEvent(resolved, event, client, state, replay)) return;
-    if (await this.forwardPlanEvent(resolved, event, client, replay)) return;
-    if (await this.forwardToolRequestEvent(resolved, event, client, replay, signal)) return;
-    await this.forwardToolResultEvent(resolved, event, client, replay);
-  }
-
-  private async forwardUserEvent(
-    resolved: ResolvedSession,
-    event: AgentEventEnvelope,
-    client: acp.AgentContext,
-    replay: boolean
-  ): Promise<boolean> {
-    const sessionId = resolved.record.sessionId;
-    if (isAgentEventOf(event, "user.message") || isAgentEventOf(event, "user.steer")) {
-      if (replay) await this.notify(client, sessionId, {
-        sessionUpdate: "user_message_chunk",
-        content: { type: "text", text: event.payload.text }
-      }, true);
-      return true;
-    }
-    if (!isAgentEventOf(event, "user.follow_up")) return false;
-    if (replay && event.payload.status === "delivered") {
-      await this.notify(client, sessionId, {
-        sessionUpdate: "user_message_chunk",
-        content: { type: "text", text: event.payload.text }
-      }, true);
-    }
-    return true;
-  }
-
-  private async forwardModelEvent(
-    resolved: ResolvedSession,
-    event: AgentEventEnvelope,
-    client: acp.AgentContext,
-    state: ForwardState,
-    replay: boolean
-  ): Promise<boolean> {
-    const sessionId = resolved.record.sessionId;
-    if (isAgentEventOf(event, "model.delta")) {
-      state.modelText.set(
-        event.payload.turnId,
-        `${state.modelText.get(event.payload.turnId) ?? ""}${event.payload.delta}`
-      );
-      await this.notify(client, sessionId, {
-        sessionUpdate: "agent_message_chunk",
-        content: { type: "text", text: event.payload.delta }
-      }, replay);
-      return true;
-    }
-    if (isAgentEventOf(event, "model.reasoning_delta")) {
-      state.reasoningText.set(
-        event.payload.turnId,
-        `${state.reasoningText.get(event.payload.turnId) ?? ""}${event.payload.delta}`
-      );
-      await this.notify(client, sessionId, {
-        sessionUpdate: "agent_thought_chunk",
-        content: { type: "text", text: event.payload.delta }
-      }, replay);
-      return true;
-    }
-    if (!isAgentEventOf(event, "model.completed")) return false;
-    const streamed = state.modelText.get(event.payload.turnId) ?? "";
-    const remaining = event.payload.text.startsWith(streamed)
-      ? event.payload.text.slice(streamed.length)
-      : streamed ? "" : event.payload.text;
-    if (remaining) await this.notify(client, sessionId, {
-      sessionUpdate: "agent_message_chunk",
-      content: { type: "text", text: remaining }
-    }, replay);
-    const reasoning = event.payload.message.reasoningContent ?? "";
-    const streamedReasoning = state.reasoningText.get(event.payload.turnId) ?? "";
-    const reasoningRemaining = reasoning.startsWith(streamedReasoning)
-      ? reasoning.slice(streamedReasoning.length)
-      : streamedReasoning ? "" : reasoning;
-    if (reasoningRemaining) await this.notify(client, sessionId, {
-      sessionUpdate: "agent_thought_chunk",
-      content: { type: "text", text: reasoningRemaining }
-    }, replay);
-    state.modelText.delete(event.payload.turnId);
-    state.reasoningText.delete(event.payload.turnId);
-    return true;
-  }
-
-  private async forwardPlanEvent(
-    resolved: ResolvedSession,
-    event: AgentEventEnvelope,
-    client: acp.AgentContext,
-    replay: boolean
-  ): Promise<boolean> {
-    if (!isAgentEventOf(event, "plan.updated")) return false;
-    await this.notify(client, resolved.record.sessionId, {
-      sessionUpdate: "plan",
-      entries: event.payload.plan.nodes.map((node) => ({
-        content: node.title,
-        priority: event.payload.plan.activeNodeId === node.id ? "high" : "medium",
-        status: node.status === "completed"
-          ? "completed"
-          : node.status === "in_progress" ? "in_progress" : "pending",
-        _meta: {
-          "sigma.nodeId": node.id,
-          "sigma.status": node.status,
-          "sigma.dependencies": node.dependencies
-        }
-      }))
-    }, replay);
-    return true;
-  }
-
-  private async forwardToolRequestEvent(
-    resolved: ResolvedSession,
-    event: AgentEventEnvelope,
-    client: acp.AgentContext,
-    replay: boolean,
-    signal?: AbortSignal
-  ): Promise<boolean> {
-    const sessionId = resolved.record.sessionId;
-    if (isAgentEventOf(event, "tool.requested")) {
-      await this.notify(client, sessionId, {
-        sessionUpdate: "tool_call",
-        toolCallId: event.payload.callId,
-        title: event.payload.name,
-        name: event.payload.name,
-        kind: toolKind(event.payload.name),
-        status: "pending",
-        rawInput: event.payload.arguments
-      }, replay);
-      return true;
-    }
-    if (!isAgentEventOf(event, "tool.approval_requested")) return false;
-    const effects = event.payload.effects;
-    await this.notify(client, sessionId, {
-      sessionUpdate: "tool_call_update",
-      toolCallId: event.payload.callId,
-      title: event.payload.toolName,
-      name: event.payload.toolName,
-      kind: toolKind(event.payload.toolName, effects),
-      status: "pending",
-      rawInput: event.payload.arguments,
-      rawOutput: { approvalReason: event.payload.reason, effects }
-    }, replay);
-    if (!replay && event.payload.approvalMode === "human" && event.payload.delegated !== true) {
-      if (!signal) throw new Error("Live Sigma approval forwarding requires an abort signal.");
-      await this.requestToolApproval(resolved, event, client, signal);
-    }
-    return true;
-  }
-
-  private async requestToolApproval(
-    resolved: ResolvedSession,
-    event: AgentEventOf<"tool.approval_requested">,
-    client: acp.AgentContext,
-    signal: AbortSignal
-  ): Promise<void> {
-    const effects = event.payload.effects;
-    const request = client.request(acp.methods.client.session.requestPermission, {
-      sessionId: resolved.record.sessionId,
-      toolCall: {
-        toolCallId: event.payload.callId,
-        title: event.payload.toolName,
-        name: event.payload.toolName,
-        kind: toolKind(event.payload.toolName, effects),
-        status: "pending",
-        rawInput: event.payload.arguments
-      },
-      options: [
-        { optionId: "allow", name: "Allow once", kind: "allow_once" },
-        { optionId: "always_allow", name: "Always allow this tool", kind: "allow_always" },
-        { optionId: "deny", name: "Deny", kind: "reject_once" }
-      ]
-    }, { cancellationSignal: signal });
-    const permission = await abortable(request, signal);
-    await resolved.handle.runtime.command({
-      type: "approve",
-      sessionId: resolved.record.runtimeSessionId,
-      requestId: event.payload.requestId,
-      decision: approvalDecision(permission)
-    });
-  }
-
-  private async forwardToolResultEvent(
-    resolved: ResolvedSession,
-    event: AgentEventEnvelope,
-    client: acp.AgentContext,
-    replay: boolean
-  ): Promise<boolean> {
-    const sessionId = resolved.record.sessionId;
-    if (isAgentEventOf(event, "tool.started")) {
-      await this.notify(client, sessionId, {
-        sessionUpdate: "tool_call_update",
-        toolCallId: event.payload.callId,
-        title: event.payload.name,
-        name: event.payload.name,
-        kind: toolKind(event.payload.name),
-        status: "in_progress"
-      }, replay);
-      return true;
-    }
-    if (isAgentEventOf(event, "tool.progress")) {
-      await this.notify(client, sessionId, {
-        sessionUpdate: "tool_call_update",
-        toolCallId: event.payload.callId,
-        title: event.payload.name,
-        name: event.payload.name,
-        status: "in_progress",
-        content: textContent(event.payload.message),
-        rawOutput: {
-          message: event.payload.message,
-          ...(event.payload.percent === undefined ? {} : { percent: event.payload.percent })
-        }
-      }, replay);
-      return true;
-    }
-    if (!isAgentEventOf(event, "tool.completed") && !isAgentEventOf(event, "tool.failed")) return false;
-    await this.notify(client, sessionId, {
-      sessionUpdate: "tool_call_update",
-      toolCallId: event.payload.callId,
-      title: event.payload.name,
-      name: event.payload.name,
-      status: event.type === "tool.completed" ? "completed" : "failed",
-      content: textContent(event.payload.output),
-      rawOutput: {
-        ok: event.payload.ok,
-        output: event.payload.output,
-        outcome: event.payload.outcome,
-        ...(event.payload.result === undefined ? {} : { result: event.payload.result }),
-        diagnostics: event.payload.diagnostics
-      }
-    }, replay);
-    return true;
-  }
-
-  private async notify(
-    client: acp.AgentContext,
-    sessionId: string,
-    update: acp.SessionUpdate,
-    replay: boolean
-  ): Promise<void> {
-    await client.notify(acp.methods.client.session.update, {
-      sessionId,
-      update,
-      ...(replay ? { _meta: { isReplay: true } } : {})
-    });
-  }
-
-  private async resolveSession(sessionId: string, cwdHint?: string): Promise<ResolvedSession> {
-    const knownRoot = cwdHint ? undefined : this.sessionRoots.get(sessionId);
-    if (knownRoot) {
-      const knownIndex = await this.index(knownRoot);
-      const knownRecord = knownIndex.sessions.find((candidate) => candidate.sessionId === sessionId);
-      if (knownRecord) {
-        return {
-          record: knownRecord,
-          handle: await this.handle(knownRecord.cwd, knownRecord.modelId)
-        };
-      }
-    }
-    const cwd = path.resolve(cwdHint ?? process.cwd());
-    const catalog = await this.options.modelCatalog(cwd);
-    const defaultHandle = await this.handle(cwd, catalog.currentModelId);
-    const index = await this.index(defaultHandle.storeRootDir);
-    let record = index.sessions.find((candidate) => candidate.sessionId === sessionId);
-    if (!record) {
-      const native = (await defaultHandle.runtime.listSessions(Number.MAX_SAFE_INTEGER))
-        .find((candidate) => candidate.sessionId === sessionId);
-      if (!native) throw new Error(`Unknown Sigma ACP session '${sessionId}'.`);
-      record = {
-        sessionId,
-        runtimeSessionId: sessionId,
-        cwd: native.workspacePath,
-        modelId: catalog.currentModelId,
-        mode: native.mode,
-        ...(native.lastMessage ? { title: native.lastMessage.slice(0, 96) } : {}),
-        createdAt: native.updatedAt,
-        updatedAt: native.updatedAt,
-        started: native.lastSeq > 1,
-        lastSeq: native.lastSeq
-      };
-      await this.upsert(defaultHandle.storeRootDir, record);
-    }
-    if (cwdHint && path.resolve(record.cwd) !== cwd) {
-      throw new Error(`Sigma ACP session '${sessionId}' belongs to '${record.cwd}', not '${cwd}'.`);
-    }
-    return {
-      record,
-      handle: record.modelId === catalog.currentModelId
-        ? defaultHandle
-        : await this.handle(record.cwd, record.modelId)
-    };
-  }
-
-  private async ensureAttached(resolved: ResolvedSession): Promise<void> {
-    const key = this.attachmentKey(resolved.record);
-    if (this.attached.has(key)) return;
-    await resolved.handle.runtime.command({
-      type: "resume",
-      sessionId: resolved.record.runtimeSessionId
-    });
-    this.attached.add(key);
-  }
-
-  private attachmentKey(record: PersistedAcpSession): string {
-    return `${record.modelId}\0${record.runtimeSessionId}`;
-  }
-
-  private handle(cwd: string, modelId: string): Promise<SigmaAcpRuntimeHandle> {
-    const key = `${path.resolve(cwd)}\0${modelId}`;
-    let handle = this.handles.get(key);
-    if (!handle) {
-      handle = this.options.runtimeFactory(path.resolve(cwd), modelId);
-      this.handles.set(key, handle);
-      void handle.catch(() => this.handles.delete(key));
-    }
-    return handle;
-  }
-
-  private async index(storeRootDir: string): Promise<PersistedAcpIndex> {
-    const key = path.resolve(storeRootDir);
-    const cached = this.indexes.get(key);
-    if (cached) return cached;
-    let value: unknown;
-    try {
-      value = JSON.parse(await readFile(path.join(key, SESSION_INDEX_FILE), "utf8")) as unknown;
-    } catch (error) {
-      if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error;
-    }
-    const index = normalizeIndex(value);
-    this.indexes.set(key, index);
-    for (const record of index.sessions) this.sessionRoots.set(record.sessionId, key);
-    return index;
-  }
-
-  private async upsert(storeRootDir: string, record: PersistedAcpSession): Promise<void> {
-    const root = path.resolve(storeRootDir);
-    const previous = this.indexWrites.get(root) ?? Promise.resolve();
-    const write = previous.then(async () => {
-      const index = await this.index(root);
-      const existing = index.sessions.findIndex((candidate) => candidate.sessionId === record.sessionId);
-      const snapshot = { ...record };
-      if (existing >= 0) index.sessions[existing] = snapshot;
-      else index.sessions.push(snapshot);
-      this.sessionRoots.set(record.sessionId, root);
-      await mkdir(root, { recursive: true });
-      const target = path.join(root, SESSION_INDEX_FILE);
-      const temporary = `${target}.${process.pid}.${randomUUID()}.tmp`;
-      await writeFile(temporary, `${JSON.stringify(index, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
-      await rename(temporary, target);
-    });
-    this.indexWrites.set(root, write);
-    try {
-      await write;
-    } finally {
-      if (this.indexWrites.get(root) === write) this.indexWrites.delete(root);
-    }
   }
 
   private log(error: unknown): void {

--- a/packages/agent-cli/src/acp/sigma-acp-agent.ts
+++ b/packages/agent-cli/src/acp/sigma-acp-agent.ts
@@ -1,0 +1,986 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+import * as acp from "@agentclientprotocol/sdk";
+import {
+  isAgentEventOf,
+  type AgentEventEnvelope,
+  type AgentEventOf,
+  type RunMode,
+  type RunOutcome,
+  type RuntimeClient
+} from "agent-protocol";
+
+const SESSION_INDEX_FILE = "acp-sessions.json";
+const MODEL_CONFIG_ID = "sigma.model";
+const INDEX_VERSION = 1;
+
+export interface SigmaAcpRuntimeHandle {
+  runtime: RuntimeClient;
+  workspace: string;
+  storeRootDir: string;
+  close(): Promise<void>;
+}
+
+export interface SigmaAcpModelOption {
+  id: string;
+  name: string;
+  description?: string;
+}
+
+export interface SigmaAcpModelCatalog {
+  currentModelId: string;
+  options: SigmaAcpModelOption[];
+}
+
+export interface SigmaAcpAgentOptions {
+  agentVersion: string;
+  runtimeFactory(cwd: string, modelId: string): Promise<SigmaAcpRuntimeHandle>;
+  modelCatalog(cwd: string): Promise<SigmaAcpModelCatalog>;
+  stderr?: NodeJS.WritableStream;
+}
+
+interface PersistedAcpSession {
+  sessionId: string;
+  runtimeSessionId: string;
+  cwd: string;
+  modelId: string;
+  mode: RunMode;
+  title?: string;
+  createdAt: string;
+  updatedAt: string;
+  started: boolean;
+  lastSeq: number;
+}
+
+interface PersistedAcpIndex {
+  version: typeof INDEX_VERSION;
+  sessions: PersistedAcpSession[];
+}
+
+interface ResolvedSession {
+  record: PersistedAcpSession;
+  handle: SigmaAcpRuntimeHandle;
+}
+
+interface ForwardState {
+  modelText: Map<number, string>;
+  reasoningText: Map<number, string>;
+}
+
+interface SigmaTextCommand {
+  sessionId: string;
+  text: string;
+}
+
+function parseSigmaTextCommand(value: unknown): SigmaTextCommand {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Sigma ACP command params must be an object.");
+  }
+  const params = value as Record<string, unknown>;
+  if (typeof params.sessionId !== "string" || !params.sessionId) {
+    throw new Error("Sigma ACP command requires sessionId.");
+  }
+  if (typeof params.text !== "string" || !params.text) {
+    throw new Error("Sigma ACP command requires text.");
+  }
+  return { sessionId: params.sessionId, text: params.text };
+}
+
+function parseHealthRequest(value: unknown): Record<string, never> {
+  if (value === undefined || value === null) return {};
+  if (typeof value !== "object" || Array.isArray(value) || Object.keys(value).length > 0) {
+    throw new Error("Sigma ACP health params must be empty.");
+  }
+  return {};
+}
+
+function sessionModes(mode: RunMode): acp.SessionModeState {
+  return {
+    currentModeId: mode,
+    availableModes: [
+      { id: "change", name: "Agent", description: "Analyze and modify the workspace." },
+      { id: "analyze", name: "Plan", description: "Analyze the workspace without writes." }
+    ]
+  };
+}
+
+function modelConfig(catalog: SigmaAcpModelCatalog, currentModelId: string): acp.SessionConfigOption[] {
+  return [{
+    id: MODEL_CONFIG_ID,
+    name: "Model",
+    description: "Model used by Sigma Runtime.",
+    category: "model",
+    type: "select",
+    currentValue: currentModelId,
+    options: catalog.options.map((option) => ({
+      value: option.id,
+      name: option.name,
+      ...(option.description ? { description: option.description } : {})
+    }))
+  }];
+}
+
+function normalizeIndex(value: unknown): PersistedAcpIndex {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return { version: INDEX_VERSION, sessions: [] };
+  }
+  const input = value as Record<string, unknown>;
+  if (input.version !== INDEX_VERSION || !Array.isArray(input.sessions)) {
+    return { version: INDEX_VERSION, sessions: [] };
+  }
+  const sessions = input.sessions.filter((item): item is PersistedAcpSession => {
+    if (!item || typeof item !== "object" || Array.isArray(item)) return false;
+    const record = item as Record<string, unknown>;
+    return typeof record.sessionId === "string"
+      && typeof record.runtimeSessionId === "string"
+      && typeof record.cwd === "string"
+      && typeof record.modelId === "string"
+      && (record.mode === "analyze" || record.mode === "change")
+      && typeof record.createdAt === "string"
+      && typeof record.updatedAt === "string"
+      && typeof record.started === "boolean"
+      && Number.isSafeInteger(record.lastSeq)
+      && Number(record.lastSeq) >= 0;
+  });
+  return { version: INDEX_VERSION, sessions };
+}
+
+function promptText(prompt: acp.ContentBlock[]): string {
+  const unsupported = prompt.find((block) => block.type !== "text");
+  if (unsupported) {
+    throw new Error(`Sigma ACP currently accepts text prompts; received '${unsupported.type}'.`);
+  }
+  const text = prompt.map((block) => block.type === "text" ? block.text : "").join("");
+  if (!text) throw new Error("Sigma ACP prompt text must not be empty.");
+  return text;
+}
+
+function titleFromPrompt(text: string): string {
+  const firstLine = text.split(/\r?\n/u, 1)[0]?.trim() ?? "";
+  return firstLine.length > 96 ? `${firstLine.slice(0, 93)}...` : firstLine;
+}
+
+function listOffset(cursor: string | null | undefined): number {
+  if (!cursor) return 0;
+  const match = /^sigma:(0|[1-9]\d*)$/u.exec(cursor);
+  const offset = match ? Number(match[1]) : Number.NaN;
+  if (!Number.isSafeInteger(offset)) throw new Error(`Invalid Sigma session cursor '${cursor}'.`);
+  return offset;
+}
+
+function toolKind(name: string, effects: readonly string[] = []): acp.ToolKind {
+  if (effects.some((effect) => effect === "filesystem.write" || effect === "repository.write")) return "edit";
+  if (effects.some((effect) => effect.startsWith("process."))) return "execute";
+  if (effects.includes("network")) return "fetch";
+  if (/search|find|grep/iu.test(name)) return "search";
+  if (/read|list|inspect|status/iu.test(name)) return "read";
+  return "other";
+}
+
+function textContent(text: string): acp.ToolCallContent[] {
+  return text ? [{ type: "content", content: { type: "text", text } }] : [];
+}
+
+function stopReason(outcome: RunOutcome): acp.StopReason {
+  if (outcome.kind === "cancelled") return "cancelled";
+  if (outcome.kind === "fatal" || outcome.kind === "recoverable_failure") return "refusal";
+  return "end_turn";
+}
+
+function expectedAbort(error: unknown, signal: AbortSignal): boolean {
+  if (!signal.aborted) return false;
+  return error === signal.reason
+    || (error instanceof Error && (error.name === "AbortError" || /cancel|abort/iu.test(error.message)));
+}
+
+async function abortable<T>(operation: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) throw signal.reason ?? new Error("Operation aborted.");
+  return await new Promise<T>((resolve, reject) => {
+    const onAbort = (): void => {
+      signal.removeEventListener("abort", onAbort);
+      reject(signal.reason ?? new Error("Operation aborted."));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    void operation.then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (error: unknown) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(error);
+      }
+    );
+  });
+}
+
+function approvalDecision(response: acp.RequestPermissionResponse): "allow" | "always_allow" | "deny" {
+  if (response.outcome.outcome !== "selected") return "deny";
+  if (response.outcome.optionId === "always_allow") return "always_allow";
+  return response.outcome.optionId === "allow" ? "allow" : "deny";
+}
+
+export class SigmaAcpAgent {
+  private readonly handles = new Map<string, Promise<SigmaAcpRuntimeHandle>>();
+  private readonly indexes = new Map<string, PersistedAcpIndex>();
+  private readonly indexWrites = new Map<string, Promise<void>>();
+  private readonly sessionRoots = new Map<string, string>();
+  private readonly attached = new Set<string>();
+  private readonly activePrompts = new Map<string, AbortController>();
+  private readonly activeRuntimeSessions = new Map<string, ResolvedSession>();
+
+  constructor(private readonly options: SigmaAcpAgentOptions) {}
+
+  app(): acp.AgentApp {
+    return acp.agent({ name: "sigma" })
+      .onRequest(acp.methods.agent.initialize, () => this.initialize())
+      .onRequest(acp.methods.agent.session.new, (context) => this.newSession(context.params))
+      .onRequest(acp.methods.agent.session.load, (context) =>
+        this.loadSession(context.params, context.client))
+      .onRequest(acp.methods.agent.session.list, (context) => this.listSessions(context.params))
+      .onRequest(acp.methods.agent.session.resume, (context) => this.resumeSession(context.params))
+      .onRequest(acp.methods.agent.session.close, (context) => this.closeSession(context.params))
+      .onRequest(acp.methods.agent.session.setMode, (context) => this.setMode(context.params))
+      .onRequest(acp.methods.agent.session.setConfigOption, (context) =>
+        this.setConfigOption(context.params))
+      .onRequest(acp.methods.agent.session.prompt, (context) =>
+        this.prompt(context.params, context.client, context.signal))
+      .onNotification(acp.methods.agent.session.cancel, (context) => this.cancel(context.params))
+      .onRequest("_sigma/steer", parseSigmaTextCommand, (context) =>
+        this.steer(context.params))
+      .onRequest("_sigma/health", parseHealthRequest, () => ({
+        ok: true,
+        name: "Sigma",
+        protocolVersion: acp.PROTOCOL_VERSION,
+        version: this.options.agentVersion
+      }));
+  }
+
+  async close(): Promise<void> {
+    for (const controller of this.activePrompts.values()) controller.abort(new Error("ACP connection closed."));
+    const cancellations = await Promise.allSettled(
+      [...this.activeRuntimeSessions.values()].map(async (resolved) =>
+        await resolved.handle.runtime.command({
+          type: "cancel",
+          sessionId: resolved.record.runtimeSessionId,
+          reason: "ACP connection closed."
+        }))
+    );
+    for (const result of cancellations) {
+      if (result.status === "rejected") this.log(result.reason);
+    }
+    this.activePrompts.clear();
+    this.activeRuntimeSessions.clear();
+    const handles = await Promise.allSettled(this.handles.values());
+    await Promise.all(handles.flatMap((result) =>
+      result.status === "fulfilled" ? [result.value.close()] : []
+    ));
+    this.handles.clear();
+  }
+
+  private initialize(): acp.InitializeResponse {
+    return {
+      protocolVersion: acp.PROTOCOL_VERSION,
+      agentCapabilities: {
+        loadSession: true,
+        promptCapabilities: {
+          image: false,
+          audio: false,
+          embeddedContext: false
+        },
+        sessionCapabilities: {
+          list: {},
+          resume: {},
+          close: {}
+        }
+      },
+      agentInfo: {
+        name: "Sigma",
+        title: "Sigma Runtime",
+        version: this.options.agentVersion
+      }
+    };
+  }
+
+  private async newSession(params: acp.NewSessionRequest): Promise<acp.NewSessionResponse> {
+    const cwd = path.resolve(params.cwd);
+    const catalog = await this.options.modelCatalog(cwd);
+    const handle = await this.handle(cwd, catalog.currentModelId);
+    const created = await handle.runtime.createSession({
+      workspacePath: handle.workspace,
+      mode: "change"
+    });
+    const now = new Date().toISOString();
+    const record: PersistedAcpSession = {
+      sessionId: `sigma-${randomUUID()}`,
+      runtimeSessionId: created.sessionId,
+      cwd: handle.workspace,
+      modelId: catalog.currentModelId,
+      mode: "change",
+      createdAt: now,
+      updatedAt: now,
+      started: false,
+      lastSeq: 0
+    };
+    this.attached.add(this.attachmentKey(record));
+    await this.upsert(handle.storeRootDir, record);
+    return {
+      sessionId: record.sessionId,
+      modes: sessionModes(record.mode),
+      configOptions: modelConfig(catalog, record.modelId)
+    };
+  }
+
+  private async loadSession(
+    params: acp.LoadSessionRequest,
+    client: acp.AgentContext
+  ): Promise<acp.LoadSessionResponse> {
+    const resolved = await this.resolveSession(params.sessionId, params.cwd);
+    await this.ensureAttached(resolved);
+    const state: ForwardState = { modelText: new Map(), reasoningText: new Map() };
+    for await (const event of resolved.handle.runtime.sessionEvents(resolved.record.runtimeSessionId)) {
+      await this.forwardEvent(resolved, event, client, state, true);
+    }
+    const catalog = await this.options.modelCatalog(resolved.record.cwd);
+    return {
+      modes: sessionModes(resolved.record.mode),
+      configOptions: modelConfig(catalog, resolved.record.modelId)
+    };
+  }
+
+  private async resumeSession(params: acp.ResumeSessionRequest): Promise<acp.ResumeSessionResponse> {
+    const resolved = await this.resolveSession(params.sessionId, params.cwd);
+    await this.ensureAttached(resolved);
+    const catalog = await this.options.modelCatalog(resolved.record.cwd);
+    return {
+      modes: sessionModes(resolved.record.mode),
+      configOptions: modelConfig(catalog, resolved.record.modelId)
+    };
+  }
+
+  private async listSessions(params: acp.ListSessionsRequest): Promise<acp.ListSessionsResponse> {
+    const cwd = path.resolve(params.cwd ?? process.cwd());
+    const catalog = await this.options.modelCatalog(cwd);
+    const handle = await this.handle(cwd, catalog.currentModelId);
+    const index = await this.index(handle.storeRootDir);
+    const offset = listOffset(params.cursor);
+    const nativeSessions = (await handle.runtime.listSessions(Number.MAX_SAFE_INTEGER))
+      .filter((session) => path.resolve(session.workspacePath) === cwd);
+    const nativeById = new Map(nativeSessions.map((session) => [session.sessionId, session]));
+    const indexedRuntimeIds = new Set<string>();
+    const matching = index.sessions
+      .filter((record) => path.resolve(record.cwd) === cwd)
+      .map((record) => {
+        indexedRuntimeIds.add(record.runtimeSessionId);
+        const native = nativeById.get(record.runtimeSessionId);
+        return {
+          sessionId: record.sessionId,
+          cwd: record.cwd,
+          ...(record.title || native?.lastMessage
+            ? { title: record.title ?? native?.lastMessage?.slice(0, 96) }
+            : {}),
+          updatedAt: native && native.updatedAt > record.updatedAt
+            ? native.updatedAt
+            : record.updatedAt,
+          _meta: {
+            "sigma.runtimeSessionId": record.runtimeSessionId,
+            "sigma.modelId": record.modelId
+          }
+        };
+      });
+    for (const native of nativeSessions) {
+      if (indexedRuntimeIds.has(native.sessionId)) continue;
+      matching.push({
+        sessionId: native.sessionId,
+        cwd: native.workspacePath,
+        ...(native.lastMessage ? { title: native.lastMessage.slice(0, 96) } : {}),
+        updatedAt: native.updatedAt,
+        _meta: {
+          "sigma.runtimeSessionId": native.sessionId,
+          "sigma.modelId": catalog.currentModelId
+        }
+      });
+    }
+    matching.sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
+    const sessions = matching.slice(offset, offset + 50).map((record) => ({
+      sessionId: record.sessionId,
+      cwd: record.cwd,
+      ...(record.title ? { title: record.title } : {}),
+      updatedAt: record.updatedAt,
+      _meta: record._meta
+    }));
+    const nextOffset = offset + sessions.length;
+    return {
+      sessions,
+      ...(nextOffset < matching.length ? { nextCursor: `sigma:${nextOffset}` } : {})
+    };
+  }
+
+  private async closeSession(params: acp.CloseSessionRequest): Promise<void> {
+    const resolved = await this.resolveSession(params.sessionId);
+    const controller = this.activePrompts.get(params.sessionId);
+    if (controller) {
+      controller.abort(new Error("ACP session closed."));
+      await resolved.handle.runtime.command({
+        type: "cancel",
+        sessionId: resolved.record.runtimeSessionId,
+        reason: "ACP session closed."
+      });
+    }
+    await resolved.handle.runtime.releaseSession?.(resolved.record.runtimeSessionId);
+    this.attached.delete(this.attachmentKey(resolved.record));
+  }
+
+  private async setMode(params: acp.SetSessionModeRequest): Promise<void> {
+    if (params.modeId !== "analyze" && params.modeId !== "change") {
+      throw new Error(`Unsupported Sigma mode '${params.modeId}'.`);
+    }
+    const resolved = await this.resolveSession(params.sessionId);
+    resolved.record.mode = params.modeId;
+    resolved.record.updatedAt = new Date().toISOString();
+    await this.upsert(resolved.handle.storeRootDir, resolved.record);
+  }
+
+  private async setConfigOption(
+    params: acp.SetSessionConfigOptionRequest
+  ): Promise<acp.SetSessionConfigOptionResponse> {
+    if (params.configId !== MODEL_CONFIG_ID || typeof params.value !== "string") {
+      throw new Error(`Unsupported Sigma session configuration '${params.configId}'.`);
+    }
+    const resolved = await this.resolveSession(params.sessionId);
+    const catalog = await this.options.modelCatalog(resolved.record.cwd);
+    if (!catalog.options.some((option) => option.id === params.value)) {
+      throw new Error(`Unknown Sigma model '${params.value}'.`);
+    }
+    if (params.value !== resolved.record.modelId) {
+      if (resolved.record.started) {
+        throw new Error("Sigma model can only be changed before the first prompt in a session.");
+      }
+      const replacement = await this.handle(resolved.record.cwd, params.value);
+      const created = await replacement.runtime.createSession({
+        workspacePath: replacement.workspace,
+        mode: resolved.record.mode
+      });
+      await resolved.handle.runtime.releaseSession?.(resolved.record.runtimeSessionId);
+      this.attached.delete(this.attachmentKey(resolved.record));
+      resolved.record.runtimeSessionId = created.sessionId;
+      resolved.record.modelId = params.value;
+      resolved.record.cwd = replacement.workspace;
+      resolved.record.lastSeq = 0;
+      resolved.record.updatedAt = new Date().toISOString();
+      this.attached.add(this.attachmentKey(resolved.record));
+      await this.upsert(replacement.storeRootDir, resolved.record);
+    }
+    return { configOptions: modelConfig(catalog, resolved.record.modelId) };
+  }
+
+  private async dispatchPrompt(
+    resolved: ResolvedSession,
+    text: string,
+    signal: AbortSignal
+  ): Promise<void> {
+    const firstPrompt = !resolved.record.started;
+    resolved.record.started = true;
+    resolved.record.title ??= titleFromPrompt(text);
+    resolved.record.updatedAt = new Date().toISOString();
+    await this.upsert(resolved.handle.storeRootDir, resolved.record);
+    signal.throwIfAborted();
+    await resolved.handle.runtime.command(firstPrompt
+      ? {
+          type: "submit",
+          sessionId: resolved.record.runtimeSessionId,
+          text,
+          mode: resolved.record.mode
+        }
+      : {
+          type: "follow_up",
+          sessionId: resolved.record.runtimeSessionId,
+          text
+        });
+  }
+
+  private async prompt(
+    params: acp.PromptRequest,
+    client: acp.AgentContext,
+    signal: AbortSignal
+  ): Promise<acp.PromptResponse> {
+    const text = promptText(params.prompt);
+    if (this.activePrompts.has(params.sessionId)) {
+      const resolved = await this.resolveSession(params.sessionId);
+      await this.ensureAttached(resolved);
+      await resolved.handle.runtime.command({
+        type: "steer",
+        sessionId: resolved.record.runtimeSessionId,
+        text
+      });
+      return { stopReason: "end_turn", _meta: { "sigma.command": "steer" } };
+    }
+
+    const controller = new AbortController();
+    this.activePrompts.set(params.sessionId, controller);
+    let resolved: ResolvedSession | undefined;
+    let forwarding: Promise<void> | undefined;
+    const onRequestAbort = (): void => {
+      controller.abort(signal.reason ?? new Error("ACP prompt request cancelled."));
+      if (resolved) {
+        void resolved.handle.runtime.command({
+          type: "cancel",
+          sessionId: resolved.record.runtimeSessionId,
+          reason: "ACP prompt request cancelled."
+        }).catch((error: unknown) => this.log(error));
+      }
+    };
+    if (signal.aborted) onRequestAbort();
+    else signal.addEventListener("abort", onRequestAbort, { once: true });
+    try {
+      resolved = await this.resolveSession(params.sessionId);
+      this.activeRuntimeSessions.set(params.sessionId, resolved);
+      await this.ensureAttached(resolved);
+      controller.signal.throwIfAborted();
+      const state: ForwardState = { modelText: new Map(), reasoningText: new Map() };
+      await this.dispatchPrompt(resolved, text, controller.signal);
+      forwarding = this.forwardLive(resolved, client, state, controller.signal);
+      const outcome = await Promise.race([
+        resolved.handle.runtime.waitForOutcome(resolved.record.runtimeSessionId, controller.signal),
+        forwarding.then(() => {
+          throw new Error("Sigma Runtime event stream ended before the run outcome.");
+        })
+      ]);
+      controller.abort(new Error("Sigma Runtime turn completed."));
+      await forwarding.catch((error: unknown) => {
+        if (!expectedAbort(error, controller.signal)) throw error;
+      });
+      resolved.record.updatedAt = new Date().toISOString();
+      await this.upsert(resolved.handle.storeRootDir, resolved.record);
+      return {
+        stopReason: stopReason(outcome),
+        _meta: {
+          "sigma.outcome": outcome.kind,
+          ...("message" in outcome ? { "sigma.message": outcome.message } : {})
+        }
+      };
+    } catch (error) {
+      if (expectedAbort(error, controller.signal)) return { stopReason: "cancelled" };
+      throw error;
+    } finally {
+      signal.removeEventListener("abort", onRequestAbort);
+      if (this.activePrompts.get(params.sessionId) === controller) {
+        this.activePrompts.delete(params.sessionId);
+        this.activeRuntimeSessions.delete(params.sessionId);
+      }
+      if (!controller.signal.aborted) controller.abort(new Error("Sigma ACP prompt finished."));
+      if (forwarding) {
+        await forwarding.catch((error: unknown) => {
+          if (!expectedAbort(error, controller.signal)) this.log(error);
+        });
+      }
+    }
+  }
+
+  private async cancel(params: acp.CancelNotification): Promise<void> {
+    this.activePrompts.get(params.sessionId)?.abort(new Error("Cancelled by ACP client."));
+    const resolved = await this.resolveSession(params.sessionId);
+    await resolved.handle.runtime.command({
+      type: "cancel",
+      sessionId: resolved.record.runtimeSessionId,
+      reason: "Cancelled by ACP client."
+    });
+  }
+
+  private async steer(params: SigmaTextCommand): Promise<object> {
+    const resolved = await this.resolveSession(params.sessionId);
+    await this.ensureAttached(resolved);
+    await resolved.handle.runtime.command({
+      type: "steer",
+      sessionId: resolved.record.runtimeSessionId,
+      text: params.text
+    });
+    return {};
+  }
+
+  private async forwardLive(
+    resolved: ResolvedSession,
+    client: acp.AgentContext,
+    state: ForwardState,
+    signal: AbortSignal
+  ): Promise<void> {
+    for await (const event of resolved.handle.runtime.subscribe(
+      resolved.record.runtimeSessionId,
+      signal
+    )) {
+      if (event.seq <= resolved.record.lastSeq) continue;
+      await this.forwardEvent(resolved, event, client, state, false, signal);
+      resolved.record.lastSeq = event.seq;
+    }
+  }
+
+  private async forwardEvent(
+    resolved: ResolvedSession,
+    event: AgentEventEnvelope,
+    client: acp.AgentContext,
+    state: ForwardState,
+    replay: boolean,
+    signal?: AbortSignal
+  ): Promise<void> {
+    if (await this.forwardUserEvent(resolved, event, client, replay)) return;
+    if (await this.forwardModelEvent(resolved, event, client, state, replay)) return;
+    if (await this.forwardPlanEvent(resolved, event, client, replay)) return;
+    if (await this.forwardToolRequestEvent(resolved, event, client, replay, signal)) return;
+    await this.forwardToolResultEvent(resolved, event, client, replay);
+  }
+
+  private async forwardUserEvent(
+    resolved: ResolvedSession,
+    event: AgentEventEnvelope,
+    client: acp.AgentContext,
+    replay: boolean
+  ): Promise<boolean> {
+    const sessionId = resolved.record.sessionId;
+    if (isAgentEventOf(event, "user.message") || isAgentEventOf(event, "user.steer")) {
+      if (replay) await this.notify(client, sessionId, {
+        sessionUpdate: "user_message_chunk",
+        content: { type: "text", text: event.payload.text }
+      }, true);
+      return true;
+    }
+    if (!isAgentEventOf(event, "user.follow_up")) return false;
+    if (replay && event.payload.status === "delivered") {
+      await this.notify(client, sessionId, {
+        sessionUpdate: "user_message_chunk",
+        content: { type: "text", text: event.payload.text }
+      }, true);
+    }
+    return true;
+  }
+
+  private async forwardModelEvent(
+    resolved: ResolvedSession,
+    event: AgentEventEnvelope,
+    client: acp.AgentContext,
+    state: ForwardState,
+    replay: boolean
+  ): Promise<boolean> {
+    const sessionId = resolved.record.sessionId;
+    if (isAgentEventOf(event, "model.delta")) {
+      state.modelText.set(
+        event.payload.turnId,
+        `${state.modelText.get(event.payload.turnId) ?? ""}${event.payload.delta}`
+      );
+      await this.notify(client, sessionId, {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: event.payload.delta }
+      }, replay);
+      return true;
+    }
+    if (isAgentEventOf(event, "model.reasoning_delta")) {
+      state.reasoningText.set(
+        event.payload.turnId,
+        `${state.reasoningText.get(event.payload.turnId) ?? ""}${event.payload.delta}`
+      );
+      await this.notify(client, sessionId, {
+        sessionUpdate: "agent_thought_chunk",
+        content: { type: "text", text: event.payload.delta }
+      }, replay);
+      return true;
+    }
+    if (!isAgentEventOf(event, "model.completed")) return false;
+    const streamed = state.modelText.get(event.payload.turnId) ?? "";
+    const remaining = event.payload.text.startsWith(streamed)
+      ? event.payload.text.slice(streamed.length)
+      : streamed ? "" : event.payload.text;
+    if (remaining) await this.notify(client, sessionId, {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: remaining }
+    }, replay);
+    const reasoning = event.payload.message.reasoningContent ?? "";
+    const streamedReasoning = state.reasoningText.get(event.payload.turnId) ?? "";
+    const reasoningRemaining = reasoning.startsWith(streamedReasoning)
+      ? reasoning.slice(streamedReasoning.length)
+      : streamedReasoning ? "" : reasoning;
+    if (reasoningRemaining) await this.notify(client, sessionId, {
+      sessionUpdate: "agent_thought_chunk",
+      content: { type: "text", text: reasoningRemaining }
+    }, replay);
+    state.modelText.delete(event.payload.turnId);
+    state.reasoningText.delete(event.payload.turnId);
+    return true;
+  }
+
+  private async forwardPlanEvent(
+    resolved: ResolvedSession,
+    event: AgentEventEnvelope,
+    client: acp.AgentContext,
+    replay: boolean
+  ): Promise<boolean> {
+    if (!isAgentEventOf(event, "plan.updated")) return false;
+    await this.notify(client, resolved.record.sessionId, {
+      sessionUpdate: "plan",
+      entries: event.payload.plan.nodes.map((node) => ({
+        content: node.title,
+        priority: event.payload.plan.activeNodeId === node.id ? "high" : "medium",
+        status: node.status === "completed"
+          ? "completed"
+          : node.status === "in_progress" ? "in_progress" : "pending",
+        _meta: {
+          "sigma.nodeId": node.id,
+          "sigma.status": node.status,
+          "sigma.dependencies": node.dependencies
+        }
+      }))
+    }, replay);
+    return true;
+  }
+
+  private async forwardToolRequestEvent(
+    resolved: ResolvedSession,
+    event: AgentEventEnvelope,
+    client: acp.AgentContext,
+    replay: boolean,
+    signal?: AbortSignal
+  ): Promise<boolean> {
+    const sessionId = resolved.record.sessionId;
+    if (isAgentEventOf(event, "tool.requested")) {
+      await this.notify(client, sessionId, {
+        sessionUpdate: "tool_call",
+        toolCallId: event.payload.callId,
+        title: event.payload.name,
+        name: event.payload.name,
+        kind: toolKind(event.payload.name),
+        status: "pending",
+        rawInput: event.payload.arguments
+      }, replay);
+      return true;
+    }
+    if (!isAgentEventOf(event, "tool.approval_requested")) return false;
+    const effects = event.payload.effects;
+    await this.notify(client, sessionId, {
+      sessionUpdate: "tool_call_update",
+      toolCallId: event.payload.callId,
+      title: event.payload.toolName,
+      name: event.payload.toolName,
+      kind: toolKind(event.payload.toolName, effects),
+      status: "pending",
+      rawInput: event.payload.arguments,
+      rawOutput: { approvalReason: event.payload.reason, effects }
+    }, replay);
+    if (!replay && event.payload.approvalMode === "human" && event.payload.delegated !== true) {
+      if (!signal) throw new Error("Live Sigma approval forwarding requires an abort signal.");
+      await this.requestToolApproval(resolved, event, client, signal);
+    }
+    return true;
+  }
+
+  private async requestToolApproval(
+    resolved: ResolvedSession,
+    event: AgentEventOf<"tool.approval_requested">,
+    client: acp.AgentContext,
+    signal: AbortSignal
+  ): Promise<void> {
+    const effects = event.payload.effects;
+    const request = client.request(acp.methods.client.session.requestPermission, {
+      sessionId: resolved.record.sessionId,
+      toolCall: {
+        toolCallId: event.payload.callId,
+        title: event.payload.toolName,
+        name: event.payload.toolName,
+        kind: toolKind(event.payload.toolName, effects),
+        status: "pending",
+        rawInput: event.payload.arguments
+      },
+      options: [
+        { optionId: "allow", name: "Allow once", kind: "allow_once" },
+        { optionId: "always_allow", name: "Always allow this tool", kind: "allow_always" },
+        { optionId: "deny", name: "Deny", kind: "reject_once" }
+      ]
+    }, { cancellationSignal: signal });
+    const permission = await abortable(request, signal);
+    await resolved.handle.runtime.command({
+      type: "approve",
+      sessionId: resolved.record.runtimeSessionId,
+      requestId: event.payload.requestId,
+      decision: approvalDecision(permission)
+    });
+  }
+
+  private async forwardToolResultEvent(
+    resolved: ResolvedSession,
+    event: AgentEventEnvelope,
+    client: acp.AgentContext,
+    replay: boolean
+  ): Promise<boolean> {
+    const sessionId = resolved.record.sessionId;
+    if (isAgentEventOf(event, "tool.started")) {
+      await this.notify(client, sessionId, {
+        sessionUpdate: "tool_call_update",
+        toolCallId: event.payload.callId,
+        title: event.payload.name,
+        name: event.payload.name,
+        kind: toolKind(event.payload.name),
+        status: "in_progress"
+      }, replay);
+      return true;
+    }
+    if (isAgentEventOf(event, "tool.progress")) {
+      await this.notify(client, sessionId, {
+        sessionUpdate: "tool_call_update",
+        toolCallId: event.payload.callId,
+        title: event.payload.name,
+        name: event.payload.name,
+        status: "in_progress",
+        content: textContent(event.payload.message),
+        rawOutput: {
+          message: event.payload.message,
+          ...(event.payload.percent === undefined ? {} : { percent: event.payload.percent })
+        }
+      }, replay);
+      return true;
+    }
+    if (!isAgentEventOf(event, "tool.completed") && !isAgentEventOf(event, "tool.failed")) return false;
+    await this.notify(client, sessionId, {
+      sessionUpdate: "tool_call_update",
+      toolCallId: event.payload.callId,
+      title: event.payload.name,
+      name: event.payload.name,
+      status: event.type === "tool.completed" ? "completed" : "failed",
+      content: textContent(event.payload.output),
+      rawOutput: {
+        ok: event.payload.ok,
+        output: event.payload.output,
+        outcome: event.payload.outcome,
+        ...(event.payload.result === undefined ? {} : { result: event.payload.result }),
+        diagnostics: event.payload.diagnostics
+      }
+    }, replay);
+    return true;
+  }
+
+  private async notify(
+    client: acp.AgentContext,
+    sessionId: string,
+    update: acp.SessionUpdate,
+    replay: boolean
+  ): Promise<void> {
+    await client.notify(acp.methods.client.session.update, {
+      sessionId,
+      update,
+      ...(replay ? { _meta: { isReplay: true } } : {})
+    });
+  }
+
+  private async resolveSession(sessionId: string, cwdHint?: string): Promise<ResolvedSession> {
+    const knownRoot = cwdHint ? undefined : this.sessionRoots.get(sessionId);
+    if (knownRoot) {
+      const knownIndex = await this.index(knownRoot);
+      const knownRecord = knownIndex.sessions.find((candidate) => candidate.sessionId === sessionId);
+      if (knownRecord) {
+        return {
+          record: knownRecord,
+          handle: await this.handle(knownRecord.cwd, knownRecord.modelId)
+        };
+      }
+    }
+    const cwd = path.resolve(cwdHint ?? process.cwd());
+    const catalog = await this.options.modelCatalog(cwd);
+    const defaultHandle = await this.handle(cwd, catalog.currentModelId);
+    const index = await this.index(defaultHandle.storeRootDir);
+    let record = index.sessions.find((candidate) => candidate.sessionId === sessionId);
+    if (!record) {
+      const native = (await defaultHandle.runtime.listSessions(Number.MAX_SAFE_INTEGER))
+        .find((candidate) => candidate.sessionId === sessionId);
+      if (!native) throw new Error(`Unknown Sigma ACP session '${sessionId}'.`);
+      record = {
+        sessionId,
+        runtimeSessionId: sessionId,
+        cwd: native.workspacePath,
+        modelId: catalog.currentModelId,
+        mode: native.mode,
+        ...(native.lastMessage ? { title: native.lastMessage.slice(0, 96) } : {}),
+        createdAt: native.updatedAt,
+        updatedAt: native.updatedAt,
+        started: native.lastSeq > 1,
+        lastSeq: native.lastSeq
+      };
+      await this.upsert(defaultHandle.storeRootDir, record);
+    }
+    if (cwdHint && path.resolve(record.cwd) !== cwd) {
+      throw new Error(`Sigma ACP session '${sessionId}' belongs to '${record.cwd}', not '${cwd}'.`);
+    }
+    return {
+      record,
+      handle: record.modelId === catalog.currentModelId
+        ? defaultHandle
+        : await this.handle(record.cwd, record.modelId)
+    };
+  }
+
+  private async ensureAttached(resolved: ResolvedSession): Promise<void> {
+    const key = this.attachmentKey(resolved.record);
+    if (this.attached.has(key)) return;
+    await resolved.handle.runtime.command({
+      type: "resume",
+      sessionId: resolved.record.runtimeSessionId
+    });
+    this.attached.add(key);
+  }
+
+  private attachmentKey(record: PersistedAcpSession): string {
+    return `${record.modelId}\0${record.runtimeSessionId}`;
+  }
+
+  private handle(cwd: string, modelId: string): Promise<SigmaAcpRuntimeHandle> {
+    const key = `${path.resolve(cwd)}\0${modelId}`;
+    let handle = this.handles.get(key);
+    if (!handle) {
+      handle = this.options.runtimeFactory(path.resolve(cwd), modelId);
+      this.handles.set(key, handle);
+      void handle.catch(() => this.handles.delete(key));
+    }
+    return handle;
+  }
+
+  private async index(storeRootDir: string): Promise<PersistedAcpIndex> {
+    const key = path.resolve(storeRootDir);
+    const cached = this.indexes.get(key);
+    if (cached) return cached;
+    let value: unknown;
+    try {
+      value = JSON.parse(await readFile(path.join(key, SESSION_INDEX_FILE), "utf8")) as unknown;
+    } catch (error) {
+      if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error;
+    }
+    const index = normalizeIndex(value);
+    this.indexes.set(key, index);
+    for (const record of index.sessions) this.sessionRoots.set(record.sessionId, key);
+    return index;
+  }
+
+  private async upsert(storeRootDir: string, record: PersistedAcpSession): Promise<void> {
+    const root = path.resolve(storeRootDir);
+    const previous = this.indexWrites.get(root) ?? Promise.resolve();
+    const write = previous.then(async () => {
+      const index = await this.index(root);
+      const existing = index.sessions.findIndex((candidate) => candidate.sessionId === record.sessionId);
+      const snapshot = { ...record };
+      if (existing >= 0) index.sessions[existing] = snapshot;
+      else index.sessions.push(snapshot);
+      this.sessionRoots.set(record.sessionId, root);
+      await mkdir(root, { recursive: true });
+      const target = path.join(root, SESSION_INDEX_FILE);
+      const temporary = `${target}.${process.pid}.${randomUUID()}.tmp`;
+      await writeFile(temporary, `${JSON.stringify(index, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+      await rename(temporary, target);
+    });
+    this.indexWrites.set(root, write);
+    try {
+      await write;
+    } finally {
+      if (this.indexWrites.get(root) === write) this.indexWrites.delete(root);
+    }
+  }
+
+  private log(error: unknown): void {
+    const message = error instanceof Error ? error.stack ?? error.message : String(error);
+    (this.options.stderr ?? process.stderr).write(`[sigma acp] ${message}\n`);
+  }
+}

--- a/packages/agent-cli/src/acp/sigma-acp-events.ts
+++ b/packages/agent-cli/src/acp/sigma-acp-events.ts
@@ -1,0 +1,330 @@
+import * as acp from "@agentclientprotocol/sdk";
+import {
+  isAgentEventOf,
+  type AgentEventEnvelope,
+  type AgentEventOf
+} from "agent-protocol";
+import type { ForwardState, ResolvedSession } from "./sigma-acp-shared.js";
+
+function toolKind(name: string, effects: readonly string[] = []): acp.ToolKind {
+  if (effects.some((effect) => effect === "filesystem.write" || effect === "repository.write")) {
+    return "edit";
+  }
+  if (effects.some((effect) => effect.startsWith("process."))) return "execute";
+  if (effects.includes("network")) return "fetch";
+  if (/search|find|grep/iu.test(name)) return "search";
+  if (/read|list|inspect|status/iu.test(name)) return "read";
+  return "other";
+}
+
+function textContent(text: string): acp.ToolCallContent[] {
+  return text ? [{ type: "content", content: { type: "text", text } }] : [];
+}
+
+async function abortable<T>(operation: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) throw signal.reason ?? new Error("Operation aborted.");
+  return await new Promise<T>((resolve, reject) => {
+    const onAbort = (): void => {
+      signal.removeEventListener("abort", onAbort);
+      reject(signal.reason ?? new Error("Operation aborted."));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    void operation.then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (error: unknown) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(error);
+      }
+    );
+  });
+}
+
+function approvalDecision(
+  response: acp.RequestPermissionResponse
+): "allow" | "always_allow" | "deny" {
+  if (response.outcome.outcome !== "selected") return "deny";
+  if (response.outcome.optionId === "always_allow") return "always_allow";
+  return response.outcome.optionId === "allow" ? "allow" : "deny";
+}
+
+export class SigmaAcpEventForwarder {
+  async forwardLive(
+    resolved: ResolvedSession,
+    client: acp.AgentContext,
+    state: ForwardState,
+    signal: AbortSignal
+  ): Promise<void> {
+    for await (const event of resolved.handle.runtime.subscribe(
+      resolved.record.runtimeSessionId,
+      signal
+    )) {
+      if (event.seq <= resolved.record.lastSeq) continue;
+      await this.forwardEvent(resolved, event, client, state, false, signal);
+      resolved.record.lastSeq = event.seq;
+    }
+  }
+
+  async forwardEvent(
+    resolved: ResolvedSession,
+    event: AgentEventEnvelope,
+    client: acp.AgentContext,
+    state: ForwardState,
+    replay: boolean,
+    signal?: AbortSignal
+  ): Promise<void> {
+    if (await this.forwardUserEvent(resolved, event, client, replay)) return;
+    if (await this.forwardModelEvent(resolved, event, client, state, replay)) return;
+    if (await this.forwardPlanEvent(resolved, event, client, replay)) return;
+    if (await this.forwardToolRequestEvent(resolved, event, client, replay, signal)) return;
+    await this.forwardToolResultEvent(resolved, event, client, replay);
+  }
+
+  private async forwardUserEvent(
+    resolved: ResolvedSession,
+    event: AgentEventEnvelope,
+    client: acp.AgentContext,
+    replay: boolean
+  ): Promise<boolean> {
+    const sessionId = resolved.record.sessionId;
+    if (isAgentEventOf(event, "user.message") || isAgentEventOf(event, "user.steer")) {
+      if (replay) {
+        await this.notify(client, sessionId, {
+          sessionUpdate: "user_message_chunk",
+          content: { type: "text", text: event.payload.text }
+        }, true);
+      }
+      return true;
+    }
+    if (!isAgentEventOf(event, "user.follow_up")) return false;
+    if (replay && event.payload.status === "delivered") {
+      await this.notify(client, sessionId, {
+        sessionUpdate: "user_message_chunk",
+        content: { type: "text", text: event.payload.text }
+      }, true);
+    }
+    return true;
+  }
+
+  private async forwardModelEvent(
+    resolved: ResolvedSession,
+    event: AgentEventEnvelope,
+    client: acp.AgentContext,
+    state: ForwardState,
+    replay: boolean
+  ): Promise<boolean> {
+    const sessionId = resolved.record.sessionId;
+    if (isAgentEventOf(event, "model.delta")) {
+      state.modelText.set(
+        event.payload.turnId,
+        `${state.modelText.get(event.payload.turnId) ?? ""}${event.payload.delta}`
+      );
+      await this.notify(client, sessionId, {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: event.payload.delta }
+      }, replay);
+      return true;
+    }
+    if (isAgentEventOf(event, "model.reasoning_delta")) {
+      state.reasoningText.set(
+        event.payload.turnId,
+        `${state.reasoningText.get(event.payload.turnId) ?? ""}${event.payload.delta}`
+      );
+      await this.notify(client, sessionId, {
+        sessionUpdate: "agent_thought_chunk",
+        content: { type: "text", text: event.payload.delta }
+      }, replay);
+      return true;
+    }
+    if (!isAgentEventOf(event, "model.completed")) return false;
+    const streamed = state.modelText.get(event.payload.turnId) ?? "";
+    const remaining = event.payload.text.startsWith(streamed)
+      ? event.payload.text.slice(streamed.length)
+      : streamed ? "" : event.payload.text;
+    if (remaining) {
+      await this.notify(client, sessionId, {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: remaining }
+      }, replay);
+    }
+    const reasoning = event.payload.message.reasoningContent ?? "";
+    const streamedReasoning = state.reasoningText.get(event.payload.turnId) ?? "";
+    const reasoningRemaining = reasoning.startsWith(streamedReasoning)
+      ? reasoning.slice(streamedReasoning.length)
+      : streamedReasoning ? "" : reasoning;
+    if (reasoningRemaining) {
+      await this.notify(client, sessionId, {
+        sessionUpdate: "agent_thought_chunk",
+        content: { type: "text", text: reasoningRemaining }
+      }, replay);
+    }
+    state.modelText.delete(event.payload.turnId);
+    state.reasoningText.delete(event.payload.turnId);
+    return true;
+  }
+
+  private async forwardPlanEvent(
+    resolved: ResolvedSession,
+    event: AgentEventEnvelope,
+    client: acp.AgentContext,
+    replay: boolean
+  ): Promise<boolean> {
+    if (!isAgentEventOf(event, "plan.updated")) return false;
+    await this.notify(client, resolved.record.sessionId, {
+      sessionUpdate: "plan",
+      entries: event.payload.plan.nodes.map((node) => ({
+        content: node.title,
+        priority: event.payload.plan.activeNodeId === node.id ? "high" : "medium",
+        status: node.status === "completed"
+          ? "completed"
+          : node.status === "in_progress" ? "in_progress" : "pending",
+        _meta: {
+          "sigma.nodeId": node.id,
+          "sigma.status": node.status,
+          "sigma.dependencies": node.dependencies
+        }
+      }))
+    }, replay);
+    return true;
+  }
+
+  private async forwardToolRequestEvent(
+    resolved: ResolvedSession,
+    event: AgentEventEnvelope,
+    client: acp.AgentContext,
+    replay: boolean,
+    signal?: AbortSignal
+  ): Promise<boolean> {
+    const sessionId = resolved.record.sessionId;
+    if (isAgentEventOf(event, "tool.requested")) {
+      await this.notify(client, sessionId, {
+        sessionUpdate: "tool_call",
+        toolCallId: event.payload.callId,
+        title: event.payload.name,
+        name: event.payload.name,
+        kind: toolKind(event.payload.name),
+        status: "pending",
+        rawInput: event.payload.arguments
+      }, replay);
+      return true;
+    }
+    if (!isAgentEventOf(event, "tool.approval_requested")) return false;
+    const effects = event.payload.effects;
+    await this.notify(client, sessionId, {
+      sessionUpdate: "tool_call_update",
+      toolCallId: event.payload.callId,
+      title: event.payload.toolName,
+      name: event.payload.toolName,
+      kind: toolKind(event.payload.toolName, effects),
+      status: "pending",
+      rawInput: event.payload.arguments,
+      rawOutput: { approvalReason: event.payload.reason, effects }
+    }, replay);
+    if (!replay && event.payload.approvalMode === "human" && event.payload.delegated !== true) {
+      if (!signal) throw new Error("Live Sigma approval forwarding requires an abort signal.");
+      await this.requestToolApproval(resolved, event, client, signal);
+    }
+    return true;
+  }
+
+  private async requestToolApproval(
+    resolved: ResolvedSession,
+    event: AgentEventOf<"tool.approval_requested">,
+    client: acp.AgentContext,
+    signal: AbortSignal
+  ): Promise<void> {
+    const effects = event.payload.effects;
+    const request = client.request(acp.methods.client.session.requestPermission, {
+      sessionId: resolved.record.sessionId,
+      toolCall: {
+        toolCallId: event.payload.callId,
+        title: event.payload.toolName,
+        name: event.payload.toolName,
+        kind: toolKind(event.payload.toolName, effects),
+        status: "pending",
+        rawInput: event.payload.arguments
+      },
+      options: [
+        { optionId: "allow", name: "Allow once", kind: "allow_once" },
+        { optionId: "always_allow", name: "Always allow this tool", kind: "allow_always" },
+        { optionId: "deny", name: "Deny", kind: "reject_once" }
+      ]
+    }, { cancellationSignal: signal });
+    const permission = await abortable(request, signal);
+    await resolved.handle.runtime.command({
+      type: "approve",
+      sessionId: resolved.record.runtimeSessionId,
+      requestId: event.payload.requestId,
+      decision: approvalDecision(permission)
+    });
+  }
+
+  private async forwardToolResultEvent(
+    resolved: ResolvedSession,
+    event: AgentEventEnvelope,
+    client: acp.AgentContext,
+    replay: boolean
+  ): Promise<boolean> {
+    const sessionId = resolved.record.sessionId;
+    if (isAgentEventOf(event, "tool.started")) {
+      await this.notify(client, sessionId, {
+        sessionUpdate: "tool_call_update",
+        toolCallId: event.payload.callId,
+        title: event.payload.name,
+        name: event.payload.name,
+        kind: toolKind(event.payload.name),
+        status: "in_progress"
+      }, replay);
+      return true;
+    }
+    if (isAgentEventOf(event, "tool.progress")) {
+      await this.notify(client, sessionId, {
+        sessionUpdate: "tool_call_update",
+        toolCallId: event.payload.callId,
+        title: event.payload.name,
+        name: event.payload.name,
+        status: "in_progress",
+        content: textContent(event.payload.message),
+        rawOutput: {
+          message: event.payload.message,
+          ...(event.payload.percent === undefined ? {} : { percent: event.payload.percent })
+        }
+      }, replay);
+      return true;
+    }
+    if (!isAgentEventOf(event, "tool.completed") && !isAgentEventOf(event, "tool.failed")) {
+      return false;
+    }
+    await this.notify(client, sessionId, {
+      sessionUpdate: "tool_call_update",
+      toolCallId: event.payload.callId,
+      title: event.payload.name,
+      name: event.payload.name,
+      status: event.type === "tool.completed" ? "completed" : "failed",
+      content: textContent(event.payload.output),
+      rawOutput: {
+        ok: event.payload.ok,
+        output: event.payload.output,
+        outcome: event.payload.outcome,
+        ...(event.payload.result === undefined ? {} : { result: event.payload.result }),
+        diagnostics: event.payload.diagnostics
+      }
+    }, replay);
+    return true;
+  }
+
+  private async notify(
+    client: acp.AgentContext,
+    sessionId: string,
+    update: acp.SessionUpdate,
+    replay: boolean
+  ): Promise<void> {
+    await client.notify(acp.methods.client.session.update, {
+      sessionId,
+      update,
+      ...(replay ? { _meta: { isReplay: true } } : {})
+    });
+  }
+}

--- a/packages/agent-cli/src/acp/sigma-acp-session-registry.ts
+++ b/packages/agent-cli/src/acp/sigma-acp-session-registry.ts
@@ -1,0 +1,182 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+import type {
+  PersistedAcpSession,
+  ResolvedSession,
+  SigmaAcpAgentOptions,
+  SigmaAcpRuntimeHandle
+} from "./sigma-acp-shared.js";
+
+const SESSION_INDEX_FILE = "acp-sessions.json";
+const INDEX_VERSION = 1;
+
+interface PersistedAcpIndex {
+  version: typeof INDEX_VERSION;
+  sessions: PersistedAcpSession[];
+}
+
+function normalizeIndex(value: unknown): PersistedAcpIndex {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return { version: INDEX_VERSION, sessions: [] };
+  }
+  const input = value as Record<string, unknown>;
+  if (input.version !== INDEX_VERSION || !Array.isArray(input.sessions)) {
+    return { version: INDEX_VERSION, sessions: [] };
+  }
+  const sessions = input.sessions.filter((item): item is PersistedAcpSession => {
+    if (!item || typeof item !== "object" || Array.isArray(item)) return false;
+    const record = item as Record<string, unknown>;
+    return typeof record.sessionId === "string"
+      && typeof record.runtimeSessionId === "string"
+      && typeof record.cwd === "string"
+      && typeof record.modelId === "string"
+      && (record.mode === "analyze" || record.mode === "change")
+      && typeof record.createdAt === "string"
+      && typeof record.updatedAt === "string"
+      && typeof record.started === "boolean"
+      && Number.isSafeInteger(record.lastSeq)
+      && Number(record.lastSeq) >= 0;
+  });
+  return { version: INDEX_VERSION, sessions };
+}
+
+export class SigmaAcpSessionRegistry {
+  private readonly handles = new Map<string, Promise<SigmaAcpRuntimeHandle>>();
+  private readonly indexes = new Map<string, PersistedAcpIndex>();
+  private readonly indexWrites = new Map<string, Promise<void>>();
+  private readonly sessionRoots = new Map<string, string>();
+  private readonly attached = new Set<string>();
+
+  constructor(private readonly options: SigmaAcpAgentOptions) {}
+
+  async close(): Promise<void> {
+    const handles = await Promise.allSettled(this.handles.values());
+    await Promise.all(handles.flatMap((result) =>
+      result.status === "fulfilled" ? [result.value.close()] : []
+    ));
+    this.handles.clear();
+  }
+
+  markAttached(record: PersistedAcpSession): void {
+    this.attached.add(this.attachmentKey(record));
+  }
+
+  detach(record: PersistedAcpSession): void {
+    this.attached.delete(this.attachmentKey(record));
+  }
+
+  handle(cwd: string, modelId: string): Promise<SigmaAcpRuntimeHandle> {
+    const key = `${path.resolve(cwd)}\0${modelId}`;
+    let handle = this.handles.get(key);
+    if (!handle) {
+      handle = this.options.runtimeFactory(path.resolve(cwd), modelId);
+      this.handles.set(key, handle);
+      void handle.catch(() => this.handles.delete(key));
+    }
+    return handle;
+  }
+
+  async index(storeRootDir: string): Promise<PersistedAcpIndex> {
+    const key = path.resolve(storeRootDir);
+    const cached = this.indexes.get(key);
+    if (cached) return cached;
+    let value: unknown;
+    try {
+      value = JSON.parse(await readFile(path.join(key, SESSION_INDEX_FILE), "utf8")) as unknown;
+    } catch (error) {
+      if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error;
+    }
+    const index = normalizeIndex(value);
+    this.indexes.set(key, index);
+    for (const record of index.sessions) this.sessionRoots.set(record.sessionId, key);
+    return index;
+  }
+
+  async upsert(storeRootDir: string, record: PersistedAcpSession): Promise<void> {
+    const root = path.resolve(storeRootDir);
+    const previous = this.indexWrites.get(root) ?? Promise.resolve();
+    const write = previous.then(async () => {
+      const index = await this.index(root);
+      const existing = index.sessions.findIndex((candidate) => candidate.sessionId === record.sessionId);
+      const snapshot = { ...record };
+      if (existing >= 0) index.sessions[existing] = snapshot;
+      else index.sessions.push(snapshot);
+      this.sessionRoots.set(record.sessionId, root);
+      await mkdir(root, { recursive: true });
+      const target = path.join(root, SESSION_INDEX_FILE);
+      const temporary = `${target}.${process.pid}.${randomUUID()}.tmp`;
+      await writeFile(temporary, `${JSON.stringify(index, null, 2)}\n`, {
+        encoding: "utf8",
+        mode: 0o600
+      });
+      await rename(temporary, target);
+    });
+    this.indexWrites.set(root, write);
+    try {
+      await write;
+    } finally {
+      if (this.indexWrites.get(root) === write) this.indexWrites.delete(root);
+    }
+  }
+
+  async resolveSession(sessionId: string, cwdHint?: string): Promise<ResolvedSession> {
+    const knownRoot = cwdHint ? undefined : this.sessionRoots.get(sessionId);
+    if (knownRoot) {
+      const knownIndex = await this.index(knownRoot);
+      const knownRecord = knownIndex.sessions.find((candidate) => candidate.sessionId === sessionId);
+      if (knownRecord) {
+        return {
+          record: knownRecord,
+          handle: await this.handle(knownRecord.cwd, knownRecord.modelId)
+        };
+      }
+    }
+    const cwd = path.resolve(cwdHint ?? process.cwd());
+    const catalog = await this.options.modelCatalog(cwd);
+    const defaultHandle = await this.handle(cwd, catalog.currentModelId);
+    const index = await this.index(defaultHandle.storeRootDir);
+    let record = index.sessions.find((candidate) => candidate.sessionId === sessionId);
+    if (!record) {
+      const native = (await defaultHandle.runtime.listSessions(Number.MAX_SAFE_INTEGER))
+        .find((candidate) => candidate.sessionId === sessionId);
+      if (!native) throw new Error(`Unknown Sigma ACP session '${sessionId}'.`);
+      record = {
+        sessionId,
+        runtimeSessionId: sessionId,
+        cwd: native.workspacePath,
+        modelId: catalog.currentModelId,
+        mode: native.mode,
+        ...(native.lastMessage ? { title: native.lastMessage.slice(0, 96) } : {}),
+        createdAt: native.updatedAt,
+        updatedAt: native.updatedAt,
+        started: native.lastSeq > 1,
+        lastSeq: native.lastSeq
+      };
+      await this.upsert(defaultHandle.storeRootDir, record);
+    }
+    if (cwdHint && path.resolve(record.cwd) !== cwd) {
+      throw new Error(`Sigma ACP session '${sessionId}' belongs to '${record.cwd}', not '${cwd}'.`);
+    }
+    return {
+      record,
+      handle: record.modelId === catalog.currentModelId
+        ? defaultHandle
+        : await this.handle(record.cwd, record.modelId)
+    };
+  }
+
+  async ensureAttached(resolved: ResolvedSession): Promise<void> {
+    const key = this.attachmentKey(resolved.record);
+    if (this.attached.has(key)) return;
+    await resolved.handle.runtime.command({
+      type: "resume",
+      sessionId: resolved.record.runtimeSessionId
+    });
+    this.attached.add(key);
+  }
+
+  private attachmentKey(record: PersistedAcpSession): string {
+    return `${record.modelId}\0${record.runtimeSessionId}`;
+  }
+}

--- a/packages/agent-cli/src/acp/sigma-acp-shared.ts
+++ b/packages/agent-cli/src/acp/sigma-acp-shared.ts
@@ -1,0 +1,143 @@
+import * as acp from "@agentclientprotocol/sdk";
+import type { RunMode, RunOutcome, RuntimeClient } from "agent-protocol";
+
+export const MODEL_CONFIG_ID = "sigma.model";
+
+export interface SigmaAcpRuntimeHandle {
+  runtime: RuntimeClient;
+  workspace: string;
+  storeRootDir: string;
+  close(): Promise<void>;
+}
+
+export interface SigmaAcpModelOption {
+  id: string;
+  name: string;
+  description?: string;
+}
+
+export interface SigmaAcpModelCatalog {
+  currentModelId: string;
+  options: SigmaAcpModelOption[];
+}
+
+export interface SigmaAcpAgentOptions {
+  agentVersion: string;
+  runtimeFactory(cwd: string, modelId: string): Promise<SigmaAcpRuntimeHandle>;
+  modelCatalog(cwd: string): Promise<SigmaAcpModelCatalog>;
+  stderr?: NodeJS.WritableStream;
+}
+
+export interface PersistedAcpSession {
+  sessionId: string;
+  runtimeSessionId: string;
+  cwd: string;
+  modelId: string;
+  mode: RunMode;
+  title?: string;
+  createdAt: string;
+  updatedAt: string;
+  started: boolean;
+  lastSeq: number;
+}
+
+export interface ResolvedSession {
+  record: PersistedAcpSession;
+  handle: SigmaAcpRuntimeHandle;
+}
+
+export interface ForwardState {
+  modelText: Map<number, string>;
+  reasoningText: Map<number, string>;
+}
+
+export interface SigmaTextCommand {
+  sessionId: string;
+  text: string;
+}
+
+export function parseSigmaTextCommand(value: unknown): SigmaTextCommand {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Sigma ACP command params must be an object.");
+  }
+  const params = value as Record<string, unknown>;
+  if (typeof params.sessionId !== "string" || !params.sessionId) {
+    throw new Error("Sigma ACP command requires sessionId.");
+  }
+  if (typeof params.text !== "string" || !params.text) {
+    throw new Error("Sigma ACP command requires text.");
+  }
+  return { sessionId: params.sessionId, text: params.text };
+}
+
+export function parseHealthRequest(value: unknown): Record<string, never> {
+  if (value === undefined || value === null) return {};
+  if (typeof value !== "object" || Array.isArray(value) || Object.keys(value).length > 0) {
+    throw new Error("Sigma ACP health params must be empty.");
+  }
+  return {};
+}
+
+export function sessionModes(mode: RunMode): acp.SessionModeState {
+  return {
+    currentModeId: mode,
+    availableModes: [
+      { id: "change", name: "Agent", description: "Analyze and modify the workspace." },
+      { id: "analyze", name: "Plan", description: "Analyze the workspace without writes." }
+    ]
+  };
+}
+
+export function modelConfig(
+  catalog: SigmaAcpModelCatalog,
+  currentModelId: string
+): acp.SessionConfigOption[] {
+  return [{
+    id: MODEL_CONFIG_ID,
+    name: "Model",
+    description: "Model used by Sigma Runtime.",
+    category: "model",
+    type: "select",
+    currentValue: currentModelId,
+    options: catalog.options.map((option) => ({
+      value: option.id,
+      name: option.name,
+      ...(option.description ? { description: option.description } : {})
+    }))
+  }];
+}
+
+export function promptText(prompt: acp.ContentBlock[]): string {
+  const unsupported = prompt.find((block) => block.type !== "text");
+  if (unsupported) {
+    throw new Error(`Sigma ACP currently accepts text prompts; received '${unsupported.type}'.`);
+  }
+  const text = prompt.map((block) => block.type === "text" ? block.text : "").join("");
+  if (!text) throw new Error("Sigma ACP prompt text must not be empty.");
+  return text;
+}
+
+export function titleFromPrompt(text: string): string {
+  const firstLine = text.split(/\r?\n/u, 1)[0]?.trim() ?? "";
+  return firstLine.length > 96 ? `${firstLine.slice(0, 93)}...` : firstLine;
+}
+
+export function listOffset(cursor: string | null | undefined): number {
+  if (!cursor) return 0;
+  const match = /^sigma:(0|[1-9]\d*)$/u.exec(cursor);
+  const offset = match ? Number(match[1]) : Number.NaN;
+  if (!Number.isSafeInteger(offset)) throw new Error(`Invalid Sigma session cursor '${cursor}'.`);
+  return offset;
+}
+
+export function stopReason(outcome: RunOutcome): acp.StopReason {
+  if (outcome.kind === "cancelled") return "cancelled";
+  if (outcome.kind === "fatal" || outcome.kind === "recoverable_failure") return "refusal";
+  return "end_turn";
+}
+
+export function expectedAbort(error: unknown, signal: AbortSignal): boolean {
+  if (!signal.aborted) return false;
+  return error === signal.reason
+    || (error instanceof Error && (error.name === "AbortError" || /cancel|abort/iu.test(error.message)));
+}

--- a/packages/agent-cli/src/commands/acp.ts
+++ b/packages/agent-cli/src/commands/acp.ts
@@ -1,0 +1,143 @@
+import os from "node:os";
+import path from "node:path";
+import { Readable, Writable } from "node:stream";
+import * as acp from "@agentclientprotocol/sdk";
+import { SIGMA_PROJECT_FACTS } from "agent-config";
+import { BUILTIN_MODEL_SPECS, defaultModel } from "agent-model";
+import type { RuntimeClient } from "agent-protocol";
+import {
+  createConfiguredRuntime,
+  type RuntimeFactoryDeps
+} from "agent-runtime";
+import {
+  loadCliConfig,
+  parseArgs,
+  workspaceCustomizationTrustMessage,
+  workspaceMcpTrustMessage
+} from "../config.js";
+import {
+  SigmaAcpAgent,
+  type SigmaAcpModelCatalog,
+  type SigmaAcpRuntimeHandle
+} from "../acp/sigma-acp-agent.js";
+
+export interface AcpCommandDeps {
+  runtimeFactoryDeps?: RuntimeFactoryDeps;
+  runtime?: RuntimeClient;
+  stderr?: NodeJS.WritableStream;
+  stdin?: Readable;
+  stdout?: Writable;
+}
+
+interface SelectedModel {
+  provider: "deepseek" | "glm";
+  model: string;
+}
+
+function modelId(provider: string, model: string): string {
+  return `${provider}/${model}`;
+}
+
+function selectedModel(value: string): SelectedModel {
+  const separator = value.indexOf("/");
+  const provider = value.slice(0, separator);
+  const model = value.slice(separator + 1);
+  if ((provider !== "deepseek" && provider !== "glm") || separator < 1 || !model) {
+    throw new Error(`Invalid Sigma ACP model identifier '${value}'.`);
+  }
+  return { provider, model };
+}
+
+function catalogFor(
+  flags: Record<string, unknown>,
+  cwd: string
+): SigmaAcpModelCatalog {
+  const config = loadCliConfig({ ...flags, workspace: cwd });
+  const currentModel = config.model === "auto"
+    ? defaultModel(config.provider)
+    : config.model;
+  const options = [
+    ...BUILTIN_MODEL_SPECS.map((spec) => ({
+      id: modelId(spec.providerId, spec.upstreamModel),
+      name: spec.upstreamModel,
+      description: `${spec.providerId} · ${spec.capabilities.reasoning ? "reasoning" : "standard"}`
+    })),
+    ...config.modelSpecs.map((spec) => ({
+      id: modelId(spec.providerId, spec.upstreamModel),
+      name: spec.upstreamModel,
+      description: `${spec.providerId} · custom model`
+    }))
+  ];
+  return {
+    currentModelId: modelId(config.provider, currentModel),
+    options: [...new Map(options.map((option) => [option.id, option])).values()]
+  };
+}
+
+function trustFailure(flags: Record<string, unknown>, cwd: string): string | undefined {
+  const config = loadCliConfig({ ...flags, workspace: cwd });
+  return workspaceMcpTrustMessage(config) ?? workspaceCustomizationTrustMessage(config);
+}
+
+export async function runAcpCommand(
+  argv: string[],
+  deps: AcpCommandDeps = {}
+): Promise<number> {
+  if (argv.includes("--help") || argv.includes("-h")) {
+    (deps.stdout ?? process.stdout).write(
+      "Usage: sigma acp [configuration options]\n\n"
+      + "Serves stable ACP v1 as newline-delimited JSON-RPC over stdin/stdout.\n"
+      + "Protocol output is written only to stdout; diagnostics are written to stderr.\n"
+    );
+    return 0;
+  }
+  const parsed = parseArgs(argv);
+  if (parsed.positionals.length > 0) {
+    throw new Error(`Unexpected sigma acp argument '${parsed.positionals[0]}'.`);
+  }
+  const baseFlags = parsed.flags;
+  const runtimeFactory = async (cwd: string, selectedId: string): Promise<SigmaAcpRuntimeHandle> => {
+    const trustMessage = trustFailure(baseFlags, cwd);
+    if (trustMessage) throw new Error(trustMessage);
+    if (deps.runtime) {
+      return {
+        runtime: deps.runtime,
+        workspace: path.resolve(cwd),
+        storeRootDir: deps.runtimeFactoryDeps?.stateRootDir
+          ?? path.join(os.tmpdir(), "sigma-acp-injected-runtime"),
+        close: async () => undefined
+      };
+    }
+    const selection = selectedModel(selectedId);
+    const config = loadCliConfig({
+      ...baseFlags,
+      workspace: cwd,
+      provider: selection.provider,
+      model: selection.model
+    });
+    return await createConfiguredRuntime(config, deps.runtimeFactoryDeps, {
+      surface: "acp",
+      interactiveApprovals: true
+    });
+  };
+  const sigma = new SigmaAcpAgent({
+    agentVersion: SIGMA_PROJECT_FACTS.productVersion,
+    runtimeFactory,
+    modelCatalog: async (cwd) => catalogFor(baseFlags, cwd),
+    stderr: deps.stderr
+  });
+  const input = deps.stdin ?? process.stdin;
+  const output = deps.stdout ?? process.stdout;
+  const stream = acp.ndJsonStream(
+    Writable.toWeb(output),
+    Readable.toWeb(input)
+  );
+  const connection = sigma.app().connect(stream);
+  try {
+    await connection.closed;
+  } finally {
+    await sigma.close();
+  }
+  return 0;
+}
+

--- a/packages/agent-cli/src/commands/run.ts
+++ b/packages/agent-cli/src/commands/run.ts
@@ -291,7 +291,7 @@ export async function runCommand(argv: string[], deps: RunCommandDeps = {}): Pro
   let errorOutput: Pick<CliConfig, "outputFormat" | "streamJsonMaxLineBytes"> | undefined;
   try {
     if (argv.includes("--help") || argv.includes("-h")) {
-      stdout.write(`Usage: agent ${deps.mode === "analyze" ? "inspect" : "run"} [instruction] [--workspace <path>] [--permission-mode ask|auto|deny] [--output-format text|json|stream-json]\n`);
+      stdout.write(`Usage: sigma ${deps.mode === "analyze" ? "inspect" : "run"} [instruction] [--workspace <path>] [--permission-mode ask|auto|deny] [--output-format text|json|stream-json]\n`);
       return 0;
     }
     const parsed = parseArgs(argv);

--- a/packages/agent-cli/src/index.ts
+++ b/packages/agent-cli/src/index.ts
@@ -17,6 +17,7 @@ import { runReplayCommand } from "./commands/replay.js";
 import { runCommand } from "./commands/run.js";
 import { runSessionCommand, runSessionsCommand } from "./commands/session.js";
 import { runVersionCommand } from "./commands/version.js";
+import { runAcpCommand } from "./commands/acp.js";
 import {
   loadCliConfig, parseArgs, workspaceCustomizationTrustMessage, workspaceMcpTrustMessage
 } from "./config.js";
@@ -31,17 +32,17 @@ export interface AgentCliMainOptions {
 
 function printHelp(): void {
   const commands = new CommandRegistry().definitions();
-  process.stdout.write(`Sigma Code ${SIGMA_PROJECT_FACTS.productVersion}\n\nUsage: agent <command> [options]\n\nCommands:\n${commands.map((item) => `  ${item.name.padEnd(10)} ${item.summary}`).join("\n")}\n\nConfiguration:\n${configHelp().join("\n")}\n`);
+  process.stdout.write(`Sigma Code ${SIGMA_PROJECT_FACTS.productVersion}\n\nUsage: sigma <command> [options]\n\nCommands:\n${commands.map((item) => `  ${item.name.padEnd(10)} ${item.summary}`).join("\n")}\n\nConfiguration:\n${configHelp().join("\n")}\n`);
 }
 
 function completionScript(shell: string): string {
   const commands = new CommandRegistry().definitions().flatMap((item) => [item.name, ...(item.aliases ?? [])]);
   const flags = SIGMA_CONFIG_SCHEMA.map((item) => `--${item.flag}`);
-  if (shell === "bash") return `_agent_completion() { COMPREPLY=( $(compgen -W "${[...commands, ...flags].join(" ")}" -- "\${COMP_WORDS[COMP_CWORD]}") ); }\ncomplete -F _agent_completion agent\n`;
-  if (shell === "zsh") return `#compdef agent\n_arguments '*: :(${[...commands, ...flags].join(" ")})'\n`;
+  if (shell === "bash") return `_sigma_completion() { COMPREPLY=( $(compgen -W "${[...commands, ...flags].join(" ")}" -- "\${COMP_WORDS[COMP_CWORD]}") ); }\ncomplete -F _sigma_completion sigma\n`;
+  if (shell === "zsh") return `#compdef sigma\n_arguments '*: :(${[...commands, ...flags].join(" ")})'\n`;
   if (shell === "fish") return [
-    ...commands.map((command) => `complete -c agent -f -n "__fish_is_first_arg" -a ${command}`),
-    ...flags.map((flag) => `complete -c agent -f -l ${flag.slice(2)}`)
+    ...commands.map((command) => `complete -c sigma -f -n "__fish_is_first_arg" -a ${command}`),
+    ...flags.map((flag) => `complete -c sigma -f -l ${flag.slice(2)}`)
   ].join("\n") + "\n";
   throw new Error("completion shell must be bash, zsh, or fish");
 }
@@ -86,6 +87,11 @@ async function dispatchCommand(
   switch (definition.handler) {
     case "run": return await runCommand(argv, { mode: definition.mode });
     case "tui": return await runTuiCommand(argv, options);
+    case "acp": return await runAcpCommand(argv, {
+      runtimeFactoryDeps: options.runtimeFactoryDeps,
+      runtime: options.runtime,
+      stderr: options.stderr
+    });
     case "session": return definition.sessionAction === "list"
       ? await runSessionsCommand(argv, { runtime: options.runtime })
       : await runSessionCommand(definition.sessionAction ? [definition.sessionAction, ...argv] : argv, {

--- a/packages/agent-config/src/commands.ts
+++ b/packages/agent-config/src/commands.ts
@@ -5,7 +5,7 @@ export interface CommandDefinition {
   aliases?: string[];
   summary: string;
   mode?: RunMode;
-  handler: "run" | "tui" | "session" | "replay" | "doctor" | "sandbox" | "version" | "init" | "completion";
+  handler: "run" | "tui" | "acp" | "session" | "replay" | "doctor" | "sandbox" | "version" | "init" | "completion";
   sessionAction?: "list" | "cancel" | "resume" | "approve";
 }
 
@@ -13,6 +13,7 @@ export const SIGMA_COMMANDS: readonly CommandDefinition[] = [
   { name: "run", summary: "Run a workspace-changing task", mode: "change", handler: "run" },
   { name: "inspect", summary: "Analyze a workspace without writes", mode: "analyze", handler: "run" },
   { name: "tui", summary: "Open the interactive terminal UI", handler: "tui" },
+  { name: "acp", summary: "Serve ACP v1 over JSON-RPC stdio", handler: "acp" },
   { name: "session", summary: "Inspect or resume sessions", handler: "session" },
   { name: "sessions", summary: "List sessions", handler: "session", sessionAction: "list" },
   { name: "cancel", summary: "Cancel an active session", handler: "session", sessionAction: "cancel" },

--- a/packages/agent-runtime/src/configured-runtime.ts
+++ b/packages/agent-runtime/src/configured-runtime.ts
@@ -99,7 +99,11 @@ export interface ConfiguredRuntime {
   execution: ExecutionBroker;
   close(): Promise<void>;
 }
-export interface RuntimeFactoryOptions { connectMcp?: boolean; surface?: "cli" | "tui"; interactiveApprovals?: boolean; }
+export interface RuntimeFactoryOptions {
+  connectMcp?: boolean;
+  surface?: "cli" | "tui" | "acp";
+  interactiveApprovals?: boolean;
+}
 
 interface PreparedComposition extends RuntimeAssemblyPrepared {
   workspace: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
 
   .:
     devDependencies:
+      '@agentclientprotocol/sdk':
+        specifier: 1.3.0
+        version: 1.3.0(zod@4.4.3)
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.6.0(jiti@2.7.0))
@@ -71,6 +74,9 @@ importers:
 
   packages/agent-cli:
     dependencies:
+      '@agentclientprotocol/sdk':
+        specifier: 1.3.0
+        version: 1.3.0(zod@4.4.3)
       agent-code-intel:
         specifier: workspace:*
         version: link:../agent-code-intel
@@ -316,6 +322,11 @@ importers:
         version: 5.0.6
 
 packages:
+
+  '@agentclientprotocol/sdk@1.3.0':
+    resolution: {integrity: sha512-i3h/efaeuMUFAO1HSfo97QZQnnvMd7wWBYtBsdL6UMZg3a78sk3Ffya5Xu7C7tYsXomXoDXJBAzQF2PcFKAhIQ==}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
 
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -2805,6 +2816,10 @@ packages:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
+
+  '@agentclientprotocol/sdk@1.3.0(zod@4.4.3)':
+    dependencies:
+      zod: 4.4.3
 
   '@ampproject/remapping@2.3.0':
     dependencies:

--- a/scripts/package-agent-cli.mjs
+++ b/scripts/package-agent-cli.mjs
@@ -1481,6 +1481,7 @@ function releaseChannelFor(version, targetPlatform, windowsSignerPolicyVerified)
 function createBundleReadme(targetPlatform, targetArch, nodeRuntime, releaseChannel) {
   const isWindows = targetPlatform === "win32";
   const agent = isWindows ? String.raw`.\bin\agent.cmd` : "./bin/agent";
+  const sigma = isWindows ? String.raw`.\bin\sigma.cmd` : "./bin/sigma";
   const workspace = isWindows ? String.raw`D:\path\to\repo` : "/path/to/repo";
   const platformLabel = isWindows ? `Windows ${targetArch}` : `Linux ${targetArch}`;
   const releaseDescription = releaseChannel === "stable"
@@ -1504,22 +1505,32 @@ ${trustNotice}
 ## Start
 
 \`\`\`${isWindows ? "powershell" : "sh"}
-${agent} init --workspace ${workspace}
-${agent} version --json
-${agent} doctor --workspace ${workspace}
-${agent} doctor --workspace ${workspace} --json --strict
-${agent} tui --workspace ${workspace}
+${sigma} init --workspace ${workspace}
+${sigma} version --json
+${sigma} doctor --workspace ${workspace}
+${sigma} doctor --workspace ${workspace} --json --strict
+${sigma} tui --workspace ${workspace}
 \`\`\`
 
 For non-interactive use:
 
 \`\`\`${isWindows ? "powershell" : "sh"}
-${agent} run "Fix failing tests" --workspace ${workspace} --permission-mode auto
+${sigma} run "Fix failing tests" --workspace ${workspace} --permission-mode auto
+${sigma} inspect "Review the architecture" --workspace ${workspace}
+${sigma} sessions --workspace ${workspace}
+\`\`\`
+
+The \`${agent}\` command remains as a compatibility alias:
+
+\`\`\`${isWindows ? "powershell" : "sh"}
+${agent} init --workspace ${workspace}
+${agent} version --json
+${agent} doctor --workspace ${workspace} --json --strict
 ${agent} inspect "Review the architecture" --workspace ${workspace}
 ${agent} sessions --workspace ${workspace}
 \`\`\`
 
-The wrapper requires the pinned bundled Node runtime. It never falls back to a system \`node\` on PATH. The archive also includes the target-native \`sigma-exec\` broker, pinned TypeScript/Python language-server assets, and the offline tokenizer-estimator asset; their SHA-256 values are recorded in \`integrity-manifest.json\`.
+The wrappers require the pinned bundled Node runtime. They never fall back to a system \`node\` on PATH. The archive also includes the target-native \`sigma-exec\` broker, pinned TypeScript/Python language-server assets, and the offline tokenizer-estimator asset; their SHA-256 values are recorded in \`integrity-manifest.json\`.
 
 ## Provider Keys
 
@@ -1790,6 +1801,7 @@ async function writeBundleEntrypoints(context, nodeRuntime, signing) {
         license: "MIT",
         type: "module",
         bin: {
+          sigma: targetPlatform === "win32" ? "./bin/sigma.cmd" : "./bin/sigma",
           agent: targetPlatform === "win32" ? "./bin/agent.cmd" : "./bin/agent"
         }
       },
@@ -1800,10 +1812,14 @@ async function writeBundleEntrypoints(context, nodeRuntime, signing) {
   );
   if (targetPlatform === "win32") {
     await writeFile(path.join(bundleDir, "bin", "agent.cmd"), createAgentCmdWrapper(), "utf8");
+    await writeFile(path.join(bundleDir, "bin", "sigma.cmd"), createAgentCmdWrapper(), "utf8");
   } else {
     const agentBin = path.join(bundleDir, "bin", "agent");
     await writeFile(agentBin, createAgentWrapper(), "utf8");
     await chmod(agentBin, 0o755).catch(() => undefined);
+    const sigmaBin = path.join(bundleDir, "bin", "sigma");
+    await writeFile(sigmaBin, createAgentWrapper(), "utf8");
+    await chmod(sigmaBin, 0o755).catch(() => undefined);
   }
   await writeFile(
     path.join(bundleDir, "README.md"),

--- a/scripts/package-agent-cli.mjs
+++ b/scripts/package-agent-cli.mjs
@@ -1530,7 +1530,7 @@ ${agent} inspect "Review the architecture" --workspace ${workspace}
 ${agent} sessions --workspace ${workspace}
 \`\`\`
 
-The wrappers require the pinned bundled Node runtime. They never fall back to a system \`node\` on PATH. The archive also includes the target-native \`sigma-exec\` broker, pinned TypeScript/Python language-server assets, and the offline tokenizer-estimator asset; their SHA-256 values are recorded in \`integrity-manifest.json\`.
+The \`${sigma}\` wrapper requires the pinned bundled Node runtime and never falls back to a system \`node\` on PATH. The compatibility \`${agent}\` wrapper follows the same pinned-runtime rule. The archive also includes the target-native \`sigma-exec\` broker, pinned TypeScript/Python language-server assets, and the offline tokenizer-estimator asset; their SHA-256 values are recorded in \`integrity-manifest.json\`.
 
 ## Provider Keys
 

--- a/tests/agent-acp.contract.test.ts
+++ b/tests/agent-acp.contract.test.ts
@@ -1,0 +1,532 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { PassThrough, Readable, Writable } from "node:stream";
+import * as acp from "@agentclientprotocol/sdk";
+import type {
+  AgentEventEnvelope,
+  RunCommand,
+  RunOutcome,
+  RuntimeClient,
+  SessionOverview,
+  SessionRef,
+  StartSession
+} from "agent-protocol";
+import { afterEach, describe, expect, it } from "vitest";
+import { runAcpCommand } from "../packages/agent-cli/src/commands/acp.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map(async (directory) =>
+    await rm(directory, { recursive: true, force: true })
+  ));
+});
+
+function envelope(
+  sessionId: string,
+  runId: string,
+  seq: number,
+  type: AgentEventEnvelope["type"],
+  payload: unknown
+): AgentEventEnvelope {
+  return {
+    schemaVersion: 1,
+    seq,
+    eventId: `event-${seq}`,
+    sessionId,
+    runId,
+    occurredAt: new Date().toISOString(),
+    type,
+    authority: type.startsWith("tool.") ? "tool" : "runtime",
+    payload
+  };
+}
+
+class FakeRuntime implements RuntimeClient {
+  readonly commands: RunCommand[] = [];
+  readonly releasedSessions: string[] = [];
+  private readonly events: AgentEventEnvelope[] = [];
+  private readonly eventWaiters = new Set<() => void>();
+  private readonly outcomes = new Map<string, RunOutcome>();
+  private readonly outcomeWaiters = new Map<string, Set<(outcome: RunOutcome) => void>>();
+  private readonly sessions = new Map<string, SessionOverview>();
+  private readonly approvals = new Map<string, (decision: string) => void>();
+  private nextSession = 0;
+
+  async createSession(input: StartSession): Promise<SessionRef> {
+    const sessionId = `runtime-${++this.nextSession}`;
+    const runId = `run-${this.nextSession}`;
+    this.sessions.set(sessionId, {
+      sessionId,
+      workspacePath: input.workspacePath,
+      mode: input.mode,
+      status: "idle",
+      updatedAt: new Date().toISOString(),
+      lastSeq: 0
+    });
+    return { sessionId, runId };
+  }
+
+  async command(command: RunCommand): Promise<void> {
+    this.commands.push(command);
+    if (command.type === "submit" || command.type === "follow_up") {
+      const overview = this.required(command.sessionId);
+      overview.status = "running";
+      if (command.type === "submit") overview.mode = command.mode ?? overview.mode;
+      overview.updatedAt = new Date().toISOString();
+      this.outcomes.delete(command.sessionId);
+      if (command.text === "wait for cancellation") {
+        this.emit(command.sessionId, "model.reasoning_delta", { turnId: 2, delta: "Waiting." });
+        return;
+      }
+      void this.completeTurn(command.sessionId);
+      return;
+    }
+    if (command.type === "approve") {
+      this.approvals.get(command.requestId)?.(command.decision);
+      return;
+    }
+    if (command.type === "cancel") {
+      this.finish(command.sessionId, { kind: "cancelled", reason: command.reason ?? "cancelled" });
+    }
+  }
+
+  async *subscribe(sessionId: string, signal?: AbortSignal): AsyncIterable<AgentEventEnvelope> {
+    let offset = 0;
+    while (true) {
+      while (offset < this.events.length) {
+        const event = this.events[offset++];
+        if (event?.sessionId === sessionId) yield event;
+      }
+      if (signal?.aborted) throw signal.reason ?? new Error("aborted");
+      await new Promise<void>((resolve, reject) => {
+        const wake = (): void => {
+          signal?.removeEventListener("abort", abort);
+          this.eventWaiters.delete(wake);
+          resolve();
+        };
+        const abort = (): void => {
+          this.eventWaiters.delete(wake);
+          reject(signal?.reason ?? new Error("aborted"));
+        };
+        this.eventWaiters.add(wake);
+        signal?.addEventListener("abort", abort, { once: true });
+      });
+    }
+  }
+
+  async waitForOutcome(sessionId: string, signal?: AbortSignal): Promise<RunOutcome> {
+    const outcome = this.outcomes.get(sessionId);
+    if (outcome) return outcome;
+    return await new Promise<RunOutcome>((resolve, reject) => {
+      const waiters = this.outcomeWaiters.get(sessionId) ?? new Set();
+      const settle = (value: RunOutcome): void => {
+        signal?.removeEventListener("abort", abort);
+        waiters.delete(settle);
+        resolve(value);
+      };
+      const abort = (): void => {
+        waiters.delete(settle);
+        reject(signal?.reason ?? new Error("aborted"));
+      };
+      waiters.add(settle);
+      this.outcomeWaiters.set(sessionId, waiters);
+      signal?.addEventListener("abort", abort, { once: true });
+    });
+  }
+
+  async listSessions(): Promise<SessionOverview[]> {
+    return [...this.sessions.values()];
+  }
+
+  async *sessionEvents(sessionId: string, afterSeq = 0): AsyncIterable<AgentEventEnvelope> {
+    for (const event of this.events) {
+      if (event.sessionId === sessionId && event.seq > afterSeq) yield event;
+    }
+  }
+
+  async releaseSession(sessionId: string): Promise<void> {
+    this.releasedSessions.push(sessionId);
+  }
+
+  seedHistory(sessionId: string, text: string): void {
+    this.emit(sessionId, "user.message", { text });
+    this.emit(sessionId, "model.delta", { turnId: 1, delta: "Stored response." });
+    const overview = this.required(sessionId);
+    overview.status = "completed";
+    overview.lastMessage = text;
+    this.outcomes.set(sessionId, { kind: "completed", message: "Stored response.", evidence: [] });
+  }
+
+  private async completeTurn(sessionId: string): Promise<void> {
+    const runId = `active-${sessionId}`;
+    this.emit(sessionId, "model.reasoning_delta", { turnId: 1, delta: "Inspecting the workspace. " }, runId);
+    this.emit(sessionId, "model.delta", { turnId: 1, delta: "I will update the file. " }, runId);
+    this.emit(sessionId, "plan.updated", {
+      previousRevision: 0,
+      plan: {
+        revision: 1,
+        goal: "Update a file",
+        activeNodeId: "edit",
+        nodes: [{
+          id: "edit",
+          title: "Edit README",
+          dependencies: [],
+          status: "in_progress",
+          owner: { kind: "root" },
+          acceptanceCriteria: ["README updated"],
+          evidence: []
+        }]
+      }
+    }, runId);
+    this.emit(sessionId, "tool.requested", {
+      callId: "tool-1",
+      name: "write_file",
+      arguments: { path: "README.md", content: "Sigma" },
+      turnId: 1,
+      effectRevision: 0
+    }, runId);
+    const decision = new Promise<string>((resolve) => this.approvals.set("approval-1", resolve));
+    this.emit(sessionId, "tool.approval_requested", {
+      requestId: "approval-1",
+      callId: "tool-1",
+      toolName: "write_file",
+      arguments: { path: "README.md", content: "Sigma" },
+      effects: ["filesystem.write"],
+      plan: {
+        exactEffects: ["filesystem.write"],
+        readPaths: [],
+        writePaths: ["README.md"],
+        network: "none",
+        processMode: "none",
+        checkpointScope: ["README.md"],
+        idempotence: "replay_safe"
+      },
+      reason: "Writing README requires approval.",
+      approvalMode: "human",
+      turnId: 1,
+      effectRevision: 0
+    }, runId);
+    if (await decision === "deny") {
+      this.finish(sessionId, { kind: "cancelled", reason: "tool denied" });
+      return;
+    }
+    this.emit(sessionId, "tool.started", {
+      callId: "tool-1",
+      name: "write_file",
+      turnId: 1,
+      effectRevision: 0
+    }, runId);
+    this.emit(sessionId, "tool.progress", {
+      callId: "tool-1",
+      name: "write_file",
+      turnId: 1,
+      effectRevision: 0,
+      message: "Writing README",
+      percent: 50
+    }, runId);
+    const now = new Date().toISOString();
+    this.emit(sessionId, "tool.completed", {
+      callId: "tool-1",
+      name: "write_file",
+      ok: true,
+      output: "README updated",
+      result: { path: "README.md" },
+      outcome: { status: "succeeded", output: "README updated", diagnosticCodes: [] },
+      observedEffects: ["filesystem.write"],
+      actualEffects: ["filesystem.write"],
+      artifacts: [],
+      diagnostics: [],
+      evidence: [],
+      startedAt: now,
+      completedAt: now,
+      turnId: 1,
+      effectRevision: 0
+    }, runId);
+    this.emit(sessionId, "model.delta", { turnId: 1, delta: "Done." }, runId);
+    this.emit(sessionId, "model.completed", {
+      model: "fake-model",
+      turnId: 1,
+      effectRevision: 0,
+      text: "I will update the file. Done.",
+      finishReason: "stop",
+      message: {
+        role: "assistant",
+        content: "I will update the file. Done.",
+        reasoningContent: "Inspecting the workspace. "
+      },
+      toolCalls: [],
+      usage: {
+        usageId: "usage-1",
+        requestId: "request-1",
+        sessionId,
+        runId,
+        role: "root",
+        routeId: "default",
+        providerId: "fake",
+        modelId: "fake-model",
+        tokenizerId: "fake",
+        tokenizerAccuracy: "exact",
+        providerReported: true,
+        inputTokens: 1,
+        outputTokens: 1,
+        reasoningTokens: 1,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+        costMicroUsd: 0,
+        latencyMs: 1,
+        attempt: 1,
+        occurredAt: now
+      }
+    }, runId);
+    this.finish(sessionId, { kind: "completed", message: "Done.", evidence: [] });
+  }
+
+  private emit(sessionId: string, type: AgentEventEnvelope["type"], payload: unknown, runId?: string): void {
+    const event = envelope(sessionId, runId ?? `active-${sessionId}`, this.events.length + 1, type, payload);
+    this.events.push(event);
+    const overview = this.required(sessionId);
+    overview.lastSeq = event.seq;
+    overview.updatedAt = event.occurredAt;
+    for (const wake of [...this.eventWaiters]) wake();
+  }
+
+  private finish(sessionId: string, outcome: RunOutcome): void {
+    this.outcomes.set(sessionId, outcome);
+    const overview = this.required(sessionId);
+    overview.status = outcome.kind === "completed"
+      ? "completed"
+      : outcome.kind === "cancelled" ? "cancelled" : "failed";
+    for (const resolve of this.outcomeWaiters.get(sessionId) ?? []) resolve(outcome);
+    this.outcomeWaiters.delete(sessionId);
+  }
+
+  private required(sessionId: string): SessionOverview {
+    const overview = this.sessions.get(sessionId);
+    if (!overview) throw new Error(`Unknown fake session '${sessionId}'.`);
+    return overview;
+  }
+}
+
+describe("Sigma ACP v1 contract", () => {
+  it("speaks NDJSON JSON-RPC and maps streaming, plans, tools, approvals, cancellation, load and resume", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "sigma-acp-contract-"));
+    temporaryDirectories.push(root);
+    const runtime = new FakeRuntime();
+    const nativeSession = await runtime.createSession({ workspacePath: root, mode: "change" });
+    runtime.seedHistory(nativeSession.sessionId, "Existing native Sigma session");
+    const updates: acp.SessionNotification[] = [];
+    const permissionRequests: acp.RequestPermissionRequest[] = [];
+    let permissionOptionId = "allow";
+    const clientToAgent = new PassThrough();
+    const agentToClient = new PassThrough();
+    const diagnostics = new PassThrough();
+    let protocolOutput = "";
+    let diagnosticOutput = "";
+    agentToClient.on("data", (chunk: Buffer) => {
+      protocolOutput += chunk.toString("utf8");
+    });
+    diagnostics.on("data", (chunk: Buffer) => {
+      diagnosticOutput += chunk.toString("utf8");
+    });
+    const serving = runAcpCommand([], {
+      runtime,
+      runtimeFactoryDeps: { stateRootDir: path.join(root, "state") },
+      stdin: clientToAgent,
+      stdout: agentToClient,
+      stderr: diagnostics
+    });
+    const client = acp.client({ name: "sigma-acp-contract-client" })
+      .onNotification(acp.methods.client.session.update, ({ params }) => {
+        updates.push(params);
+      })
+      .onRequest(acp.methods.client.session.requestPermission, ({ params }) => {
+        permissionRequests.push(params);
+        return { outcome: { outcome: "selected", optionId: permissionOptionId } };
+      });
+    const clientConnection = client.connect(acp.ndJsonStream(
+      Writable.toWeb(clientToAgent),
+      Readable.toWeb(agentToClient)
+    ));
+
+    try {
+      const initialized = await clientConnection.agent.request(acp.methods.agent.initialize, {
+        protocolVersion: acp.PROTOCOL_VERSION,
+        clientInfo: { name: "contract-test", version: "1" }
+      });
+      expect(initialized.protocolVersion).toBe(1);
+      expect(initialized.agentCapabilities?.loadSession).toBe(true);
+      expect(initialized.agentCapabilities?.sessionCapabilities?.resume).toEqual({});
+      const health = await clientConnection.agent.request<SigmaHealthForTest, Record<string, never>>(
+        "_sigma/health",
+        {}
+      );
+      expect(health).toMatchObject({ ok: true, name: "Sigma", protocolVersion: 1 });
+      const nativeList = await clientConnection.agent.request(acp.methods.agent.session.list, {
+        cwd: root
+      });
+      expect(nativeList.sessions.map((session) => session.sessionId)).toContain(nativeSession.sessionId);
+      const beforeNativeReplay = updates.length;
+      await clientConnection.agent.request(acp.methods.agent.session.load, {
+        sessionId: nativeSession.sessionId,
+        cwd: root,
+        mcpServers: []
+      });
+      expect(updates.slice(beforeNativeReplay)).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          _meta: expect.objectContaining({ isReplay: true }),
+          update: expect.objectContaining({ sessionUpdate: "agent_message_chunk" })
+        })
+      ]));
+      await clientConnection.agent.request(acp.methods.agent.session.close, {
+        sessionId: nativeSession.sessionId
+      });
+      expect(runtime.releasedSessions).toContain(nativeSession.sessionId);
+      await clientConnection.agent.request(acp.methods.agent.session.resume, {
+        sessionId: nativeSession.sessionId,
+        cwd: root,
+        mcpServers: []
+      });
+      expect(runtime.commands).toContainEqual({
+        type: "resume",
+        sessionId: nativeSession.sessionId
+      });
+
+      const created = await clientConnection.agent.request(acp.methods.agent.session.new, {
+        cwd: root,
+        mcpServers: []
+      });
+      expect(created.sessionId).toMatch(/^sigma-/u);
+      expect(created.configOptions?.[0]?.category).toBe("model");
+      const changedModel = await clientConnection.agent.request(
+        acp.methods.agent.session.setConfigOption,
+        {
+          sessionId: created.sessionId,
+          configId: "sigma.model",
+          value: "glm/glm-5.2"
+        }
+      );
+      expect(changedModel.configOptions[0]).toMatchObject({ currentValue: "glm/glm-5.2" });
+
+      const prompt = await clientConnection.agent.request(acp.methods.agent.session.prompt, {
+        sessionId: created.sessionId,
+        prompt: [{ type: "text", text: "Update README" }]
+      });
+      expect(prompt.stopReason).toBe("end_turn");
+      expect(permissionRequests).toHaveLength(1);
+      expect(runtime.commands).toEqual(expect.arrayContaining([
+        expect.objectContaining({ type: "submit", text: "Update README" }),
+        expect.objectContaining({ type: "approve", decision: "allow" })
+      ]));
+      const updateKinds = updates.map((notification) => notification.update.sessionUpdate);
+      expect(updateKinds).toEqual(expect.arrayContaining([
+        "agent_message_chunk",
+        "agent_thought_chunk",
+        "plan",
+        "tool_call",
+        "tool_call_update"
+      ]));
+      expect(updates.some((notification) =>
+        notification.update.sessionUpdate === "tool_call_update"
+        && notification.update.status === "completed"
+      )).toBe(true);
+
+      const secondPrompt = await clientConnection.agent.request(acp.methods.agent.session.prompt, {
+        sessionId: created.sessionId,
+        prompt: [{ type: "text", text: "Check the result" }]
+      });
+      expect(secondPrompt.stopReason).toBe("end_turn");
+      expect(runtime.commands).toContainEqual(expect.objectContaining({
+        type: "follow_up",
+        text: "Check the result"
+      }));
+      await clientConnection.agent.request<object, SigmaTextCommandForTest>(
+        "_sigma/steer",
+        { sessionId: created.sessionId, text: "Focus on the final diff" }
+      );
+      expect(runtime.commands).toContainEqual(expect.objectContaining({
+        type: "steer",
+        text: "Focus on the final diff"
+      }));
+
+      const beforeReplay = updates.length;
+      await clientConnection.agent.request(acp.methods.agent.session.load, {
+        sessionId: created.sessionId,
+        cwd: root,
+        mcpServers: []
+      });
+      expect(updates.slice(beforeReplay).some((notification) => notification._meta?.isReplay === true))
+        .toBe(true);
+
+      permissionOptionId = "deny";
+      const denied = await clientConnection.agent.request(acp.methods.agent.session.new, {
+        cwd: root,
+        mcpServers: []
+      });
+      const deniedPrompt = await clientConnection.agent.request(acp.methods.agent.session.prompt, {
+        sessionId: denied.sessionId,
+        prompt: [{ type: "text", text: "Try a denied tool" }]
+      });
+      expect(deniedPrompt.stopReason).toBe("cancelled");
+      expect(runtime.commands).toContainEqual(expect.objectContaining({
+        type: "approve",
+        decision: "deny"
+      }));
+      permissionOptionId = "allow";
+
+      const cancellable = await clientConnection.agent.request(acp.methods.agent.session.new, {
+        cwd: root,
+        mcpServers: []
+      });
+      const pendingPrompt = clientConnection.agent.request(acp.methods.agent.session.prompt, {
+        sessionId: cancellable.sessionId,
+        prompt: [{ type: "text", text: "wait for cancellation" }]
+      });
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      await clientConnection.agent.notify(acp.methods.agent.session.cancel, {
+        sessionId: cancellable.sessionId
+      });
+      expect((await pendingPrompt).stopReason).toBe("cancelled");
+
+      await clientConnection.agent.request(acp.methods.agent.session.close, {
+        sessionId: created.sessionId
+      });
+      await clientConnection.agent.request(acp.methods.agent.session.resume, {
+        sessionId: created.sessionId,
+        cwd: root,
+        mcpServers: []
+      });
+      expect(runtime.commands).toContainEqual(expect.objectContaining({
+        type: "resume"
+      }));
+      const listed = await clientConnection.agent.request(acp.methods.agent.session.list, {
+        cwd: root
+      });
+      expect(listed.sessions.map((session) => session.sessionId)).toContain(created.sessionId);
+      expect(listed.sessions.filter((session) => session.sessionId === nativeSession.sessionId))
+        .toHaveLength(1);
+    } finally {
+      clientConnection.close();
+      clientToAgent.end();
+      await Promise.allSettled([clientConnection.closed, serving]);
+    }
+    await expect(serving).resolves.toBe(0);
+    expect(diagnosticOutput).toBe("");
+    const protocolLines = protocolOutput.trim().split(/\r?\n/u);
+    expect(protocolLines.length).toBeGreaterThan(0);
+    for (const line of protocolLines) expect(() => JSON.parse(line)).not.toThrow();
+  });
+});
+
+interface SigmaTextCommandForTest {
+  sessionId: string;
+  text: string;
+}
+
+interface SigmaHealthForTest {
+  ok: boolean;
+  name: string;
+  protocolVersion: number;
+  version: string;
+}

--- a/tests/agent-cli.commands.coverage.test.ts
+++ b/tests/agent-cli.commands.coverage.test.ts
@@ -464,6 +464,7 @@ describe("CLI command registry dispatch", () => {
     await expect(runAgentCommand(["run", "--help"])).resolves.toBe(0);
     await expect(runAgentCommand(["inspect", "--help"])).resolves.toBe(0);
     await expect(runAgentCommand(["tui", "--help"])).resolves.toBe(0);
+    await expect(runAgentCommand(["acp", "--help"])).resolves.toBe(0);
     await expect(runAgentCommand(["session", "--help"])).resolves.toBe(0);
     await expect(runAgentCommand(["cancel", "--help"])).resolves.toBe(0);
     await expect(runAgentCommand(["replay", "--help"])).resolves.toBe(0);

--- a/tests/agent-cli.run.coverage.test.ts
+++ b/tests/agent-cli.run.coverage.test.ts
@@ -219,10 +219,10 @@ describe("run command branch coverage", () => {
   it("renders both run and inspect help and reports empty instructions", async () => {
     const runHelp = new Capture();
     await expect(runCommand(["--help"], { stdout: runHelp })).resolves.toBe(0);
-    expect(runHelp.text()).toContain("agent run");
+    expect(runHelp.text()).toContain("sigma run");
     const inspectHelp = new Capture();
     await expect(runCommand(["-h"], { mode: "analyze", stdout: inspectHelp })).resolves.toBe(0);
-    expect(inspectHelp.text()).toContain("agent inspect");
+    expect(inspectHelp.text()).toContain("sigma inspect");
 
     const stderr = new Capture();
     const stdin = Object.assign(new PassThrough(), { isTTY: true });


### PR DESCRIPTION
## Summary

- add a long-running `sigma acp` command using the official ACP SDK
- map Sigma runtime sessions, streaming model/reasoning events, plans, tools, approvals, cancellation, history, and resume to ACP v1
- keep protocol output on stdout and diagnostics on stderr without changing the existing one-shot stream-json command

## Impact

This provides a product-neutral ACP boundary that downstream clients such as Sigma Code can launch and control over local JSON-RPC stdio.

## Validation

- `pnpm test -- tests/agent-acp.contract.test.ts tests/agent-cli.commands.coverage.test.ts` (18 tests passed)
- focused agent-cli build, typecheck, and lint passed

No benchmark- or task-specific behavior is included.