### PR TITLE
Fix transient streams and isolate child runs

### DIFF
--- a/packages/agent-pi/src/errors.ts
+++ b/packages/agent-pi/src/errors.ts
@@ -178,7 +178,18 @@ function isServerFailure(status: number | undefined, text: string): boolean {
 
 function isNetworkFailure(error: unknown, text: string): boolean {
   return error instanceof TypeError
-    || containsAny(text, ["fetch failed", "network", "econn", "enotfound"]);
+    || containsAny(text, [
+      "fetch failed",
+      "network",
+      "econn",
+      "enotfound",
+      "socket hang up",
+      "unexpected eof",
+      "premature close",
+      "websocket stream closed",
+      "stream closed before response.completed",
+      "connection closed before response.completed"
+    ]);
 }
 
 function fallbackFailure(

--- a/packages/agent-protocol/src/supervisor.ts
+++ b/packages/agent-protocol/src/supervisor.ts
@@ -4,6 +4,7 @@ import type { ToolEffect } from "./tools.js";
 export interface SupervisorSpawnInput {
   childId?: string;
   parentId: string;
+  runId: string;
   instruction: string;
   workspacePath: string;
   intent: "analyze" | "write";

--- a/packages/agent-runtime/src/configured-runtime-assembly.ts
+++ b/packages/agent-runtime/src/configured-runtime-assembly.ts
@@ -51,9 +51,10 @@ async function joinChildren(
   supervisor: AgentSupervisor,
   store: RunStore,
   parentId: string,
+  parentRunId: string,
   signal: AbortSignal
 ): Promise<ChildJoinSummary> {
-  const jobs = await supervisor.joinParent(parentId, signal);
+  const jobs = await supervisor.joinParent(parentId, parentRunId, signal);
   const evidence: JsonValue[] = jobs.map((job) => JSON.parse(JSON.stringify({
     childId: job.id,
     status: job.status,
@@ -72,6 +73,7 @@ async function joinChildren(
   const durable = await auditDurableChildren(
     store,
     parentId,
+    parentRunId,
     new Set(jobs.map((job) => job.id))
   );
   return {
@@ -137,10 +139,10 @@ export function createComposedRuntime(input: {
     hookArtifacts: customization.hookArtifacts,
     hookRunner,
     agentProfileHookRunner,
-    joinChildren: async (parentId, signal) =>
-      await joinChildren(supervisor, store, parentId, signal),
-    cancelChildren: async (parentId, reason) =>
-      await supervisor.cancelParent(parentId, reason),
+    joinChildren: async (parentId, parentRunId, signal) =>
+      await joinChildren(supervisor, store, parentId, parentRunId, signal),
+    cancelChildren: async (parentId, parentRunId, reason) =>
+      await supervisor.cancelParent(parentId, parentRunId, reason),
     hasActiveChildren: (parentId) => supervisor.list(parentId)
       .some((child) => child.status === "queued" || child.status === "running")
   });

--- a/packages/agent-runtime/src/configured-runtime-supervisor.ts
+++ b/packages/agent-runtime/src/configured-runtime-supervisor.ts
@@ -16,7 +16,7 @@ export function createConfiguredSupervisor(
     async (event) => {
       const runtime = runtimeReference.current;
       if (!runtime) throw new Error("Runtime is not ready to record child events.");
-      await runtime.recordChildEvent(event.parentId, event.type, {
+      await runtime.recordChildEvent(event.parentId, event.runId, event.type, {
         childId: event.childId,
         payload: event.payload
       });

--- a/packages/agent-runtime/src/durable-children.ts
+++ b/packages/agent-runtime/src/durable-children.ts
@@ -13,6 +13,7 @@ import type { ChildJoinSummary, RuntimeSession } from "./types.js";
 
 export interface DurableChild {
   childId: string;
+  runId: string;
   detached: boolean;
   metadata: Record<string, JsonValue>;
   childSessionId?: string;
@@ -50,6 +51,7 @@ export async function readDurableChildren(store: RunStore, parentSessionId: stri
     if (event.type === "child.spawned") {
       children.set(parsed.childId, {
         childId: parsed.childId,
+        runId: event.runId,
         detached: parsed.detail.detached === true,
         metadata: record(parsed.detail.metadata ?? null),
         integrated: false,
@@ -89,10 +91,13 @@ function failure(child: DurableChild): string | null {
 export async function auditDurableChildren(
   store: RunStore,
   parentSessionId: string,
+  parentRunId: string,
   excludeIds: ReadonlySet<string> = new Set()
 ): Promise<ChildJoinSummary> {
   const children = await readDurableChildren(store, parentSessionId);
-  const joined = [...children.values()].filter((child) => !child.detached && !excludeIds.has(child.childId));
+  const joined = [...children.values()].filter((child) =>
+    child.runId === parentRunId && !child.detached && !excludeIds.has(child.childId)
+  );
   return {
     evidence: joined.map((child) => ({
       childId: child.childId,

--- a/packages/agent-runtime/src/effect-runner.ts
+++ b/packages/agent-runtime/src/effect-runner.ts
@@ -177,7 +177,11 @@ export class EffectRunner {
       return false;
     }
     if (outcome.kind === "completed" && this.options.runtime.joinChildren) {
-      const children = await this.options.runtime.joinChildren(session.identity.sessionId, signal);
+      const children = await this.options.runtime.joinChildren(
+        session.identity.sessionId,
+        session.durable.runId,
+        signal
+      );
       if (children.failures.length > 0) {
         await this.options.emit(session, "diagnostic", "runtime", {
           kind: "child.join_failed",

--- a/packages/agent-runtime/src/runtime-client.ts
+++ b/packages/agent-runtime/src/runtime-client.ts
@@ -305,11 +305,17 @@ export class InProcessRuntimeClient implements RuntimeClient {
   async undoLatestCheckpoint(sessionId: string): Promise<import("agent-protocol").CheckpointRef> { return await this.checkpoints.undoLatest(this.required(sessionId)); }
   async recordChildEvent(
     parentSessionId: string,
+    parentRunId: string,
     type: "child.spawned" | "child.message" | "child.completed",
     payload: JsonValue
   ): Promise<void> {
+    const session = this.required(parentSessionId);
+    // Detached children may finish after the parent has advanced to a new
+    // run. Never apply their historical completion to the new run's budget,
+    // plan, or event stream.
+    if (session.durable.runId !== parentRunId) return;
     await handleChildEvent(
-      this.required(parentSessionId), type, payload, this.control,
+      session, type, payload, this.control,
       async (target, eventType, authority, value) => await this.emit(target, eventType, authority, value)
     );
   }

--- a/packages/agent-runtime/src/runtime-command-handler.ts
+++ b/packages/agent-runtime/src/runtime-command-handler.ts
@@ -142,7 +142,11 @@ export class RuntimeCommandHandler {
     session.interaction.approvals.clear();
     session.interaction.callApprovals.clear();
     const children = Promise.resolve().then(async () =>
-      await this.options.cancelChildren?.(session.identity.sessionId, reason));
+      await this.options.cancelChildren?.(
+        session.identity.sessionId,
+        session.durable.runId,
+        reason
+      ));
     // A cancellation acknowledgement is a quiescence boundary: mutation
     // tools and broker processes must settle before the caller can observe it.
     await waitForCancelledRunSettlement(session, running);

--- a/packages/agent-runtime/src/runtime-session-finish.ts
+++ b/packages/agent-runtime/src/runtime-session-finish.ts
@@ -15,7 +15,7 @@ export interface RuntimeSessionFinishOptions {
   hooks: RuntimeHookCoordinator;
   events: RuntimeEventLog;
   commandBus: SessionCommandBus;
-  cancelChildren?(parentSessionId: string, reason: string): Promise<void> | void;
+  cancelChildren?(parentSessionId: string, parentRunId: string, reason: string): Promise<void> | void;
   beforeOutcome?(session: RuntimeSession, outcome: RunOutcome): Promise<number>;
 }
 
@@ -120,7 +120,11 @@ async function cancelChildrenAfterFailure(
   outcome: RunOutcome
 ): Promise<void> {
   if (outcome.kind === "completed") return;
-  await options.cancelChildren?.(session.identity.sessionId, `Parent run ended as ${outcome.kind}.`);
+  await options.cancelChildren?.(
+    session.identity.sessionId,
+    session.durable.runId,
+    `Parent run ended as ${outcome.kind}.`
+  );
 }
 
 async function settleBeforeTerminalEvent(

--- a/packages/agent-runtime/src/types.ts
+++ b/packages/agent-runtime/src/types.ts
@@ -70,8 +70,8 @@ export interface RuntimeOptions {
   /** Runtime-authority provenance supplied by a trusted launcher. Never derive
    * this from the workspace being operated on. */
   subjectAttestation?: SubjectAttestationContext;
-  joinChildren?(parentSessionId: string, signal: AbortSignal): Promise<ChildJoinSummary>;
-  cancelChildren?(parentSessionId: string, reason: string): Promise<void> | void;
+  joinChildren?(parentSessionId: string, parentRunId: string, signal: AbortSignal): Promise<ChildJoinSummary>;
+  cancelChildren?(parentSessionId: string, parentRunId: string, reason: string): Promise<void> | void;
   hasActiveChildren?(parentSessionId: string): Promise<boolean> | boolean;
 }
 

--- a/packages/agent-supervisor/src/supervisor-types.ts
+++ b/packages/agent-supervisor/src/supervisor-types.ts
@@ -1,0 +1,70 @@
+import type { JsonValue, RunOutcome, ToolEffect } from "agent-protocol";
+import type { ChildRunIntent, ChildWorkspaceIsolation } from "./workspace-isolation.js";
+
+export interface ChildMessage {
+  type: "follow_up" | "cancel";
+  text?: string;
+}
+
+export interface ChildAgentContext {
+  childId: string;
+  parentId: string;
+  runId: string;
+  instruction: string;
+  intent: ChildRunIntent;
+  workspacePath: string;
+  sourceWorkspacePath: string;
+  isolation: ChildWorkspaceIsolation;
+  writeScope: string[];
+  delegatedEffects: ToolEffect[];
+  signal: AbortSignal;
+  mailbox: AsyncIterable<ChildMessage>;
+  metadata: JsonValue;
+  started(sessionId: string): Promise<void>;
+  notify(payload: JsonValue): Promise<void>;
+  settling(): void;
+}
+
+export interface SpawnChildInput {
+  childId?: string;
+  parentId: string;
+  runId: string;
+  instruction: string;
+  workspacePath: string;
+  intent?: ChildRunIntent;
+  writeScope?: string[];
+  delegatedEffects?: ToolEffect[];
+  detached?: boolean;
+  metadata?: JsonValue;
+}
+
+export interface ChildAgentResult {
+  childId: string;
+  outcome: RunOutcome;
+  report: JsonValue;
+}
+
+export type ChildAgentFactory = (context: ChildAgentContext) => Promise<ChildAgentResult>;
+
+export interface ChildSupervisorEvent {
+  type: "child.spawned" | "child.message" | "child.completed";
+  parentId: string;
+  runId: string;
+  childId: string;
+  payload: JsonValue;
+}
+
+export type ChildEventSink = (event: ChildSupervisorEvent) => Promise<void>;
+
+export interface ChildJob {
+  id: string;
+  parentId: string;
+  runId: string;
+  status: "queued" | "running" | "completed" | "failed" | "cancelled";
+  detached: boolean;
+  writeScope: string[];
+  isolation?: ChildWorkspaceIsolation;
+  sessionId?: string;
+  result?: ChildAgentResult;
+  error?: string;
+}

--- a/packages/agent-supervisor/src/supervisor.ts
+++ b/packages/agent-supervisor/src/supervisor.ts
@@ -14,6 +14,7 @@ export interface ChildMessage {
 export interface ChildAgentContext {
   childId: string;
   parentId: string;
+  runId: string;
   instruction: string;
   intent: ChildRunIntent;
   workspacePath: string;
@@ -31,6 +32,7 @@ export interface ChildAgentContext {
 export interface SpawnChildInput {
   childId?: string;
   parentId: string;
+  runId: string;
   instruction: string;
   workspacePath: string;
   intent?: ChildRunIntent;
@@ -51,6 +53,7 @@ export type ChildAgentFactory = (context: ChildAgentContext) => Promise<ChildAge
 export interface ChildSupervisorEvent {
   type: "child.spawned" | "child.message" | "child.completed";
   parentId: string;
+  runId: string;
   childId: string;
   payload: JsonValue;
 }
@@ -60,6 +63,7 @@ export type ChildEventSink = (event: ChildSupervisorEvent) => Promise<void>;
 export interface ChildJob {
   id: string;
   parentId: string;
+  runId: string;
   status: "queued" | "running" | "completed" | "failed" | "cancelled";
   detached: boolean;
   writeScope: string[];
@@ -145,6 +149,7 @@ export class AgentSupervisor implements SupervisorPort {
     const job: ChildJob = {
       id,
       parentId: input.parentId,
+      runId: input.runId,
       status: "queued",
       detached: input.detached === true,
       writeScope: [...(input.writeScope ?? [])]
@@ -209,9 +214,9 @@ export class AgentSupervisor implements SupervisorPort {
     finally { job.controller.abort(new Error(reason)); }
   }
 
-  async cancelParent(parentId: string, reason = "parent cancelled children"): Promise<void> {
+  async cancelParent(parentId: string, runId: string, reason = "parent cancelled children"): Promise<void> {
     const children = [...this.jobs.values()].filter((job) =>
-      job.public.parentId === parentId && !job.public.detached
+      job.public.parentId === parentId && job.public.runId === runId && !job.public.detached
     );
     for (const job of children) this.cancel(job.public.id, reason);
     await Promise.all(children.map(async (job) => await job.completion));
@@ -221,8 +226,10 @@ export class AgentSupervisor implements SupervisorPort {
     return await this.required(childId).completion;
   }
 
-  async joinParent(parentId: string, signal?: AbortSignal): Promise<ChildJob[]> {
-    const jobs = [...this.jobs.values()].filter((job) => job.public.parentId === parentId && !job.public.detached);
+  async joinParent(parentId: string, runId: string, signal?: AbortSignal): Promise<ChildJob[]> {
+    const jobs = [...this.jobs.values()].filter((job) =>
+      job.public.parentId === parentId && job.public.runId === runId && !job.public.detached
+    );
     if (!signal) return await Promise.all(jobs.map((job) => job.completion));
     return await new Promise<ChildJob[]>((resolve, reject) => {
       let settled = false;
@@ -319,6 +326,7 @@ export class AgentSupervisor implements SupervisorPort {
     void this.factory({
       childId: job.public.id,
       parentId: job.input.parentId,
+      runId: job.input.runId,
       instruction: job.input.instruction,
       intent: job.intent,
       workspacePath: allocation.workspacePath,
@@ -394,6 +402,12 @@ export class AgentSupervisor implements SupervisorPort {
 
   private async publish(job: InternalJob, type: ChildSupervisorEvent["type"], payload: JsonValue): Promise<void> {
     if (!this.eventSink) return;
-    await this.eventSink({ type, parentId: job.public.parentId, childId: job.public.id, payload });
+    await this.eventSink({
+      type,
+      parentId: job.public.parentId,
+      runId: job.public.runId,
+      childId: job.public.id,
+      payload
+    });
   }
 }

--- a/packages/agent-supervisor/src/supervisor.ts
+++ b/packages/agent-supervisor/src/supervisor.ts
@@ -1,77 +1,29 @@
 import { randomUUID } from "node:crypto";
-import type { JsonValue, RunOutcome, SupervisorPort, ToolEffect } from "agent-protocol";
+import type { JsonValue, SupervisorPort } from "agent-protocol";
 import { AsyncMailbox } from "./mailbox.js";
+import type {
+  ChildAgentFactory,
+  ChildEventSink,
+  ChildJob,
+  ChildMessage,
+  ChildSupervisorEvent,
+  SpawnChildInput
+} from "./supervisor-types.js";
+export type {
+  ChildAgentContext,
+  ChildAgentFactory,
+  ChildAgentResult,
+  ChildEventSink,
+  ChildJob,
+  ChildMessage,
+  ChildSupervisorEvent,
+  SpawnChildInput
+} from "./supervisor-types.js";
 import {
   WorkspaceIsolationManager,
   type ChildRunIntent,
-  type ChildWorkspaceIsolation,
   type WorkspaceAllocation
 } from "./workspace-isolation.js";
-export interface ChildMessage {
-  type: "follow_up" | "cancel";
-  text?: string;
-}
-export interface ChildAgentContext {
-  childId: string;
-  parentId: string;
-  runId: string;
-  instruction: string;
-  intent: ChildRunIntent;
-  workspacePath: string;
-  sourceWorkspacePath: string;
-  isolation: ChildWorkspaceIsolation;
-  writeScope: string[];
-  delegatedEffects: ToolEffect[];
-  signal: AbortSignal;
-  mailbox: AsyncIterable<ChildMessage>;
-  metadata: JsonValue;
-  started(sessionId: string): Promise<void>;
-  notify(payload: JsonValue): Promise<void>;
-  settling(): void;
-}
-export interface SpawnChildInput {
-  childId?: string;
-  parentId: string;
-  runId: string;
-  instruction: string;
-  workspacePath: string;
-  intent?: ChildRunIntent;
-  writeScope?: string[];
-  delegatedEffects?: ToolEffect[];
-  detached?: boolean;
-  metadata?: JsonValue;
-}
-
-export interface ChildAgentResult {
-  childId: string;
-  outcome: RunOutcome;
-  report: JsonValue;
-}
-
-export type ChildAgentFactory = (context: ChildAgentContext) => Promise<ChildAgentResult>;
-
-export interface ChildSupervisorEvent {
-  type: "child.spawned" | "child.message" | "child.completed";
-  parentId: string;
-  runId: string;
-  childId: string;
-  payload: JsonValue;
-}
-
-export type ChildEventSink = (event: ChildSupervisorEvent) => Promise<void>;
-
-export interface ChildJob {
-  id: string;
-  parentId: string;
-  runId: string;
-  status: "queued" | "running" | "completed" | "failed" | "cancelled";
-  detached: boolean;
-  writeScope: string[];
-  isolation?: ChildWorkspaceIsolation;
-  sessionId?: string;
-  result?: ChildAgentResult;
-  error?: string;
-}
 
 interface InternalJob {
   public: ChildJob;

--- a/packages/agent-tools/src/supervisor-tools.ts
+++ b/packages/agent-tools/src/supervisor-tools.ts
@@ -185,6 +185,7 @@ async function executeSpawn(
     const child = await supervisor.spawnDurable({
       childId,
       parentId: context.sessionId,
+      runId: context.runId,
       instruction: requiredText(value, "instruction"),
       workspacePath: context.workspacePath,
       intent: mode === "change" ? "write" : "analyze",
@@ -218,7 +219,19 @@ function spawnTool(supervisor: SupervisorPort): RegisteredEffectTool {
     profileId: { type: "string" },
     network: { type: "string", enum: ["none", "loopback", "full"] },
     allowDestructive: { type: "boolean" },
-    budget: { type: "object", additionalProperties: { type: "integer", minimum: 0 } },
+    budget: {
+      type: "object",
+      properties: {
+        inputTokens: { type: "integer", minimum: 0 },
+        outputTokens: { type: "integer", minimum: 0 },
+        costMicroUsd: { type: "integer", minimum: 0 },
+        modelTurns: { type: "integer", minimum: 0 },
+        toolCalls: { type: "integer", minimum: 0 },
+        children: { type: "integer", minimum: 0 },
+        maxDepth: { type: "integer", minimum: 0 }
+      },
+      additionalProperties: false
+    },
     detached: { type: "boolean" }
   }, ["instruction", "planNodeIds"], {
     effects: DELEGATED_CHILD_EFFECTS,

--- a/tests/agent-architecture.test.ts
+++ b/tests/agent-architecture.test.ts
@@ -819,7 +819,7 @@ describe("Sigma architecture", () => {
       }
       throw new Error("mailbox closed");
     }, 1);
-    const child = supervisor.spawn({ parentId: "parent", instruction: "inspect", workspacePath: "." });
+    const child = supervisor.spawn({ parentId: "parent", runId: "run", instruction: "inspect", workspacePath: "." });
     const deadline = Date.now() + 1_000;
     while (supervisor.list("parent")[0]?.status !== "running" && Date.now() < deadline) {
       await new Promise((resolve) => setTimeout(resolve, 10));

--- a/tests/agent-pi.gateway.test.ts
+++ b/tests/agent-pi.gateway.test.ts
@@ -688,6 +688,18 @@ describe("OpenAI Codex subscription gateway", () => {
     }))).toMatchObject({ code: "server", category: "server" });
     expect(sanitizePiModelError(new Error("Provider is not configured: openai-codex")))
       .toMatchObject({ code: "auth_required", category: "auth" });
+    for (const message of [
+      "WebSocket stream closed before response.completed",
+      "stream closed before response.completed",
+      "unexpected EOF while reading response body",
+      "socket hang up"
+    ]) {
+      expect(sanitizePiModelError(new Error(message))).toMatchObject({
+        code: "network",
+        category: "network",
+        message: "Could not reach the model provider."
+      });
+    }
   });
 
   it("preserves and classifies Codex response.failed codes without exposing provider text", async () => {

--- a/tests/agent-runtime-child-cancellation.test.ts
+++ b/tests/agent-runtime-child-cancellation.test.ts
@@ -229,6 +229,7 @@ describe("child cancellation cleanup ordering", () => {
     }, 2, new WorkspaceIsolationManager(path.join(root, "isolation"), { execution }));
     const first = supervisor.spawn({
       parentId: firstParent.sessionId,
+      runId: firstParent.runId,
       instruction: "run the slow writer",
       workspacePath: workspace,
       intent: "write",
@@ -238,6 +239,7 @@ describe("child cancellation cleanup ordering", () => {
     await within(slowStarted.promise);
     const second = supervisor.spawn({
       parentId: secondParent.sessionId,
+      runId: secondParent.runId,
       instruction: "observe the workspace",
       workspacePath: workspace,
       intent: "write",
@@ -246,7 +248,11 @@ describe("child cancellation cleanup ordering", () => {
     });
 
     let parentCancellationSettled = false;
-    const parentCancellation = supervisor.cancelParent(firstParent.sessionId, "cancel the first writer").then(() => {
+    const parentCancellation = supervisor.cancelParent(
+      firstParent.sessionId,
+      firstParent.runId,
+      "cancel the first writer"
+    ).then(() => {
       parentCancellationSettled = true;
     });
     await new Promise((resolve) => setTimeout(resolve, 100));

--- a/tests/agent-runtime-child-followup.test.ts
+++ b/tests/agent-runtime-child-followup.test.ts
@@ -157,6 +157,7 @@ describe("child follow-up lifecycle", () => {
     const instruction = `${"Write first.txt and retain the general requirements. ".repeat(3)}Preserve this trailing constraint.`;
     const child = supervisor.spawn({
       parentId: parent.sessionId,
+      runId: parent.runId,
       instruction,
       workspacePath: repository,
       intent: "write",

--- a/tests/agent-runtime-queues.test.ts
+++ b/tests/agent-runtime-queues.test.ts
@@ -1309,18 +1309,60 @@ describe("runtime queues and non-blocking instruction steering", () => {
       seq += 1;
     };
     await append("child.spawned", { detached: false });
-    await expect(auditDurableChildren(store, parentSessionId)).resolves.toMatchObject({
+    await expect(auditDurableChildren(store, parentSessionId, "parent-run")).resolves.toMatchObject({
       failures: [expect.stringContaining("interrupted")]
     });
     await append("child.completed", {
       status: "completed",
       isolation: { kind: "git_worktree", cleanup: "retained", worktreePath: "worktree" }
     });
-    await expect(auditDurableChildren(store, parentSessionId)).resolves.toMatchObject({
+    await expect(auditDurableChildren(store, parentSessionId, "parent-run")).resolves.toMatchObject({
       failures: [expect.stringContaining("unintegrated")]
     });
     await append("child.message", { kind: "integrated" });
-    await expect(auditDurableChildren(store, parentSessionId)).resolves.toMatchObject({ failures: [] });
+    await expect(auditDurableChildren(store, parentSessionId, "parent-run")).resolves.toMatchObject({ failures: [] });
+  });
+
+  it("does not carry a cancelled child from an earlier run into the current run gate", async () => {
+    const workspace = await mkdtemp(path.join(os.tmpdir(), "sigma-durable-child-runs-"));
+    const store = new SegmentedJsonlStore({ rootDir: path.join(workspace, ".agent") });
+    const parentSessionId = "parent-session";
+    let seq = 0;
+    const append = async (
+      runId: string,
+      childId: string,
+      type: "child.spawned" | "child.completed",
+      detail: Record<string, unknown>
+    ): Promise<void> => {
+      const event = {
+        schemaVersion: EVENT_SCHEMA_VERSION,
+        seq: seq + 1,
+        eventId: `child-run-event-${seq + 1}`,
+        sessionId: parentSessionId,
+        runId,
+        occurredAt: new Date(Date.now() + seq).toISOString(),
+        type,
+        authority: "runtime" as const,
+        payload: { childId, payload: detail }
+      };
+      await store.append(event, seq);
+      seq += 1;
+    };
+    await append("old-run", "old-child", "child.spawned", { detached: false });
+    await append("old-run", "old-child", "child.completed", { status: "cancelled" });
+    await append("current-run", "current-child", "child.spawned", { detached: false });
+    await append("current-run", "current-child", "child.completed", {
+      status: "completed",
+      isolation: { kind: "shared_workspace", cleanup: "clean" }
+    });
+
+    await expect(auditDurableChildren(store, parentSessionId, "old-run")).resolves.toMatchObject({
+      failures: [expect.stringContaining("cancelled")]
+    });
+    await expect(auditDurableChildren(store, parentSessionId, "current-run")).resolves.toMatchObject({
+      evidence: [expect.objectContaining({ childId: "current-child", status: "completed" })],
+      failures: []
+    });
   });
 
   it("preserves 100 steering messages and rejects the superseded model turn", async () => {
@@ -1849,6 +1891,7 @@ describe("runtime queues and non-blocking instruction steering", () => {
     );
     const child = supervisor.spawn({
       parentId: parent.sessionId,
+      runId: parent.runId,
       instruction: "write child.txt",
       workspacePath: workspace,
       intent: "write",

--- a/tests/agent-runtime.child-recovery.test.ts
+++ b/tests/agent-runtime.child-recovery.test.ts
@@ -137,14 +137,14 @@ async function interruptedExclusiveWriter(root: string, store: SegmentedJsonlSto
     strictWriteScope: true
   }, undefined, undefined, true);
   const childId = "77777777-7777-4777-8777-777777777777";
-  await runtime.recordChildEvent(parent.sessionId, "child.spawned", {
+  await runtime.recordChildEvent(parent.sessionId, parent.runId, "child.spawned", {
     childId,
     payload: {
       detached: false,
       metadata: { mode: "change", planNodeIds: ["delegated"] }
     }
   });
-  await runtime.recordChildEvent(parent.sessionId, "child.message", {
+  await runtime.recordChildEvent(parent.sessionId, parent.runId, "child.message", {
     childId,
     payload: { kind: "started", sessionId: child.sessionId }
   });
@@ -271,6 +271,7 @@ describe("durable child identity and crash recovery", () => {
     const child = await supervisor.spawnDurable({
       childId: "22222222-2222-4222-8222-222222222222",
       parentId: "parent",
+      runId: "run",
       instruction: "inspect",
       workspacePath: process.cwd(),
       metadata: { planNodeIds: ["delegated"], budget: { inputTokens: 10 } }

--- a/tests/agent-runtime.sensitive-approval.test.ts
+++ b/tests/agent-runtime.sensitive-approval.test.ts
@@ -677,6 +677,7 @@ describe("sensitive per-call approvals", () => {
     const supervisor = new AgentSupervisor(createChildAgentFactory(() => runtime), 1);
     const child = supervisor.spawn({
       parentId: parent.sessionId,
+      runId: parent.runId,
       instruction: "Run one network check.",
       workspacePath: root,
       intent: "analyze",

--- a/tests/agent-supervisor.isolation.test.ts
+++ b/tests/agent-supervisor.isolation.test.ts
@@ -102,8 +102,8 @@ describe("AgentSupervisor writer isolation", () => {
       return result(context);
     }, 4, isolationManager(path.join(root, "worktrees")));
 
-    const first = supervisor.spawn({ parentId: "parent", instruction: "first", workspacePath: repository, intent: "write" });
-    const second = supervisor.spawn({ parentId: "parent", instruction: "second", workspacePath: repository, intent: "write" });
+    const first = supervisor.spawn({ parentId: "parent", runId: "run", instruction: "first", workspacePath: repository, intent: "write" });
+    const second = supervisor.spawn({ parentId: "parent", runId: "run", instruction: "second", workspacePath: repository, intent: "write" });
     await until(() => contexts.length === 2);
 
     expect(contexts[0].isolation.kind).toBe("git_worktree");
@@ -132,8 +132,8 @@ describe("AgentSupervisor writer isolation", () => {
       return result(context);
     }, 2, isolationManager(path.join(root, "worktrees")));
 
-    const uncommitted = supervisor.spawn({ parentId: "parent", instruction: "uncommitted", workspacePath: repository, intent: "write" });
-    const committed = supervisor.spawn({ parentId: "parent", instruction: "committed", workspacePath: repository, intent: "write" });
+    const uncommitted = supervisor.spawn({ parentId: "parent", runId: "run", instruction: "uncommitted", workspacePath: repository, intent: "write" });
+    const committed = supervisor.spawn({ parentId: "parent", runId: "run", instruction: "committed", workspacePath: repository, intent: "write" });
     const jobs = await Promise.all([supervisor.join(uncommitted.id), supervisor.join(committed.id)]);
 
     expect(jobs.map((job) => job.isolation?.cleanup)).toEqual(["retained", "retained"]);
@@ -173,11 +173,11 @@ describe("AgentSupervisor writer isolation", () => {
       return result(context);
     }, 4, isolationManager(path.join(root, "worktrees")));
 
-    const first = supervisor.spawn({ parentId: "parent", instruction: "writer one", workspacePath: workspace, intent: "write" });
+    const first = supervisor.spawn({ parentId: "parent", runId: "run", instruction: "writer one", workspacePath: workspace, intent: "write" });
     await until(() => writerContexts.length === 1);
-    const second = supervisor.spawn({ parentId: "parent", instruction: "writer two", workspacePath: workspace, metadata: { mode: "change" } });
-    const analyzeOne = supervisor.spawn({ parentId: "parent", instruction: "analyze one", workspacePath: workspace, intent: "analyze" });
-    const analyzeTwo = supervisor.spawn({ parentId: "parent", instruction: "analyze two", workspacePath: workspace, metadata: { mode: "analyze" } });
+    const second = supervisor.spawn({ parentId: "parent", runId: "run", instruction: "writer two", workspacePath: workspace, metadata: { mode: "change" } });
+    const analyzeOne = supervisor.spawn({ parentId: "parent", runId: "run", instruction: "analyze one", workspacePath: workspace, intent: "analyze" });
+    const analyzeTwo = supervisor.spawn({ parentId: "parent", runId: "run", instruction: "analyze two", workspacePath: workspace, metadata: { mode: "analyze" } });
 
     await until(() => analyzeContexts.length === 2);
     expect(writerContexts).toHaveLength(1);
@@ -285,8 +285,8 @@ describe("AgentSupervisor writer isolation", () => {
       return result(context);
     }, 1, manager);
 
-    const first = supervisor.spawn({ parentId: "parent", instruction: "first", workspacePath: workspace });
-    const second = supervisor.spawn({ parentId: "parent", instruction: "second", workspacePath: workspace });
+    const first = supervisor.spawn({ parentId: "parent", runId: "run", instruction: "first", workspacePath: workspace });
+    const second = supervisor.spawn({ parentId: "parent", runId: "run", instruction: "second", workspacePath: workspace });
     const jobs = await Promise.all([supervisor.join(first.id), supervisor.join(second.id)]);
     expect(started).toHaveLength(2);
     expect(jobs.map((job) => job.status)).toEqual(["failed", "failed"]);
@@ -307,17 +307,47 @@ describe("AgentSupervisor writer isolation", () => {
       });
       return result(context);
     }, 1, isolationManager(path.join(root, "worktrees")));
-    const running = supervisor.spawn({ parentId: "parent", instruction: "running", workspacePath: workspace, intent: "analyze" });
-    const queued = supervisor.spawn({ parentId: "parent", instruction: "queued", workspacePath: workspace, intent: "analyze" });
+    const running = supervisor.spawn({ parentId: "parent", runId: "run", instruction: "running", workspacePath: workspace, intent: "analyze" });
+    const queued = supervisor.spawn({ parentId: "parent", runId: "run", instruction: "queued", workspacePath: workspace, intent: "analyze" });
     await until(() => started.length === 1);
 
     const controller = new AbortController();
-    const joined = supervisor.joinParent("parent", controller.signal);
+    const joined = supervisor.joinParent("parent", "run", controller.signal);
     const startedAt = Date.now();
     controller.abort(new Error("parent deadline"));
     await expect(joined).rejects.toThrow("parent deadline");
     expect(Date.now() - startedAt).toBeLessThan(500);
     await expect(supervisor.join(running.id)).resolves.toMatchObject({ status: "cancelled" });
     await expect(supervisor.join(queued.id)).resolves.toMatchObject({ status: "cancelled" });
+  });
+
+  it("joins only children created by the requested parent run", async () => {
+    const root = await fixture("parent-run-scope");
+    const workspace = path.join(root, "workspace");
+    await mkdir(workspace);
+    const supervisor = new AgentSupervisor(async (context) => ({
+      childId: context.childId,
+      outcome: context.runId === "old-run"
+        ? { kind: "cancelled", reason: "old run failed" }
+        : { kind: "completed", message: "current run done", evidence: [] },
+      report: null
+    }), 2, isolationManager(path.join(root, "worktrees")));
+    const oldChild = supervisor.spawn({
+      parentId: "parent",
+      runId: "old-run",
+      instruction: "old",
+      workspacePath: workspace
+    });
+    const currentChild = supervisor.spawn({
+      parentId: "parent",
+      runId: "current-run",
+      instruction: "current",
+      workspacePath: workspace
+    });
+    await Promise.all([supervisor.join(oldChild.id), supervisor.join(currentChild.id)]);
+
+    await expect(supervisor.joinParent("parent", "current-run")).resolves.toMatchObject([
+      { id: currentChild.id, runId: "current-run", status: "completed" }
+    ]);
   });
 });

--- a/tests/agent-tools.supervisor-budget.test.ts
+++ b/tests/agent-tools.supervisor-budget.test.ts
@@ -70,6 +70,26 @@ function harness(reserve: RuntimeControlPort["reserveChildBudget"], spawn: Super
 }
 
 describe("spawn_agent budget and Plan transaction", () => {
+  it("advertises only the budget dimensions accepted by the runtime", () => {
+    const test = harness(
+      async () => allocation(),
+      async ({ childId }) => ({ id: childId! })
+    );
+    const schema = test.tools.descriptor("spawn_agent")?.inputSchema as {
+      properties?: { budget?: { properties?: Record<string, unknown>; additionalProperties?: unknown } };
+    };
+    expect(Object.keys(schema.properties?.budget?.properties ?? {})).toEqual([
+      "inputTokens",
+      "outputTokens",
+      "costMicroUsd",
+      "modelTurns",
+      "toolCalls",
+      "children",
+      "maxDepth"
+    ]);
+    expect(schema.properties?.budget?.additionalProperties).toBe(false);
+  });
+
   it("returns budget_exhausted before changing Plan or spawning", async () => {
     const spawn = vi.fn<SupervisorPort["spawnDurable"]>();
     const reserve = vi.fn<RuntimeControlPort["reserveChildBudget"]>(async () => {
@@ -116,6 +136,25 @@ describe("spawn_agent budget and Plan transaction", () => {
     expect(test.current().nodes[0]!.owner).toEqual(owner);
     expect(spawn).toHaveBeenCalledOnce();
     expect(reserve).toHaveBeenCalledOnce();
+  });
+
+  it("passes the originating run and an accepted budget allocation to the supervisor", async () => {
+    const reserve = vi.fn<RuntimeControlPort["reserveChildBudget"]>(async () => allocation());
+    const spawn = vi.fn<SupervisorPort["spawnDurable"]>(async ({ childId }) => ({ id: childId! }));
+    const test = harness(reserve, spawn);
+    await expect(test.tools.execute({
+      callId: "spawn", name: "spawn_agent",
+      arguments: {
+        instruction: "inspect",
+        planNodeIds: ["root"],
+        budget: { inputTokens: 20, modelTurns: 2 }
+      }
+    }, test.context)).resolves.toMatchObject({ ok: true });
+    expect(reserve).toHaveBeenCalledWith(expect.any(String), { inputTokens: 20, modelTurns: 2 });
+    expect(spawn).toHaveBeenCalledWith(expect.objectContaining({
+      parentId: "parent",
+      runId: "run"
+    }));
   });
 });
 


### PR DESCRIPTION
## What changed

- Classify premature WebSocket/response stream closure and EOF/socket hangups as transient network failures so the existing retry policy can recover.
- Bind every supervised child to the originating runtime run ID.
- Join, cancel, audit, and record child events only for that run, preventing stale detached children from contaminating later turns.
- Tighten the `spawn_agent` budget schema to the dimensions accepted by the runtime.
- Add regression coverage for transport classification, run isolation, durable child recovery, cancellation, and budget forwarding.

## Root cause

Provider streams that closed before `response.completed` were classified as unknown failures, bypassing transient retry handling. Separately, child lifecycle operations were keyed only by the parent session, so an older child could finish during a later run and affect that run's state or completion.

## Impact

Sigma now recovers from the observed transient stream closures and keeps child state scoped to the turn that spawned it, avoiding false failures and cross-turn event leakage.

## Validation

- `pnpm typecheck`
- `pnpm test -- tests/agent-pi.gateway.test.ts tests/agent-model.routing.test.ts tests/agent-tools.supervisor-budget.test.ts tests/agent-supervisor.isolation.test.ts tests/agent-runtime-queues.test.ts tests/agent-runtime.child-recovery.test.ts tests/agent-runtime-child-cancellation.test.ts` (128 tests)
- Focused ESLint on all changed files
- `git diff --check`
- `pnpm package:agent-cli:windows`
- `node scripts/verify-agent-cli-package.mjs --target-platform win32 --target-arch x64 --require-target-wrapper`
- Installed Runtime file hashes match the generated verified bundle
