### PR TITLE
Add model-specific reasoning level selection

### DIFF
--- a/packages/agent-cli/src/acp/sigma-acp-agent.ts
+++ b/packages/agent-cli/src/acp/sigma-acp-agent.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import path from "node:path";
 import * as acp from "@agentclientprotocol/sdk";
+import type { ModelReasoningEffort } from "agent-model";
 import { SigmaAcpEventForwarder } from "./sigma-acp-events.js";
 import { SigmaAcpSessionRegistry } from "./sigma-acp-session-registry.js";
 import {
@@ -9,6 +10,7 @@ import {
 } from "./sigma-acp-cancellation.js";
 import {
   MODEL_CONFIG_ID,
+  REASONING_EFFORT_CONFIG_ID,
   SIGMA_RUNTIME_REQUEST_ERROR,
   expectedAbort,
   listOffset,
@@ -17,12 +19,14 @@ import {
   parseSigmaTextCommand,
   promptResponseForOutcome,
   promptText,
+  reasoningEffortForModel,
   sessionModes,
   titleFromPrompt,
   type ForwardState,
   type PersistedAcpSession,
   type ResolvedSession,
   type SigmaAcpAgentOptions,
+  type SigmaAcpModelCatalog,
   type SigmaTextCommand
 } from "./sigma-acp-shared.js";
 
@@ -32,6 +36,52 @@ export type {
   SigmaAcpModelOption,
   SigmaAcpRuntimeHandle
 } from "./sigma-acp-shared.js";
+
+interface SigmaSessionConfigSelection {
+  currentReasoningEffort?: ModelReasoningEffort;
+  nextModelId: string;
+  nextReasoningEffort?: ModelReasoningEffort;
+}
+
+function resolveSessionConfigSelection(
+  configId: string,
+  value: string,
+  catalog: SigmaAcpModelCatalog,
+  record: PersistedAcpSession
+): SigmaSessionConfigSelection {
+  const currentReasoningEffort = reasoningEffortForModel(
+    catalog,
+    record.modelId,
+    record.reasoningEffort
+  );
+  if (configId === MODEL_CONFIG_ID) {
+    if (!catalog.options.some((option) => option.id === value)) {
+      throw new Error(`Unknown Sigma model '${value}'.`);
+    }
+    return {
+      currentReasoningEffort,
+      nextModelId: value,
+      nextReasoningEffort: reasoningEffortForModel(
+        catalog,
+        value,
+        currentReasoningEffort
+      )
+    };
+  }
+  const supported = catalog.options.find(
+    (option) => option.id === record.modelId
+  )?.supportedReasoningEfforts ?? [];
+  if (!supported.includes(value as ModelReasoningEffort)) {
+    throw new Error(
+      `Unsupported Sigma reasoning effort '${value}' for model '${record.modelId}'.`
+    );
+  }
+  return {
+    currentReasoningEffort,
+    nextModelId: record.modelId,
+    nextReasoningEffort: value as ModelReasoningEffort
+  };
+}
 
 export class SigmaAcpAgent {
   private readonly sessions: SigmaAcpSessionRegistry;
@@ -102,7 +152,8 @@ export class SigmaAcpAgent {
   private async newSession(params: acp.NewSessionRequest): Promise<acp.NewSessionResponse> {
     const cwd = path.resolve(params.cwd);
     const catalog = await this.options.modelCatalog(cwd);
-    const handle = await this.sessions.handle(cwd, catalog.currentModelId);
+    const reasoningEffort = reasoningEffortForModel(catalog, catalog.currentModelId);
+    const handle = await this.sessions.handle(cwd, catalog.currentModelId, reasoningEffort);
     const created = await handle.runtime.createSession({
       workspacePath: handle.workspace,
       mode: "change"
@@ -113,6 +164,7 @@ export class SigmaAcpAgent {
       runtimeSessionId: created.sessionId,
       cwd: handle.workspace,
       modelId: catalog.currentModelId,
+      ...(reasoningEffort ? { reasoningEffort } : {}),
       mode: "change",
       createdAt: now,
       updatedAt: now,
@@ -124,7 +176,7 @@ export class SigmaAcpAgent {
     return {
       sessionId: record.sessionId,
       modes: sessionModes(record.mode),
-      configOptions: modelConfig(catalog, record.modelId)
+      configOptions: modelConfig(catalog, record.modelId, record.reasoningEffort)
     };
   }
 
@@ -141,7 +193,11 @@ export class SigmaAcpAgent {
     const catalog = await this.options.modelCatalog(resolved.record.cwd);
     return {
       modes: sessionModes(resolved.record.mode),
-      configOptions: modelConfig(catalog, resolved.record.modelId)
+      configOptions: modelConfig(
+        catalog,
+        resolved.record.modelId,
+        resolved.record.reasoningEffort
+      )
     };
   }
 
@@ -151,14 +207,22 @@ export class SigmaAcpAgent {
     const catalog = await this.options.modelCatalog(resolved.record.cwd);
     return {
       modes: sessionModes(resolved.record.mode),
-      configOptions: modelConfig(catalog, resolved.record.modelId)
+      configOptions: modelConfig(
+        catalog,
+        resolved.record.modelId,
+        resolved.record.reasoningEffort
+      )
     };
   }
 
   private async listSessions(params: acp.ListSessionsRequest): Promise<acp.ListSessionsResponse> {
     const cwd = path.resolve(params.cwd ?? process.cwd());
     const catalog = await this.options.modelCatalog(cwd);
-    const handle = await this.sessions.handle(cwd, catalog.currentModelId);
+    const handle = await this.sessions.handle(
+      cwd,
+      catalog.currentModelId,
+      reasoningEffortForModel(catalog, catalog.currentModelId)
+    );
     const index = await this.sessions.index(handle.storeRootDir);
     const offset = listOffset(params.cursor);
     const nativeSessions = (await handle.runtime.listSessions(Number.MAX_SAFE_INTEGER))
@@ -234,37 +298,88 @@ export class SigmaAcpAgent {
     await this.sessions.upsert(resolved.handle.storeRootDir, resolved.record);
   }
 
+  private async replaceSessionConfiguration(input: {
+    resolved: ResolvedSession;
+    sessionId: string;
+    nextModelId: string;
+    nextReasoningEffort?: ModelReasoningEffort;
+  }): Promise<void> {
+    const { resolved, sessionId, nextModelId, nextReasoningEffort } = input;
+    const modelChanged = nextModelId !== resolved.record.modelId;
+    if (resolved.record.started && modelChanged) {
+      throw new Error("Sigma model can only be changed before the first prompt in a session.");
+    }
+    if (resolved.record.started && this.activePrompts.has(sessionId)) {
+      throw new Error("Sigma reasoning effort cannot be changed while a prompt is running.");
+    }
+    const replacement = await this.sessions.handle(
+      resolved.record.cwd,
+      nextModelId,
+      nextReasoningEffort
+    );
+    const created = resolved.record.started
+      ? undefined
+      : await replacement.runtime.createSession({
+          workspacePath: replacement.workspace,
+          mode: resolved.record.mode
+        });
+    if (resolved.record.started) {
+      await replacement.runtime.command({
+        type: "resume",
+        sessionId: resolved.record.runtimeSessionId
+      });
+    }
+    await resolved.handle.runtime.releaseSession?.(resolved.record.runtimeSessionId);
+    this.sessions.detach(resolved.record);
+    if (created) resolved.record.runtimeSessionId = created.sessionId;
+    resolved.record.modelId = nextModelId;
+    if (nextReasoningEffort) resolved.record.reasoningEffort = nextReasoningEffort;
+    else delete resolved.record.reasoningEffort;
+    resolved.record.cwd = replacement.workspace;
+    if (created) resolved.record.lastSeq = 0;
+    resolved.record.updatedAt = new Date().toISOString();
+    this.sessions.markAttached(resolved.record);
+    await this.sessions.upsert(replacement.storeRootDir, resolved.record);
+  }
+
   private async setConfigOption(
     params: acp.SetSessionConfigOptionRequest
   ): Promise<acp.SetSessionConfigOptionResponse> {
-    if (params.configId !== MODEL_CONFIG_ID || typeof params.value !== "string") {
+    if (
+      (params.configId !== MODEL_CONFIG_ID
+        && params.configId !== REASONING_EFFORT_CONFIG_ID)
+      || typeof params.value !== "string"
+    ) {
       throw new Error(`Unsupported Sigma session configuration '${params.configId}'.`);
     }
     const resolved = await this.sessions.resolveSession(params.sessionId);
     const catalog = await this.options.modelCatalog(resolved.record.cwd);
-    if (!catalog.options.some((option) => option.id === params.value)) {
-      throw new Error(`Unknown Sigma model '${params.value}'.`);
-    }
-    if (params.value !== resolved.record.modelId) {
-      if (resolved.record.started) {
-        throw new Error("Sigma model can only be changed before the first prompt in a session.");
-      }
-      const replacement = await this.sessions.handle(resolved.record.cwd, params.value);
-      const created = await replacement.runtime.createSession({
-        workspacePath: replacement.workspace,
-        mode: resolved.record.mode
+    const selection = resolveSessionConfigSelection(
+      params.configId,
+      params.value,
+      catalog,
+      resolved.record
+    );
+    if (
+      selection.nextModelId !== resolved.record.modelId
+      || selection.nextReasoningEffort !== selection.currentReasoningEffort
+    ) {
+      await this.replaceSessionConfiguration({
+        resolved,
+        sessionId: params.sessionId,
+        nextModelId: selection.nextModelId,
+        ...(selection.nextReasoningEffort
+          ? { nextReasoningEffort: selection.nextReasoningEffort }
+          : {})
       });
-      await resolved.handle.runtime.releaseSession?.(resolved.record.runtimeSessionId);
-      this.sessions.detach(resolved.record);
-      resolved.record.runtimeSessionId = created.sessionId;
-      resolved.record.modelId = params.value;
-      resolved.record.cwd = replacement.workspace;
-      resolved.record.lastSeq = 0;
-      resolved.record.updatedAt = new Date().toISOString();
-      this.sessions.markAttached(resolved.record);
-      await this.sessions.upsert(replacement.storeRootDir, resolved.record);
     }
-    return { configOptions: modelConfig(catalog, resolved.record.modelId) };
+    return {
+      configOptions: modelConfig(
+        catalog,
+        resolved.record.modelId,
+        resolved.record.reasoningEffort
+      )
+    };
   }
 
   private async dispatchPrompt(

--- a/packages/agent-cli/src/acp/sigma-acp-session-registry.ts
+++ b/packages/agent-cli/src/acp/sigma-acp-session-registry.ts
@@ -1,15 +1,18 @@
 import { randomUUID } from "node:crypto";
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import path from "node:path";
+import type { ModelReasoningEffort } from "agent-model";
 import type {
   PersistedAcpSession,
   ResolvedSession,
   SigmaAcpAgentOptions,
   SigmaAcpRuntimeHandle
 } from "./sigma-acp-shared.js";
+import { reasoningEffortForModel } from "./sigma-acp-shared.js";
 
 const SESSION_INDEX_FILE = "acp-sessions.json";
 const INDEX_VERSION = 1;
+const REASONING_EFFORTS = new Set(["none", "low", "medium", "high", "xhigh", "max"]);
 
 interface PersistedAcpIndex {
   version: typeof INDEX_VERSION;
@@ -36,6 +39,11 @@ function invalidPersistedState(filePath: string): Error {
   });
 }
 
+function isPersistedReasoningEffort(value: unknown): boolean {
+  return value === undefined
+    || (typeof value === "string" && REASONING_EFFORTS.has(value));
+}
+
 function isPersistedSession(item: unknown): item is PersistedAcpSession {
   if (!item || typeof item !== "object" || Array.isArray(item)) return false;
   const record = item as Record<string, unknown>;
@@ -43,6 +51,7 @@ function isPersistedSession(item: unknown): item is PersistedAcpSession {
     && typeof record.runtimeSessionId === "string"
     && typeof record.cwd === "string"
     && typeof record.modelId === "string"
+    && isPersistedReasoningEffort(record.reasoningEffort)
     && (record.mode === "analyze" || record.mode === "change")
     && typeof record.createdAt === "string"
     && typeof record.updatedAt === "string"
@@ -92,11 +101,15 @@ export class SigmaAcpSessionRegistry {
     this.attached.delete(this.attachmentKey(record));
   }
 
-  handle(cwd: string, modelId: string): Promise<SigmaAcpRuntimeHandle> {
-    const key = `${path.resolve(cwd)}\0${modelId}`;
+  handle(
+    cwd: string,
+    modelId: string,
+    reasoningEffort?: ModelReasoningEffort
+  ): Promise<SigmaAcpRuntimeHandle> {
+    const key = `${path.resolve(cwd)}\0${modelId}\0${reasoningEffort ?? ""}`;
     let handle = this.handles.get(key);
     if (!handle) {
-      handle = this.options.runtimeFactory(path.resolve(cwd), modelId);
+      handle = this.options.runtimeFactory(path.resolve(cwd), modelId, reasoningEffort);
       this.handles.set(key, handle);
       void handle.catch(() => this.handles.delete(key));
     }
@@ -164,15 +177,22 @@ export class SigmaAcpSessionRegistry {
       const knownIndex = await this.index(knownRoot);
       const knownRecord = knownIndex.sessions.find((candidate) => candidate.sessionId === sessionId);
       if (knownRecord) {
+        const catalog = await this.options.modelCatalog(knownRecord.cwd);
+        const reasoningEffort = reasoningEffortForModel(
+          catalog,
+          knownRecord.modelId,
+          knownRecord.reasoningEffort
+        );
         return {
           record: knownRecord,
-          handle: await this.handle(knownRecord.cwd, knownRecord.modelId)
+          handle: await this.handle(knownRecord.cwd, knownRecord.modelId, reasoningEffort)
         };
       }
     }
     const cwd = path.resolve(cwdHint ?? process.cwd());
     const catalog = await this.options.modelCatalog(cwd);
-    const defaultHandle = await this.handle(cwd, catalog.currentModelId);
+    const defaultReasoningEffort = reasoningEffortForModel(catalog, catalog.currentModelId);
+    const defaultHandle = await this.handle(cwd, catalog.currentModelId, defaultReasoningEffort);
     const index = await this.index(defaultHandle.storeRootDir);
     let record = index.sessions.find((candidate) => candidate.sessionId === sessionId);
     if (!record) {
@@ -184,6 +204,7 @@ export class SigmaAcpSessionRegistry {
         runtimeSessionId: sessionId,
         cwd: native.workspacePath,
         modelId: catalog.currentModelId,
+        ...(defaultReasoningEffort ? { reasoningEffort: defaultReasoningEffort } : {}),
         mode: native.mode,
         ...(native.lastMessage ? { title: native.lastMessage.slice(0, 96) } : {}),
         createdAt: native.updatedAt,
@@ -199,8 +220,14 @@ export class SigmaAcpSessionRegistry {
     return {
       record,
       handle: record.modelId === catalog.currentModelId
+        && reasoningEffortForModel(catalog, record.modelId, record.reasoningEffort)
+          === defaultReasoningEffort
         ? defaultHandle
-        : await this.handle(record.cwd, record.modelId)
+        : await this.handle(
+            record.cwd,
+            record.modelId,
+            reasoningEffortForModel(catalog, record.modelId, record.reasoningEffort)
+          )
     };
   }
 
@@ -225,6 +252,6 @@ export class SigmaAcpSessionRegistry {
   }
 
   private attachmentKey(record: PersistedAcpSession): string {
-    return `${record.modelId}\0${record.runtimeSessionId}`;
+    return `${record.modelId}\0${record.reasoningEffort ?? ""}\0${record.runtimeSessionId}`;
   }
 }

--- a/packages/agent-cli/src/acp/sigma-acp-shared.ts
+++ b/packages/agent-cli/src/acp/sigma-acp-shared.ts
@@ -1,7 +1,9 @@
 import * as acp from "@agentclientprotocol/sdk";
+import type { ModelReasoningEffort } from "agent-model";
 import type { RunMode, RunOutcome, RuntimeClient } from "agent-protocol";
 
 export const MODEL_CONFIG_ID = "sigma.model";
+export const REASONING_EFFORT_CONFIG_ID = "sigma.reasoning_effort";
 export const SIGMA_RUNTIME_REQUEST_ERROR = -32001;
 
 export interface SigmaAcpRuntimeHandle {
@@ -15,6 +17,8 @@ export interface SigmaAcpModelOption {
   id: string;
   name: string;
   description?: string;
+  supportedReasoningEfforts?: readonly ModelReasoningEffort[];
+  defaultReasoningEffort?: ModelReasoningEffort;
 }
 
 export interface SigmaAcpModelCatalog {
@@ -24,7 +28,11 @@ export interface SigmaAcpModelCatalog {
 
 export interface SigmaAcpAgentOptions {
   agentVersion: string;
-  runtimeFactory(cwd: string, modelId: string): Promise<SigmaAcpRuntimeHandle>;
+  runtimeFactory(
+    cwd: string,
+    modelId: string,
+    reasoningEffort?: ModelReasoningEffort
+  ): Promise<SigmaAcpRuntimeHandle>;
   modelCatalog(cwd: string): Promise<SigmaAcpModelCatalog>;
   stderr?: NodeJS.WritableStream;
 }
@@ -34,6 +42,7 @@ export interface PersistedAcpSession {
   runtimeSessionId: string;
   cwd: string;
   modelId: string;
+  reasoningEffort?: ModelReasoningEffort;
   mode: RunMode;
   title?: string;
   createdAt: string;
@@ -91,9 +100,10 @@ export function sessionModes(mode: RunMode): acp.SessionModeState {
 
 export function modelConfig(
   catalog: SigmaAcpModelCatalog,
-  currentModelId: string
+  currentModelId: string,
+  currentReasoningEffort?: ModelReasoningEffort
 ): acp.SessionConfigOption[] {
-  return [{
+  const options: acp.SessionConfigOption[] = [{
     id: MODEL_CONFIG_ID,
     name: "Model",
     description: "Model used by Sigma Runtime.",
@@ -106,6 +116,51 @@ export function modelConfig(
       ...(option.description ? { description: option.description } : {})
     }))
   }];
+  const model = catalog.options.find((option) => option.id === currentModelId);
+  const supported = model?.supportedReasoningEfforts ?? [];
+  const reasoningEffort = reasoningEffortForModel(
+    catalog,
+    currentModelId,
+    currentReasoningEffort
+  );
+  if (supported.length > 0 && reasoningEffort) {
+    const labels: Record<ModelReasoningEffort, string> = {
+      none: "None",
+      minimal: "Minimal",
+      low: "Low",
+      medium: "Medium",
+      high: "High",
+      xhigh: "Extra High",
+      max: "Max"
+    };
+    options.push({
+      id: REASONING_EFFORT_CONFIG_ID,
+      name: "Reasoning",
+      description: "Reasoning effort used by Sigma Runtime for this model.",
+      category: "thought_level",
+      type: "select",
+      currentValue: reasoningEffort,
+      options: supported.map((effort) => ({
+        value: effort,
+        name: labels[effort]
+      }))
+    });
+  }
+  return options;
+}
+
+export function reasoningEffortForModel(
+  catalog: SigmaAcpModelCatalog,
+  modelId: string,
+  requested?: ModelReasoningEffort
+): ModelReasoningEffort | undefined {
+  const model = catalog.options.find((option) => option.id === modelId);
+  const supported = model?.supportedReasoningEfforts ?? [];
+  if (requested && supported.includes(requested)) return requested;
+  if (model?.defaultReasoningEffort && supported.includes(model.defaultReasoningEffort)) {
+    return model.defaultReasoningEffort;
+  }
+  return supported[0];
 }
 
 export function promptText(prompt: acp.ContentBlock[]): string {

--- a/packages/agent-cli/src/commands/acp.ts
+++ b/packages/agent-cli/src/commands/acp.ts
@@ -7,6 +7,7 @@ import {
   BUILTIN_MODEL_SPECS,
   defaultModel,
   loadPiRuntimeModelCatalog,
+  type ModelReasoningEffort,
   type ModelSpec
 } from "agent-model";
 import type { RuntimeClient } from "agent-protocol";
@@ -81,7 +82,13 @@ function catalogFor(
             : spec.capabilities.reasoning
             ? "reasoning"
             : "standard"
-      }`
+      }`,
+      ...(spec.supportedReasoningEfforts
+        ? { supportedReasoningEfforts: spec.supportedReasoningEfforts }
+        : {}),
+      ...(spec.defaultReasoningEffort
+        ? { defaultReasoningEffort: spec.defaultReasoningEffort }
+        : {})
     })),
     ...config.modelSpecs.map((spec) => ({
       id: modelId(spec.providerId, spec.upstreamModel),
@@ -120,7 +127,11 @@ export async function runAcpCommand(
   const catalogSpecs = deps.runtime || deps.runtimeFactoryDeps?.gatewayFactory
     ? BUILTIN_MODEL_SPECS
     : (await loadPiRuntimeModelCatalog()).specs;
-  const runtimeFactory = async (cwd: string, selectedId: string): Promise<SigmaAcpRuntimeHandle> => {
+  const runtimeFactory = async (
+    cwd: string,
+    selectedId: string,
+    reasoningEffort?: ModelReasoningEffort
+  ): Promise<SigmaAcpRuntimeHandle> => {
     const trustMessage = trustFailure(baseFlags, cwd);
     if (trustMessage) throw new Error(trustMessage);
     if (deps.runtime) {
@@ -139,7 +150,10 @@ export async function runAcpCommand(
       provider: selection.provider,
       model: selection.model
     });
-    return await createConfiguredRuntime(config, deps.runtimeFactoryDeps, {
+    return await createConfiguredRuntime({
+      ...config,
+      ...(reasoningEffort ? { reasoningEffort } : {})
+    }, deps.runtimeFactoryDeps, {
       surface: "acp",
       interactiveApprovals: true
     });

--- a/packages/agent-cli/src/commands/models.ts
+++ b/packages/agent-cli/src/commands/models.ts
@@ -69,7 +69,11 @@ async function modelCatalog() {
       imageInput: model.imageInput,
       billingModes: model.billingModes,
       activeBillingMode: activeMethod?.billingMode ?? null,
-      isRecommended: model.recommended
+      isRecommended: model.recommended,
+      supportedReasoningEfforts: model.supportedReasoningEfforts,
+      ...(model.defaultReasoningEffort
+        ? { defaultReasoningEffort: model.defaultReasoningEffort }
+        : {})
     };
   });
   return {

--- a/packages/agent-model/src/catalog.ts
+++ b/packages/agent-model/src/catalog.ts
@@ -1,4 +1,8 @@
-import { listPiModels, type PiModelDescriptor } from "agent-pi";
+import {
+  listPiModels,
+  type PiModelDescriptor,
+  type PiReasoningEffort
+} from "agent-pi";
 import type {
   ModelBillingMode,
   ModelCapabilities,
@@ -104,7 +108,11 @@ export interface ModelSpec {
   capabilities: ModelCapabilities;
   tokenizer: TokenizerMetadata;
   pricing?: ModelPricing;
+  supportedReasoningEfforts?: readonly PiReasoningEffort[];
+  defaultReasoningEffort?: PiReasoningEffort;
 }
+
+export type ModelReasoningEffort = PiReasoningEffort;
 
 export interface ModelRoute {
   id: string;
@@ -145,6 +153,12 @@ export function modelSpecsForPiCatalog(
       billingModes: model.billingModes,
       capabilities: model.capabilities,
       tokenizer: approximateTokenizer,
+      ...(model.supportedReasoningEfforts.length > 0
+        ? { supportedReasoningEfforts: model.supportedReasoningEfforts }
+        : {}),
+      ...(model.defaultReasoningEffort
+        ? { defaultReasoningEffort: model.defaultReasoningEffort }
+        : {}),
       ...(billingMode === "metered" && model.pricing
         ? { pricing: model.pricing }
         : {})

--- a/packages/agent-model/src/registry.ts
+++ b/packages/agent-model/src/registry.ts
@@ -7,7 +7,8 @@ import {
   PiModelGateway,
   type CredentialStore,
   type Models,
-  type ModelsStore
+  type ModelsStore,
+  type PiReasoningEffort
 } from "agent-pi";
 import type { ModelCapabilities, ModelGateway } from "agent-protocol";
 import {
@@ -31,6 +32,7 @@ export interface CreateGatewayOptions {
   idleTimeoutMs?: number;
   activeStreamTimeoutMs?: number;
   capabilities?: ModelCapabilities;
+  reasoningEffort?: PiReasoningEffort;
 }
 
 export type CreateCatalogGatewayOptions = Omit<CreateGatewayOptions, "provider" | "model">;
@@ -110,6 +112,7 @@ export interface PiRuntimeModelCatalog {
     requestTimeoutMs: number;
     idleTimeoutMs: number;
     activeStreamTimeoutMs?: number;
+    reasoningEffort?: PiReasoningEffort;
   }): ModelGateway;
 }
 

--- a/packages/agent-pi/src/gateway.ts
+++ b/packages/agent-pi/src/gateway.ts
@@ -26,9 +26,11 @@ import {
   getPiModel,
   getPiProvider,
   OPENAI_CODEX_PROVIDER_ID,
-  piBillingMode
+  piBillingMode,
+  type PiReasoningEffort
 } from "./models.js";
 import { FileModelsStore } from "./models-store.js";
+import { piReasoningStreamOptions } from "./reasoning.js";
 import { monitoredPiStream } from "./stream-timeout.js";
 
 export interface PiModelGatewayOptions {
@@ -42,6 +44,7 @@ export interface PiModelGatewayOptions {
   requestTimeoutMs?: number;
   idleTimeoutMs?: number;
   activeStreamTimeoutMs?: number;
+  reasoningEffort?: PiReasoningEffort;
 }
 
 function fallbackModel(providerId: string, modelId: string): PiModel<Api> | undefined {
@@ -61,6 +64,7 @@ export class PiModelGateway implements ModelGateway {
   private readonly requestTimeoutMs?: number;
   private readonly idleTimeoutMs: number;
   private readonly activeStreamTimeoutMs?: number;
+  private readonly reasoningEffort?: PiReasoningEffort;
 
   constructor(options: PiModelGatewayOptions) {
     this.provider = options.provider;
@@ -80,6 +84,7 @@ export class PiModelGateway implements ModelGateway {
     this.activeStreamTimeoutMs = options.activeStreamTimeoutMs === undefined
       ? undefined
       : Math.max(1, Math.trunc(options.activeStreamTimeoutMs));
+    this.reasoningEffort = options.reasoningEffort;
     this.capabilities = options.capabilities ?? {
       contextWindowTokens: piModel.contextWindow,
       maxOutputTokens: piModel.maxTokens,
@@ -109,6 +114,7 @@ export class PiModelGateway implements ModelGateway {
     let responseStatus: number | undefined;
     try {
       const stream = monitoredPiStream((signal) => {
+        const context = piContext(request, this.piModel);
         const options = {
           signal,
           maxTokens: request.maxOutputTokens,
@@ -117,6 +123,12 @@ export class PiModelGateway implements ModelGateway {
           maxRetries: 0,
           ...(request.sessionId ? { sessionId: request.sessionId } : {}),
           ...(this.provider === OPENAI_CODEX_PROVIDER_ID ? { transport: "sse" as const } : {}),
+          ...piReasoningStreamOptions(
+            this.piModel,
+            this.reasoningEffort,
+            context,
+            request.maxOutputTokens
+          ),
           ...(this.requestTimeoutMs ? { timeoutMs: this.requestTimeoutMs } : {}),
           ...(this.provider === "deepseek"
             ? { onPayload: (payload: unknown) => deepSeekPayload(payload, request) }
@@ -127,7 +139,7 @@ export class PiModelGateway implements ModelGateway {
         };
         return this.models.stream(
           this.piModel,
-          piContext(request, this.piModel),
+          context,
           options as never
         );
       }, {

--- a/packages/agent-pi/src/models.ts
+++ b/packages/agent-pi/src/models.ts
@@ -2,6 +2,7 @@ import {
   createModels,
   createProvider,
   envApiKeyAuth,
+  getSupportedThinkingLevels,
   type Api,
   type AuthType,
   type Credential,
@@ -37,6 +38,17 @@ export const GLM_DEFAULT_MODEL = "glm-5.2" as const;
 export const PI_AI_VERSION = "0.82.1" as const;
 
 export type PiBillingMode = "metered" | "subscription" | "unpriced";
+export const PI_REASONING_EFFORTS = [
+  "none",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max"
+] as const;
+export type PiReasoningEffort = (typeof PI_REASONING_EFFORTS)[number];
+export const DEFAULT_PI_REASONING_EFFORT: PiReasoningEffort = "medium";
 
 export interface PiAuthMethodDescriptor {
   id: string;
@@ -66,6 +78,8 @@ export interface PiModelDescriptor {
   billingModes: readonly PiBillingMode[];
   pricing?: PiModelPricing;
   recommended: boolean;
+  supportedReasoningEfforts: readonly PiReasoningEffort[];
+  defaultReasoningEffort?: PiReasoningEffort;
 }
 
 const generatedAt = getBuiltinModelDataGeneratedAt();
@@ -143,6 +157,33 @@ function freshProviders(): Provider[] {
 
 function pricing(model: Model<Api>): PiModelPricing | undefined {
   return piModelPricing(model, catalogEffectiveAt);
+}
+
+function supportedReasoningEfforts(model: Model<Api>): readonly PiReasoningEffort[] {
+  if (!model.reasoning) return [];
+  const supportedLevels = new Set(getSupportedThinkingLevels(model));
+  const candidates = PI_REASONING_EFFORTS.flatMap((effort) => {
+    const level = effort === "none" ? "off" : effort;
+    if (!supportedLevels.has(level)) return [];
+    const mapped = model.thinkingLevelMap?.[level];
+    return [{
+      effort,
+      effective: typeof mapped === "string" ? mapped.toLowerCase() : level
+    }];
+  });
+  const effectiveLevels = new Map<string, PiReasoningEffort[]>();
+  for (const candidate of candidates) {
+    const efforts = effectiveLevels.get(candidate.effective) ?? [];
+    efforts.push(candidate.effort);
+    effectiveLevels.set(candidate.effective, efforts);
+  }
+  const supported = new Set<PiReasoningEffort>();
+  for (const [effective, efforts] of effectiveLevels) {
+    const matchingEffort = efforts.find((effort) => effort === effective);
+    supported.add(matchingEffort ?? efforts[0]!);
+  }
+  const result = PI_REASONING_EFFORTS.filter((effort) => supported.has(effort));
+  return result.length > 1 ? result : [];
 }
 
 export function piBillingMode(
@@ -328,6 +369,10 @@ export function listPiModels(models: Models = createPiModels()): readonly PiMode
     const billingModes = [...new Set(authTypes.map((type) =>
       piBillingMode(model.provider, type, model)))];
     const modelPricing = pricing(model);
+    const reasoningEfforts = supportedReasoningEfforts(model);
+    const defaultReasoningEffort = reasoningEfforts.includes(DEFAULT_PI_REASONING_EFFORT)
+      ? DEFAULT_PI_REASONING_EFFORT
+      : reasoningEfforts[0];
     return {
       id: model.id,
       name: model.name,
@@ -341,7 +386,9 @@ export function listPiModels(models: Models = createPiModels()): readonly PiMode
       capabilities: capabilities(model),
       billingModes,
       ...(modelPricing ? { pricing: modelPricing } : {}),
-      recommended: recommendedModels.has(`${model.provider}/${model.id}`)
+      recommended: recommendedModels.has(`${model.provider}/${model.id}`),
+      supportedReasoningEfforts: reasoningEfforts,
+      ...(defaultReasoningEffort ? { defaultReasoningEffort } : {})
     };
   });
 }

--- a/packages/agent-pi/src/reasoning.ts
+++ b/packages/agent-pi/src/reasoning.ts
@@ -1,0 +1,264 @@
+import {
+  clampThinkingLevel,
+  type Api,
+  type Context,
+  type Model,
+  type ThinkingLevel
+} from "@earendil-works/pi-ai";
+import {
+  adjustMaxTokensForThinking,
+  clampMaxTokensToContext
+} from "@earendil-works/pi-ai/api/simple-options";
+import type { PiReasoningEffort } from "./models.js";
+
+const MISTRAL_REASONING_EFFORT_MODELS = new Set([
+  "mistral-small-2603",
+  "mistral-small-latest",
+  "mistral-medium-3.5"
+]);
+
+function budgetLevel(
+  level: ThinkingLevel
+): Exclude<ThinkingLevel, "xhigh" | "max"> {
+  return level === "xhigh" || level === "max" ? "high" : level;
+}
+
+function anthropicEffort(model: Model<Api>, level: ThinkingLevel): string {
+  const mapped = model.thinkingLevelMap?.[level];
+  if (typeof mapped === "string") return mapped;
+  if (level === "minimal" || level === "low") return "low";
+  if (level === "medium") return "medium";
+  return "high";
+}
+
+function anthropicReasoningOptions(
+  model: Model<Api>,
+  level: ThinkingLevel,
+  context: Context,
+  requestedMaxTokens: number | undefined
+): Readonly<Record<string, unknown>> {
+  if (
+    model.compat
+    && "forceAdaptiveThinking" in model.compat
+    && model.compat.forceAdaptiveThinking === true
+  ) {
+    return {
+      thinkingEnabled: true,
+      effort: anthropicEffort(model, level)
+    };
+  }
+  const baseMaxTokens = clampMaxTokensToContext(
+    model,
+    context,
+    requestedMaxTokens ?? model.maxTokens
+  );
+  const adjusted = adjustMaxTokensForThinking(baseMaxTokens, model.maxTokens, level);
+  const maxTokens = clampMaxTokensToContext(model, context, adjusted.maxTokens);
+  return {
+    maxTokens,
+    thinkingEnabled: true,
+    thinkingBudgetTokens: Math.min(
+      adjusted.thinkingBudget,
+      Math.max(0, maxTokens - 1_024)
+    )
+  };
+}
+
+function bedrockModelMatchCandidates(model: Model<Api>): readonly string[] {
+  return [model.id, model.name].flatMap((value) => {
+    const lower = value.toLowerCase();
+    return [lower, lower.replace(/[\s_.:]+/gu, "-")];
+  });
+}
+
+function isAnthropicBedrockModel(model: Model<Api>): boolean {
+  const id = model.id.toLowerCase();
+  const name = model.name.toLowerCase();
+  return id.includes("anthropic.claude")
+    || id.includes("anthropic/claude")
+    || name.includes("anthropic.claude")
+    || name.includes("anthropic/claude")
+    || name.includes("claude");
+}
+
+function supportsBedrockAdaptiveThinking(model: Model<Api>): boolean {
+  return bedrockModelMatchCandidates(model).some((candidate) =>
+    [
+      "opus-4-6",
+      "opus-4-7",
+      "opus-4-8",
+      "opus-5",
+      "sonnet-4-6",
+      "sonnet-5",
+      "fable-5"
+    ].some((marker) => candidate.includes(marker)));
+}
+
+function bedrockReasoningOptions(
+  model: Model<Api>,
+  level: ThinkingLevel,
+  context: Context,
+  requestedMaxTokens: number | undefined
+): Readonly<Record<string, unknown>> {
+  if (!isAnthropicBedrockModel(model) || supportsBedrockAdaptiveThinking(model)) {
+    return { reasoning: level };
+  }
+  const baseMaxTokens = clampMaxTokensToContext(
+    model,
+    context,
+    requestedMaxTokens ?? model.maxTokens
+  );
+  const adjusted = adjustMaxTokensForThinking(baseMaxTokens, model.maxTokens, level);
+  const maxTokens = clampMaxTokensToContext(model, context, adjusted.maxTokens);
+  const normalizedLevel = budgetLevel(level);
+  return {
+    maxTokens,
+    reasoning: level,
+    thinkingBudgets: {
+      [normalizedLevel]: Math.min(
+        adjusted.thinkingBudget,
+        Math.max(0, maxTokens - 1_024)
+      )
+    }
+  };
+}
+
+function isGemini3Pro(model: Model<Api>): boolean {
+  return /gemini-3(?:\.\d+)?-pro/u.test(model.id.toLowerCase());
+}
+
+function isGemini3Flash(model: Model<Api>): boolean {
+  const id = model.id.toLowerCase();
+  return /gemini-3(?:\.\d+)?-flash/u.test(id)
+    || id === "gemini-flash-latest"
+    || id === "gemini-flash-lite-latest";
+}
+
+function isGemma4(model: Model<Api>): boolean {
+  return /gemma-?4/u.test(model.id.toLowerCase());
+}
+
+function googleThinkingLevel(model: Model<Api>, level: ThinkingLevel): string {
+  const normalized = budgetLevel(level);
+  if (isGemini3Pro(model)) {
+    return normalized === "minimal" || normalized === "low" ? "LOW" : "HIGH";
+  }
+  if (isGemma4(model)) {
+    return normalized === "minimal" || normalized === "low" ? "MINIMAL" : "HIGH";
+  }
+  return normalized.toUpperCase();
+}
+
+function googleThinkingBudget(model: Model<Api>, level: ThinkingLevel): number {
+  const normalized = budgetLevel(level);
+  if (model.id.includes("2.5-pro")) {
+    return {
+      minimal: 128,
+      low: 2_048,
+      medium: 8_192,
+      high: 32_768
+    }[normalized];
+  }
+  if (model.id.includes("2.5-flash-lite")) {
+    return {
+      minimal: 512,
+      low: 2_048,
+      medium: 8_192,
+      high: 24_576
+    }[normalized];
+  }
+  if (model.id.includes("2.5-flash")) {
+    return {
+      minimal: 128,
+      low: 2_048,
+      medium: 8_192,
+      high: 24_576
+    }[normalized];
+  }
+  return -1;
+}
+
+function googleReasoningOptions(
+  model: Model<Api>,
+  level: ThinkingLevel
+): Readonly<Record<string, unknown>> {
+  const usesThinkingLevel = isGemini3Pro(model)
+    || isGemini3Flash(model)
+    || (model.api === "google-generative-ai" && isGemma4(model));
+  return usesThinkingLevel
+    ? {
+        thinking: {
+          enabled: true,
+          level: googleThinkingLevel(model, level)
+        }
+      }
+    : {
+        thinking: {
+          enabled: true,
+          budgetTokens: googleThinkingBudget(model, level)
+        }
+      };
+}
+
+function disabledReasoningOptions(model: Model<Api>): Readonly<Record<string, unknown>> {
+  switch (model.api) {
+    case "openai-codex-responses":
+      return { reasoningEffort: "none" };
+    case "anthropic-messages":
+      return { thinkingEnabled: false };
+    case "google-generative-ai":
+    case "google-vertex":
+      return { thinking: { enabled: false } };
+    default:
+      return {};
+  }
+}
+
+function enabledReasoningOptions(
+  model: Model<Api>,
+  level: ThinkingLevel,
+  context: Context,
+  requestedMaxTokens: number | undefined
+): Readonly<Record<string, unknown>> {
+  switch (model.api) {
+    case "openai-completions":
+    case "openai-responses":
+    case "openai-codex-responses":
+    case "azure-openai-responses":
+      return { reasoningEffort: level };
+    case "anthropic-messages":
+      return anthropicReasoningOptions(model, level, context, requestedMaxTokens);
+    case "google-generative-ai":
+    case "google-vertex":
+      return googleReasoningOptions(model, level);
+    case "bedrock-converse-stream":
+      return bedrockReasoningOptions(model, level, context, requestedMaxTokens);
+    case "pi-messages":
+      return { reasoning: level };
+    case "mistral-conversations":
+      return MISTRAL_REASONING_EFFORT_MODELS.has(model.id)
+        ? { reasoningEffort: model.thinkingLevelMap?.[level] ?? "high" }
+        : { promptMode: "reasoning" };
+    default:
+      return { reasoning: level };
+  }
+}
+
+/**
+ * Translate Sigma's provider-neutral effort into the direct Pi API options.
+ * The gateway intentionally keeps using `Models.stream` so provider-specific
+ * tool choice, payload hooks, and transport settings remain intact.
+ */
+export function piReasoningStreamOptions(
+  model: Model<Api>,
+  effort: PiReasoningEffort | undefined,
+  context: Context,
+  requestedMaxTokens?: number
+): Readonly<Record<string, unknown>> {
+  if (!effort || !model.reasoning) return {};
+  const requestedLevel = effort === "none" ? "off" : effort;
+  const level = clampThinkingLevel(model, requestedLevel);
+  return level === "off"
+    ? disabledReasoningOptions(model)
+    : enabledReasoningOptions(model, level, context, requestedMaxTokens);
+}

--- a/packages/agent-runtime/src/configured-runtime.ts
+++ b/packages/agent-runtime/src/configured-runtime.ts
@@ -7,6 +7,7 @@ import type {
 } from "agent-config";
 import type { ModelGateway, RuntimeClient } from "agent-protocol";
 import { loadPiRuntimeModelCatalog } from "agent-model";
+import type { ModelReasoningEffort } from "agent-model";
 import type {
   BrokerDoctorReport,
   ContainerEngine,
@@ -72,6 +73,7 @@ export interface RuntimeCompositionConfig {
   explicitSingleModelRoute?: boolean;
   modelSpecs?: readonly ModelSpecConfigValue[];
   modelRoutes?: readonly ModelRouteConfigValue[];
+  reasoningEffort?: ModelReasoningEffort;
   budget?: {
     maxInputTokens: number; maxOutputTokens: number; maxCostMicroUsd: number;
     allowUnpricedCosts?: boolean;
@@ -81,7 +83,8 @@ export interface RuntimeCompositionConfig {
 }
 export interface RuntimeFactoryDeps {
   gatewayFactory?: (options: { provider: string; model: string; maxRetries: number;
-    requestTimeoutMs: number; idleTimeoutMs: number; activeStreamTimeoutMs?: number }) => ModelGateway;
+    requestTimeoutMs: number; idleTimeoutMs: number; activeStreamTimeoutMs?: number;
+    reasoningEffort?: ModelReasoningEffort }) => ModelGateway;
   stateRootDir?: string;
   executionBroker?: ExecutionBroker;
   /** Trusted product launcher input. Never derive this from workspace, model,

--- a/packages/agent-runtime/src/model-composition.ts
+++ b/packages/agent-runtime/src/model-composition.ts
@@ -8,6 +8,7 @@ import {
   RoutedModelGateway,
   type ModelRoute,
   type ModelRouteConstraints,
+  type ModelReasoningEffort,
   type ModelSpec
 } from "agent-model";
 import type { ModelExecutionRole, ModelGateway } from "agent-protocol";
@@ -27,6 +28,7 @@ export interface ModelCompositionConfig {
   explicitSingleModelRoute?: boolean;
   modelSpecs?: readonly ModelSpecConfigValue[];
   modelRoutes?: readonly ModelRouteConfigValue[];
+  reasoningEffort?: ModelReasoningEffort;
   budget?: { maxCostMicroUsd: number; allowUnpricedCosts?: boolean };
 }
 
@@ -37,6 +39,7 @@ interface ModelGatewayFactoryOptions {
   requestTimeoutMs: number;
   idleTimeoutMs: number;
   activeStreamTimeoutMs?: number;
+  reasoningEffort?: ModelReasoningEffort;
 }
 
 export interface ModelCompositionDeps {
@@ -225,7 +228,8 @@ function gatewayOptions(config: ModelCompositionConfig): Omit<
     idleTimeoutMs: config.streamIdleSec * 1_000,
     ...(config.streamActiveSec && config.streamActiveSec > 0
       ? { activeStreamTimeoutMs: config.streamActiveSec * 1_000 }
-      : {})
+      : {}),
+    ...(config.reasoningEffort ? { reasoningEffort: config.reasoningEffort } : {})
   };
 }
 

--- a/tests/agent-acp.contract.test.ts
+++ b/tests/agent-acp.contract.test.ts
@@ -552,15 +552,53 @@ describe("Sigma ACP v1 contract", () => {
           description: "openai-codex · subscription"
         })
       ]));
-      const changedModel = await clientConnection.agent.request(
+      expect(created.configOptions?.[1]).toMatchObject({
+        id: "sigma.reasoning_effort",
+        category: "thought_level",
+        currentValue: "medium",
+        options: [
+          { value: "none", name: "None" },
+          { value: "low", name: "Low" },
+          { value: "medium", name: "Medium" },
+          { value: "high", name: "High" },
+          { value: "xhigh", name: "Extra High" },
+          { value: "max", name: "Max" }
+        ]
+      });
+      const changedReasoning = await clientConnection.agent.request(
         acp.methods.agent.session.setConfigOption,
         {
           sessionId: created.sessionId,
+          configId: "sigma.reasoning_effort",
+          value: "high"
+        }
+      );
+      expect(changedReasoning.configOptions[1]).toMatchObject({ currentValue: "high" });
+      const modelSwitchSession = await clientConnection.agent.request(
+        acp.methods.agent.session.new,
+        { cwd: root, mcpServers: [] }
+      );
+      const changedModel = await clientConnection.agent.request(
+        acp.methods.agent.session.setConfigOption,
+        {
+          sessionId: modelSwitchSession.sessionId,
           configId: "sigma.model",
           value: "glm/glm-5.2"
         }
       );
       expect(changedModel.configOptions[0]).toMatchObject({ currentValue: "glm/glm-5.2" });
+      expect(changedModel.configOptions[1]).toMatchObject({
+        id: "sigma.reasoning_effort",
+        currentValue: "medium",
+        options: [
+          { value: "none", name: "None" },
+          { value: "minimal", name: "Minimal" },
+          { value: "low", name: "Low" },
+          { value: "medium", name: "Medium" },
+          { value: "high", name: "High" }
+        ]
+      });
+      expect(changedModel.configOptions).toHaveLength(2);
 
       const prompt = await clientConnection.agent.request(acp.methods.agent.session.prompt, {
         sessionId: created.sessionId,
@@ -585,6 +623,17 @@ describe("Sigma ACP v1 contract", () => {
         && notification.update.status === "completed"
       )).toBe(true);
 
+      const changedReasoningAfterPrompt = await clientConnection.agent.request(
+        acp.methods.agent.session.setConfigOption,
+        {
+          sessionId: created.sessionId,
+          configId: "sigma.reasoning_effort",
+          value: "max"
+        }
+      );
+      expect(changedReasoningAfterPrompt.configOptions[1]).toMatchObject({
+        currentValue: "max"
+      });
       const secondPrompt = await clientConnection.agent.request(acp.methods.agent.session.prompt, {
         sessionId: created.sessionId,
         prompt: [{ type: "text", text: "Check the result" }]

--- a/tests/agent-pi.api-families.test.ts
+++ b/tests/agent-pi.api-families.test.ts
@@ -276,7 +276,8 @@ describe.each(apiFamilies)("Pi %s API family contract", (api) => {
     const gateway = new PiModelGateway({
       provider: model.provider,
       model: model.id,
-      models: contractModels(model, captured)
+      models: contractModels(model, captured),
+      reasoningEffort: "high"
     });
 
     const response = await gateway.complete(request(model));
@@ -349,10 +350,56 @@ describe.each(apiFamilies)("Pi %s API family contract", (api) => {
       expect.objectContaining({ thoughtSignature: "opaque-prior-tool" })
     ]));
     expect(call.options.maxRetries).toBe(0);
-    expect(call.options.maxTokens).toBe(4_096);
+    expect(call.options.maxTokens).toBe(api === "anthropic-messages" ? 16_384 : 4_096);
     expect(call.options.signal).toBeInstanceOf(AbortSignal);
+    expect(call.options.toolChoice).toBe("auto");
     expect(call.options.transport).toBe(
       api === "openai-codex-responses" ? "sse" : undefined
     );
+    const expectedReasoningOptions: Record<
+      (typeof apiFamilies)[number],
+      Record<string, unknown>
+    > = {
+      "openai-completions": { reasoningEffort: "high" },
+      "openai-responses": { reasoningEffort: "high" },
+      "openai-codex-responses": { reasoningEffort: "high" },
+      "anthropic-messages": {
+        thinkingEnabled: true,
+        thinkingBudgetTokens: 15_360
+      },
+      "google-generative-ai": {
+        thinking: { enabled: true, budgetTokens: -1 }
+      },
+      "bedrock-converse-stream": { reasoning: "high" },
+      "mistral-conversations": { promptMode: "reasoning" },
+      "pi-messages": { reasoning: "high" }
+    };
+    expect(call.options).toMatchObject(expectedReasoningOptions[api]);
+  });
+});
+
+describe("Pi token-budget reasoning adapters", () => {
+  it("reserves the selected thinking budget for non-adaptive Claude on Bedrock", async () => {
+    const model = {
+      ...contractModel("bedrock-converse-stream"),
+      id: "anthropic.claude-sonnet-3-7",
+      name: "Claude Sonnet 3.7"
+    };
+    const captured: CapturedCall[] = [];
+    const gateway = new PiModelGateway({
+      provider: model.provider,
+      model: model.id,
+      models: contractModels(model, captured),
+      reasoningEffort: "high"
+    });
+
+    await gateway.complete(request(model));
+
+    expect(captured[0]?.options).toMatchObject({
+      maxTokens: 16_384,
+      reasoning: "high",
+      thinkingBudgets: { high: 15_360 },
+      toolChoice: "auto"
+    });
   });
 });

--- a/tests/agent-pi.gateway.test.ts
+++ b/tests/agent-pi.gateway.test.ts
@@ -352,6 +352,20 @@ describe("OpenAI Codex subscription gateway", () => {
       "gpt-5.6-sol",
       "gpt-5.6-terra"
     ]);
+    expect(models.find((model) =>
+      model.providerId === OPENAI_CODEX_PROVIDER_ID
+      && model.id === "gpt-5.6-sol"
+    )).toMatchObject({
+      supportedReasoningEfforts: ["none", "low", "medium", "high", "xhigh", "max"],
+      defaultReasoningEffort: "medium"
+    });
+    expect(models.find((model) =>
+      model.providerId === "google"
+      && model.id === "gemini-3-pro-preview"
+    )).toMatchObject({
+      supportedReasoningEfforts: ["low", "high"],
+      defaultReasoningEffort: "low"
+    });
   });
 
   it("uses only the ChatGPT Codex SSE endpoint and durably replays opaque state", async () => {
@@ -374,7 +388,8 @@ describe("OpenAI Codex subscription gateway", () => {
     const gateway = new PiModelGateway({
       provider: OPENAI_CODEX_PROVIDER_ID,
       model: OPENAI_CODEX_DEFAULT_MODEL,
-      credentials: new MemoryCredentialStore(oauth())
+      credentials: new MemoryCredentialStore(oauth()),
+      reasoningEffort: "max"
     });
     const sessionId = "sigma-session-affinity";
     const controller = new AbortController();
@@ -478,6 +493,11 @@ describe("OpenAI Codex subscription gateway", () => {
       request.headers.get("x-client-request-id") === sessionId)).toBe(true);
     expect(captured.every((request) =>
       request.body.prompt_cache_key === sessionId)).toBe(true);
+    expect(captured.every((request) =>
+      JSON.stringify(request.body.reasoning) === JSON.stringify({
+        effort: "max",
+        summary: "auto"
+      }))).toBe(true);
     expect(captured[0]!.body.instructions).toBe(
       "<system>\nSystem first.\n</system>\n\n<developer>\nDeveloper second.\n</developer>"
     );


### PR DESCRIPTION
## What

- derive selectable reasoning levels from each Pi model's metadata, including mapped-level de-duplication and model-specific defaults
- translate the provider-neutral selection into the direct options expected by OpenAI, Anthropic, Google, Bedrock, Mistral, and Pi Messages without dropping tool choice, transport, timeout, or payload hooks
- expose the selection through the model catalog and Sigma ACP, and preserve it across runtime/session replacement
- allow changing a reasoning level between prompts while retaining the same durable Sigma session

## Why

Reasoning effort was previously implicit, and the first implementation path only targeted `openai-codex-responses`. Models on other Pi API families could advertise reasoning capability but had no model-specific selector or end-to-end configuration path.

## Impact

- GPT-5.6 Sol exposes `none`, `low`, `medium`, `high`, `xhigh`, and `max`, with `medium` as the default
- other models expose only their own distinct supported levels; models without multiple selectable levels do not receive a selector
- token-budget providers reserve the selected thinking budget while retaining their requested output allowance
- ACP model/level changes remain isolated by runtime handle and resume the existing persisted session

## Companion

- T3/Sigma Code integration: https://github.com/hututuQQQ/sigma-code/pull/6

## Checks

- `pnpm typecheck`
- `pnpm test -- tests/agent-pi.gateway.test.ts tests/agent-pi.api-families.test.ts tests/agent-acp.contract.test.ts tests/agent-cli.models.test.ts` (36 tests)
- focused ESLint on changed Sigma files
- actual CLI catalog inspection for GPT-5.6 Sol, GLM 5.2, and Gemini 3 Pro