### PR TITLE
Slim the READMEs and move detail to the website

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@
 
 <p align="center">
   <a href="https://sigmacode.biz"><strong>Official website</strong></a>
+  · <a href="https://sigmacode.biz/en/docs/getting-started"><strong>Documentation</strong></a>
   · <a href="https://github.com/hututuQQQ/sigma/releases/tag/v0.1.5"><strong>Download v0.1.5</strong></a>
-  · <a href="https://github.com/hututuQQQ/sigma-code">Desktop client source</a>
   · <a href="SECURITY.md">Security</a>
 </p>
 
@@ -30,66 +30,33 @@
   <img src="assets/sigma-code-desktop.png" alt="Sigma Code desktop app using Sigma Runtime to analyze a repository" width="1200">
 </p>
 
-<p align="center">
-  <sub>
-    The <a href="https://github.com/hututuQQQ/sigma-code">Sigma Code desktop client</a> is an independently maintained downstream of
-    <a href="https://github.com/pingdotgg/t3code">T3 Code</a> and connects to this runtime over ACP v1.
-  </sub>
-</p>
+Sigma Code is built for coding tasks that must not lose their state or declare victory too early. Commands run inside a required native sandbox, the complete working session is persisted for recovery, and changed work completes only after current validation and any required review agree.
 
-Sigma Code is built for coding tasks that must not lose their state or declare victory too early. It runs commands inside a required native sandbox, persists the full working session so it can resume after interruption, and completes only after current changes are validated and any required review is satisfied. This repository owns Sigma Runtime, the CLI, and the TUI; the desktop, Web, and mobile client lives in [hututuQQQ/sigma-code](https://github.com/hututuQQQ/sigma-code). Every surface uses the same event-sourced kernel, session store, tools, recovery logic, and outcome protocol, either in process through `RuntimeClient` or over stable ACP v1.
-
-`0.1.5` is the current supported product baseline.
-Linux x64 is the stable release target. Windows x64 remains an explicitly
-unsigned preview until trusted Authenticode signing is available. See the [security
-policy](SECURITY.md) and [contribution guide](CONTRIBUTING.md) before reporting
-or proposing changes.
-
-> [!TIP]
-> **OpenCode comparison—same model, all 89 tasks:** Sigma Code + DeepSeek completed **51/89 (57.303%)** while OpenCode + DeepSeek completed **49/89 (55.056%)**, a difference of **+2 passes / +2.247 percentage points**. Both agents ran DeepSeek `deepseek-v4-pro` on the same Terminal-Bench 2.1 population; Sigma used one attempt per task, zero retries, and no verifier feedback. Methodology and limitations are documented under [Evaluation and benchmark boundary](#evaluation-and-benchmark-boundary).
+This repository owns Sigma Runtime, the CLI, the TUI, and the ACP v1 server. The independently maintained [Sigma Code desktop, Web, and mobile client](https://github.com/hututuQQQ/sigma-code) is a downstream of [T3 Code](https://github.com/pingdotgg/t3code) and connects to this runtime over ACP v1.
 
 > [!IMPORTANT]
-> **Current product boundary**
->
-> - **[Sigma Code 0.1.5](https://github.com/hututuQQQ/sigma/releases/tag/v0.1.5) is stable on Linux x64; Windows x64 is an unsigned preview.** The Windows installer contains both the Sigma Code desktop UI and the verified Sigma Runtime, so users do not need a separate Node.js or agent CLI installation. Release candidates must pass native sandbox, packaged-product, checksum, SBOM, and signed-provenance gates. Windows executables do not yet have a trusted Authenticode signature and may trigger Windows security warnings.
-> - **Formal evaluation is preregistered, not provider-coded.** The SHA-bound run manifest freezes the provider, model, source, archive, task selection, network, timeouts, concurrency, attempts, and retries before execution.
-> - Provider comparisons are valid only when their SHA-bound run manifests freeze comparable controls; the harness does not infer comparability from a model name.
+> **0.1.5 is the current supported baseline.** Linux x64 is stable. Windows x64 is an unsigned preview and may trigger Windows security warnings. Verify the published SHA-256 sidecar and signed provenance before installation.
 
 ## Why Sigma Code
 
-| Core capability | What it means for you |
+| Capability | What it means |
 | --- | --- |
 | Native sandbox execution | Commands stay inside required OS-level isolation. If the sandbox is unhealthy, Sigma refuses to execute. |
-| Sessions that survive interruption | Commands, model turns, tool receipts, plans, and outcomes are persisted as checksummed events, so the same task can be resumed and replayed. |
-| Evidence before completion | Model prose alone cannot mark changed work as done. Sigma requires current-state validation and any required review evidence. |
+| Durable sessions | Plans, model turns, tool receipts, checkpoints, and outcomes survive a closed terminal or restarted process. |
+| Evidence-backed completion | Model prose cannot close changed work without current validation and any required review evidence. |
+| One runtime, multiple surfaces | The desktop client, TUI, one-shot CLI, and automation use the same event-sourced runtime. |
 
-## Sigma Code desktop and T3 integration
+## Get started
 
-The [Sigma Code client](https://github.com/hututuQQQ/sigma-code) is an independently maintained desktop, Web, and mobile downstream of [T3 Code](https://github.com/pingdotgg/t3code). The original T3 Code license and attribution are preserved in that repository; the downstream is not affiliated with or endorsed by T3 Tools, Inc.
+### Desktop on Windows
 
-The Windows installer published from this repository bundles the client with the exact verified Sigma Runtime from the same release. Its first-party Sigma provider starts the long-lived `sigma acp` server and communicates through newline-delimited JSON-RPC over stdio. The v0.1.5 bridge supports:
+Download `Sigma-Code-0.1.5-x64.exe` from the [v0.1.5 release](https://github.com/hututuQQQ/sigma/releases/tag/v0.1.5). The installer bundles the desktop UI and verified Sigma Runtime; a separate Node.js or Agent CLI install is not required.
 
-- creating, listing, loading, resuming, closing, cancelling, and steering durable sessions;
-- streamed model and reasoning text, plans, tool calls, approvals, usage, context-window status, hooks, and child-agent lifecycle events;
-- image prompts, structured user questions, authoritative persisted history, and append-only message rollback;
-- model and model-specific reasoning-level selection, trusted skill discovery, and client-supplied Streamable HTTP MCP servers.
+Windows artifacts are currently unsigned previews. Review the warning and verification steps in the [installation guide](https://sigmacode.biz/en/docs/getting-started) before running them.
 
-For the first-party Sigma provider, the client remains a presentation surface: execution, permissions, sandboxing, persistence, validation, review, and recovery stay authoritative in Sigma Runtime.
+### CLI and TUI on Linux
 
-<details>
-<summary><strong>Terminal UI</strong></summary>
-
-<p align="center">
-  <img src="assets/sigma-code-tui.png" alt="Sigma Code terminal UI running in Windows PowerShell" width="960">
-</p>
-
-</details>
-
-## Quick start on Linux
-
-Obtain the `0.1.5` Linux x64 stable archive from a verified project release or
-build it from source, verify its SHA-256 sidecar and signed provenance, and
-extract it:
+Download and verify the Linux x64 release archive, then initialize a repository:
 
 ```sh
 SIGMA="$HOME/.local/share/sigma-code"
@@ -102,456 +69,47 @@ export DEEPSEEK_API_KEY="your-api-key"
 "$SIGMA/bin/agent" tui --workspace "$WORKSPACE"
 ```
 
-## Quick start on Windows (unsigned preview)
+Keep secrets out of `.agent/config.toml` and source control. For the Windows terminal archive, other providers, permissions, session commands, and reasoning levels, use the [CLI and configuration reference](https://sigmacode.biz/en/docs/cli-and-configuration).
 
-> [!WARNING]
-> The Windows x64 archive is an unsigned preview, not an official trusted Windows
-> binary release. Verify its SHA-256 sidecar and signed provenance before extraction.
-> Its executables do not have a trusted Authenticode signature, so Windows SmartScreen
-> or Smart App Control may warn or block execution.
+## What it can do
 
-For the complete desktop product, download `Sigma-Code-0.1.5-x64.exe` from the
-[Sigma Code v0.1.5 release](https://github.com/hututuQQQ/sigma/releases/tag/v0.1.5), verify its
-SHA-256 sidecar, and run the installer. It installs the Sigma Code UI together
-with the verified Sigma Runtime; no separate Node.js or agent CLI installation
-is required.
+- Work through the desktop client, a CJK/IME-aware TUI, one-shot `run`, or read-only `inspect`.
+- Resume, replay, steer, cancel, and audit durable sessions after process interruption.
+- Read and edit repositories, run commands, use LSP-backed code intelligence, and connect explicitly trusted MCP servers.
+- Execute inside native Windows AppContainer or Linux namespace isolation with declared file, process, and network effects.
+- Coordinate bounded child agents with explicit writer isolation and integration.
+- Track tests, validation, reviews, workspace deltas, and checkpoints in one typed evidence ledger.
+- Connect multiple model providers through the version-pinned Pi gateway, including the experimental ChatGPT/Codex subscription route.
 
-The bundled UI is built from [hututuQQQ/sigma-code](https://github.com/hututuQQQ/sigma-code) and launches the Runtime through `sigma acp`. In Settings, choose a Sigma model connection and authenticate with the method exposed by that provider. The default desktop path uses the experimental ChatGPT/Codex subscription connection; supported Pi providers can expose API-key or OAuth methods through the same Runtime-owned interface.
+## Documentation
 
-The `agent-cli-win32-x64.zip` asset remains available for terminal-only and
-portable use. It includes pinned Node.js, the native `sigma-exec` broker, the
-TUI runtime, TypeScript/Python language-server assets, and tokenizer data.
+The complete product and technical documentation lives on the website:
 
-```powershell
-$Sigma = "C:\Tools\sigma-code"
-$Workspace = "D:\path\to\your\repository"
-
-$env:DEEPSEEK_API_KEY = "your-api-key"
-
-# One-time setup for the current Windows user.
-& "$Sigma\bin\agent.cmd" sandbox setup
-
-# Create workspace configuration, verify the runtime and provider, then enter the TUI.
-& "$Sigma\bin\agent.cmd" init --workspace $Workspace --provider deepseek
-& "$Sigma\bin\agent.cmd" doctor --workspace $Workspace --check-api
-& "$Sigma\bin\agent.cmd" tui --workspace $Workspace
-```
-
-The example sets the key only for the current PowerShell process. Keep secrets out of `.agent/config.toml` and source control.
-
-Published archives include a SHA-256 checksum, CycloneDX SBOM, signed
-provenance, and the public provenance verification key. Linux x64 is stable at
-`0.1.5`; Windows x64 remains an unsigned preview. See
-[SECURITY.md](SECURITY.md) for the trust boundary and
-[RELEASING.md](RELEASING.md) for the maintainer process.
-
-For a one-shot task:
-
-```powershell
-& "$Sigma\bin\agent.cmd" run "Fix the failing tests and explain the change" `
-  --workspace $Workspace `
-  --permission-mode auto
-```
-
-For read-only analysis:
-
-```powershell
-& "$Sigma\bin\agent.cmd" inspect "Map the request path and identify reliability risks" `
-  --workspace $Workspace `
-  --permission-mode auto
-```
-
-`run` uses **change** mode. `inspect` uses **analyze** mode and rejects tools whose declared effects include filesystem writes, unrestricted process spawning, or destructive work.
-
-## What Sigma can do
-
-- **Desktop and terminal interaction:** use the [Sigma Code desktop client](https://github.com/hututuQQQ/sigma-code) through ACP v1, or a CJK/IME-aware terminal UI with Markdown responses, activity views, command completion, multiline input, steering, follow-ups, scrolling, and approval overlays.
-- **Unified model access:** search the pinned Pi catalog, authenticate provider connections, select model-specific reasoning levels, and retain explicit metered, subscription, or unknown-price billing semantics.
-- **Repository intelligence:** bounded file listing and grep, repository statistics, Git status/diff, stable hash-aware workspace and declared host-input reads, nested `AGENTS.md` discovery, and LSP-backed code intelligence when a supported server is available.
-- **Scoped changes:** write and edit files, apply atomic multi-file patches, delete individual files, detect no-op writes, create mutation checkpoints, and restore the current run's latest sealed checkpoint.
-- **Sandboxed execution:** run direct executables or platform shells, execute semantic validation, manage background/PTY processes through broker-scoped session handles, and explicitly hand off verified Linux deliverable services.
-- **Read-only Web research:** use `web_run` (`web.run` in documentation) to search, open, find, and follow numbered static links. Results retain durable references and are always marked as untrusted external content.
-- **Evidence-based delivery:** record workspace deltas, commands, validation, diagnostics, reviews, child outcomes, and checkpoints in one typed evidence ledger.
-- **Durable sessions:** list, inspect, replay, resume, cancel, steer, approve, and continue sessions after a process interruption.
-- **Child agents:** delegate plan nodes to bounded child sessions; isolate writers in Git worktrees or narrow single-writer scopes, then explicitly integrate retained changes.
-- **Long-running reliability:** compact context before the provider window is exhausted, recover boundedly from transient stream closures, and isolate reviewer sessions and child runs from later turns.
-- **Extensibility:** load skills, profiles, and hooks through frozen/trusted customization boundaries, connect explicitly trusted read-only MCP stdio servers, and accept read-only Streamable HTTP MCP servers supplied by an ACP client.
-
-## Architecture
-
-`agent-runtime.createConfiguredRuntime` is the single production composition root. It wires the model routes, context provider, pure kernel, effect-aware tools, MCP clients, segmented event store, checkpoint manager, reviewer, supervisor, execution broker, and in-process `RuntimeClient`. The CLI creates that runtime; the TUI receives the client rather than rebuilding the agent loop, and `sigma acp` projects the same runtime to clients such as Sigma Code.
-
-```mermaid
-flowchart TB
-  USER["Terminal user"] --> CLI["agent-cli<br/>commands + TUI"]
-  DESKTOP["Sigma Code desktop<br/>T3 Code downstream"] <--> ACP["sigma acp<br/>stable ACP v1"]
-  CLI --> ROOT["agent-runtime<br/>single composition root"]
-  ACP --> ROOT
-  ROOT --> CLIENT["RuntimeClient<br/>session command bus"]
-  CLIENT --> KERNEL["agent-kernel<br/>pure reducer + effect decisions"]
-
-  KERNEL --> MODEL["agent-model<br/>routing, budgets, retry policy"]
-  MODEL --> PI["agent-pi + pi-ai<br/>provider auth and model transport"]
-  KERNEL --> CONTEXT["agent-context<br/>instructions, retrieval, token budget"]
-  KERNEL --> TOOLS["agent-tools<br/>typed effect plans and receipts"]
-  KERNEL --> STORE["agent-store<br/>events, snapshots, artifacts"]
-
-  TOOLS --> MCP["agent-mcp<br/>trusted stdio + ACP HTTP bridge"]
-  TOOLS --> SUP["agent-supervisor<br/>children, mailboxes, writer isolation"]
-  TOOLS --> EXEC["agent-execution<br/>only arbitrary-process boundary"]
-  EXEC --> NATIVE["sigma-exec (Rust)<br/>Windows AppContainer / Linux namespace sandbox"]
-
-  MODEL --> EVENTS["AgentEventEnvelope"]
-  CONTEXT --> EVENTS
-  TOOLS --> EVENTS
-  SUP --> EVENTS
-  EVENTS --> STORE
-  EVENTS --> KERNEL
-  EVENTS --> PRESENT["agent-presentation<br/>incremental projection"]
-  PRESENT --> TUI["agent-tui<br/>OpenTUI renderer"]
-  EVENTS --> ACP
-
-  EVAL["External evaluation + benchmark harness"] -.->|"launch packaged subject; collect only after run"| CLI
-```
-
-### The event loop
-
-1. A CLI, TUI, or ACP command becomes a typed session command and durable event.
-2. `agent-kernel` reduces the event stream into state and decides the next effect; it does not perform I/O itself.
-3. `agent-runtime` executes that decision through protocol ports for the model, context, tools, store, review, or supervision.
-4. Before a tool runs, Sigma freezes its exact read/write roots, network mode, process mode, idempotence, and checkpoint scope. Mode policy, approval, locks, and trust checks are evaluated against that plan.
-5. The resulting receipt and evidence are appended as new events. The kernel then decides the next step from durable state, while `agent-presentation` and the ACP bridge project the same events into terminal or desktop updates.
-6. A run ends only with a typed outcome: `Completed`, `NeedsInput`, `Cancelled`, `RecoverableFailure`, or `Fatal`.
-
-This separation makes replay and recovery part of the normal execution model instead of a special UI feature.
-
-### Package map
-
-| Layer | Packages | Responsibility |
-| --- | --- | --- |
-| Contracts | `agent-protocol`, `agent-config` | Events, commands, outcomes, ports, tool effects, model capabilities, and the shared CLI/env/TOML schema. |
-| Decision engine | `agent-kernel` | Pure state reduction, convergence rules, terminal protocol repair, and effect selection. |
-| Intelligence | `agent-model`, `agent-pi`, `agent-context`, `agent-code-intel`, `agent-extensions` | Model policy, unified Pi provider transport, context fitting/compaction, repository instructions, LSP, skills, profiles, and hooks. |
-| Capabilities | `agent-tools`, `agent-web`, `agent-mcp` | Repository/file/process/control/supervisor tools, brokered Web research, and the MCP bridge, all behind declared effects. |
-| Safety boundary | `agent-execution`, `agent-platform`, `agent-checkpoint`, `native/sigma-exec` | Path containment, process policy, native sandboxing, output redaction/artifacts, and transactional recovery. |
-| Durability and coordination | `agent-store`, `agent-supervisor`, `agent-runtime` | Event persistence, snapshots, session ownership, child isolation, recovery, review, and composition. |
-| Product surfaces | `agent-presentation`, `agent-tui`, `agent-cli`; downstream `sigma-code` | Event projection, terminal interaction, automation commands, ACP v1, desktop interaction, session administration, and diagnostics. |
-
-The production package dependency graph is checked for cycles and packages communicate through public exports.
-
-## Safety, permissions, and recovery
-
-### Execution boundary
-
-`agent-execution` is the only production package allowed to start arbitrary processes. It talks to the bundled Rust `sigma-exec` broker over a framed protocol. On Windows, each sandboxed command uses an AppContainer identity with scoped filesystem ACLs, a kill-on-close Job Object, capability-gated networking, and ConPTY for interactive processes. Linux uses the native namespace sandbox and a watchdog for process-tree cleanup.
-
-Configuration schema 1 defaults to `permission_mode=workspace-auto`,
-`sandbox=required`, `read_scope=workspace`, `network=full`,
-`web.mode=auto`, `process_handoff=allow`, and the native sandbox backend. Workspace-scoped reads
-and declared writes run automatically; external reads, full-network calls, and
-repository metadata writes remain separately authorized. An explicit
-`network=none` or `network=loopback` setting narrows the capability. Required
-isolation never falls back to host execution, and `container` mode fails with
-`container_unavailable` until a real OCI backend is installed.
-
-`web_run` is exposed only when full network access is enabled, Web mode is not
-disabled, and the connected broker advertises the restricted Web protocol. Its
-session grant is scoped to read-only Web access and cannot authorize shell,
-process, or MCP networking. The broker permits public HTTP(S) ports 80/443,
-binds every request to an approved origin and method, and rejects local,
-private, reserved, credential-bearing, or active browser content.
-
-Absolute external inputs are read through stable no-follow traversal and produce `input_access` evidence with path, digest, and size. Process calls mount only their declared stable read roots. A failed goal input remains an unresolved completion obligation until the same external path is read successfully; a run-created fixture cannot replace it.
-
-Path containment and OS isolation are separate checks. Workspace tools reject lexical and symlink/junction ancestor escapes; creating a workspace symlink object such as a virtual-environment interpreter link is allowed without granting writes to its external target. `.git` and `.agent` remain protected from sandbox write grants.
-
-Linux advertises `processHandoff` only when safe transfer is available. A `deliverable` process uses detached stdio, cannot use PTY/stdin, and must be independently health-checked before `process_handoff`. Handoff removes it from session cleanup; unhanded processes are still terminated on failure, cancellation, timeout, or broker loss. Windows currently advertises this capability as unavailable and fails closed.
-
-### Checkpoints and durable state
-
-Runtime state is stored outside the agent-writable workspace under a workspace-derived user-state directory:
-
-```text
-<user-state>/sigma/workspaces/<workspace-sha256>/stores/v1/sessions/<session-id>/
-  meta.json
-  events/000001.jsonl
-  snapshots/000000000250.json
-  artifacts/<sha256>
-```
-
-Event records have checksums and monotonic sequence numbers. Segments rotate at 8 MiB or 10,000 events, snapshots are written every 250 events and at rotation, and a torn final record can be repaired under the append lock. Resume restores pending approvals, follow-ups, discovered instructions, budgets, and safe idempotent work. Interrupted non-idempotent effects become `NeedsInput` instead of being silently replayed.
-
-### Completion is a protocol action
-
-A provider `stop` is only `model_stopped`. The Completion Coordinator independently derives assurance and review requirements from the current mutation frontier and emits `run.completed` only when `model_stopped`, `assurance_satisfied`, and `review_satisfied` are all true. Failed, stale, weak, or incomplete semantic validation produces structured repair guidance or a typed blocker; the model has no completion tool that can bypass the gate.
-
-All net changes require passed semantic validation on the current state. Sealed
-no-op checkpoints do not advance that frontier; mutating validation is rebound
-after its checkpoint seals. The standard profile requires current-frontier
-review approval or an explicit one-time user waiver. The strict profile does
-not accept a waiver and requires approval backed by a reviewer-executed check.
-Active non-detached children are joined before completion, and an unintegrated
-writer worktree keeps the parent open.
-
-### Current serialized and tool contracts
-
-- Every Sigma-owned serialized boundary uses strict `schemaVersion: 1` (or
-  `schema_version = 1` in TOML and `version: 1` for local provider, workspace
-  trust, and ACP indexes). Unknown schemas, malformed current documents,
-  another store layout, and old checkpoint journals fail with
-  `unsupported_schema_version`, `persisted_state_invalid`, or
-  `unsupported_store_layout`; the rejected files are never rewritten,
-  migrated, or deleted.
-- A verified shell exposes one `shell` contract for foreground, validation,
-  background, and disposable-environment execution. Direct `exec`, `validate`,
-  and `process_spawn` contracts exist only when no verified shell is available;
-  retired tool names and argument shapes are not registered for replay.
-- Active review is read-only and runs checks in a disposable overlay. It can
-  inspect the authenticated current frontier and durable process lifecycle
-  evidence without writing the parent workspace.
-- At an ordinary solver-budget boundary, already-started session processes are
-  allowed to settle within the outer deadline. Deliverable processes remain
-  session-owned until an independently health-checked `process_handoff`
-  succeeds.
-- `write` and `edit` report the resulting byte length and SHA-256;
-  `write_chunk` uses an expected preimage length and digest. An omitted shell is
-  resolved deterministically by the broker. Non-UTF-8 process output must be
-  preserved as a byte-safe artifact; a decoding error without that artifact is
-  rejected as a broker protocol violation.
-- `inspect_image` and `inspect_document` are bounded, offline, read-only
-  fallbacks for text-only providers. Their OCR or extraction metadata is
-  inspection data, not completion evidence.
-
-## Commands
-
-| Command | Purpose |
+| Guide | Covers |
 | --- | --- |
-| `agent tui --workspace .` | Open the interactive terminal UI. |
-| `agent run "..." --workspace .` | Run a workspace-changing task. |
-| `agent inspect "..." --workspace .` | Analyze without write-capable tools. |
-| `sigma acp` | Serve stable ACP v1 as newline-delimited JSON-RPC over stdio for clients such as Sigma Code. |
-| `agent sessions --workspace . --json` | List durable sessions. |
-| `agent session show --latest --workspace .` | Inspect the latest session. |
-| `agent replay --latest --workspace . --timeline` | Replay its event timeline. |
-| `agent resume <session-id> --workspace .` | Continue a durable session. |
-| `agent cancel <session-id> --workspace .` | Cancel an active session. |
-| `agent approval <session-id> <request-id> --decision allow --workspace .` | Resolve a pending approval. |
-| `agent doctor --workspace . --check-api` | Check configuration, sandbox, toolchains, and provider access. |
-| `sigma auth list --json` | List Pi provider authentication methods and local/ambient status without network access. |
-| `sigma auth status <provider> --json` | Read one provider's local authentication state without refreshing OAuth. |
-| `sigma auth login <provider> --method <method-id> --json` | Start a machine-readable API-key or OAuth login flow. |
-| `sigma auth logout <provider> --json` | Remove that provider's locally stored credential; ambient credentials remain visible. |
-| `sigma models list --json` | Read the pinned static model directory plus the offline dynamic cache. |
-| `sigma models refresh <provider> --json` | Explicitly refresh a dynamic provider's model directory. |
-| `agent sandbox setup` | Prepare and self-test the Windows sandbox. |
-| `agent init --workspace .` | Create `.agent/config.toml`. |
+| [Getting started](https://sigmacode.biz/en/docs/getting-started) | Releases, verification, Linux and Windows setup, first task |
+| [CLI, configuration, and providers](https://sigmacode.biz/en/docs/cli-and-configuration) | Commands, TUI controls, permissions, authentication, reasoning levels |
+| [Runtime architecture](https://sigmacode.biz/en/docs/architecture) | Composition root, event loop, package boundaries, ACP v1 |
+| [Security, permissions, and recovery](https://sigmacode.biz/en/docs/security-and-recovery) | Native sandbox, path and network boundaries, durable state, completion |
+| [Durable sessions](https://sigmacode.biz/en/features/durable-sessions) | Event streams, checkpoints, replay, and resume |
+| [Native sandboxing](https://sigmacode.biz/en/features/native-sandbox) | Windows AppContainer and Linux namespaces |
+| [Evidence-backed completion](https://sigmacode.biz/en/features/evidence-backed-completion) | Validation, review, and current-state evidence |
+| [Evaluation method](https://sigmacode.biz/en/docs/evaluation) | Preregistration, fairness boundary, results, and limitations |
 
-Stable process exit codes are `0` for `Completed`, `2` for `NeedsInput`, `130` for `Cancelled`, and `1` for recoverable or fatal failure.
+Repository-maintainer material remains close to the code:
 
-### TUI controls
+- [CONTRIBUTING.md](CONTRIBUTING.md) — development workflow and contribution expectations
+- [VALIDATION.md](VALIDATION.md) — test layers, coverage, native checks, and release evidence
+- [RELEASING.md](RELEASING.md) — packaging and release procedure
+- [SECURITY.md](SECURITY.md) — supported versions, trust boundary, and vulnerability reporting
 
-- `Enter`: send while idle, or steer the active run
-- `Shift+Enter` / `Ctrl+J`: insert a line
-- `Alt+Enter`: queue a follow-up
-- `Ctrl+O`: collapse or expand activity
-- `PgUp` / `PgDn`, `Ctrl+U` / `Ctrl+D`, mouse wheel: scroll
-- `/new`, `/mode analyze|change`, `/followup`, `/activity`, `/help`, `/quit`: session commands
-- First `Ctrl+C`: cancel; second press within 1.5 seconds: exit
+## Transparent evaluation
 
-## Configuration
+A staged Terminal-Bench 2.1 diagnostic on July 27–28, 2026 used DeepSeek `deepseek-v4-pro`, the same 89-task population, one Sigma attempt per task, zero retries, and no verifier feedback. Sigma Code completed **51/89 (57.303%)**; OpenCode completed **49/89 (55.056%)**.
 
-Precedence is **CLI flags → environment → workspace `.agent/config.toml` → home `~/.sigma/config.toml` → defaults**. Unknown flags and TOML keys fail immediately. Workspace-authored MCP servers and executable hooks require an explicit digest-bound trust grant.
+This is a mixed-source engineering diagnostic, not a universal-superiority claim or a single score for the final source head. Read the [method, fairness rules, and limitations](https://sigmacode.biz/en/docs/evaluation) before comparing the numbers.
 
-The packaged default is the experimental `openai-codex` subscription provider with automatic model selection. The example below explicitly selects DeepSeek for an API-key-based setup:
-
-```toml
-schema_version = 1
-
-[model]
-provider = "deepseek"
-name = "auto"
-reasoning_effort = "auto"
-
-[permissions]
-mode = "workspace-auto"
-
-[security]
-sandbox = "required"
-read_scope = "workspace"
-network = "full"
-process_handoff = "allow"
-
-[web]
-mode = "auto"
-search_provider = "exa"
-
-[runtime]
-run_deadline_sec = 0
-model_deadline_sec = 120
-stream_idle_sec = 45
-
-[tools]
-max_parallel = 4
-
-[agents]
-max_parallel = 4
-
-[ui]
-output_format = "text"
-
-[tui]
-fps = 30
-```
-
-`runtime.run_deadline_sec = 0` leaves an interactive run unbounded. Set a
-positive value only when the caller intentionally wants a whole-run wall-clock
-limit. Per-request and per-tool liveness timeouts remain independent so a hung
-provider or process can still be interrupted without imposing a task deadline.
-
-To opt into broader per-call capabilities, use:
-
-```toml
-schema_version = 1
-
-[security]
-sandbox = "required"
-read_scope = "host"
-network = "full"
-process_handoff = "deny"
-```
-
-`agent init` writes the current schema directly. Sigma does not expose a
-configuration migration command and does not read another durable store layout.
-Back up or move incompatible state yourself; rejection is deliberately
-read-only.
-
-### ChatGPT/Codex subscription provider (experimental)
-
-Sigma can keep its own runtime, tools, recovery, budgets, reviewer, strategist,
-and durable state while sending model requests through a ChatGPT/Codex
-subscription:
-
-```toml
-[model]
-provider = "openai-codex"
-name = "gpt-5.6-terra"
-reasoning_effort = "max"
-```
-
-This route uses ChatGPT OAuth and
-`https://chatgpt.com/backend-api/codex/responses`; it never reads
-`OPENAI_API_KEY` and does not use API-key billing. Credentials are shared by
-Sigma processes on the same host in `~/.sigma/auth.json`. Subscription usage
-keeps token accounting, but records `billingMode = "subscription"` and a null
-API cost. Authentication, allowance, rate-limit, network, timeout, and server
-failures are returned directly. The built-in subscription route has one
-candidate and cannot silently fall back to DeepSeek, GLM, or
-`api.openai.com/v1`.
-
-`reasoning_effort` accepts `auto`, `none`, `low`, `medium`, `high`, `xhigh`,
-or `max`; the equivalent CLI flag is `--reasoning-effort`.
-
-The JSONL login interface is intended for trusted desktop clients:
-
-```text
-sigma auth status openai-codex --json
-sigma auth login openai-codex --method browser --json
-sigma auth login openai-codex --method device-code --json
-sigma auth logout openai-codex --json
-```
-
-For Codex transports, Sigma keeps stable prompt prefixes eligible for cached
-WebSocket continuation, falls back to SSE before streaming begins, classifies
-premature stream closure as transient for bounded retry, and keeps solver and
-reviewer transport sessions isolated. Context compaction starts before the
-provider window is exhausted instead of waiting for a hard overflow.
-
-### Unified Pi provider gateway
-
-All model I/O is owned by `agent-pi`, pinned to
-`@earendil-works/pi-ai@0.82.1`. The pinned directory exposes Pi's 38 built-in
-providers and 1,109 static models, plus Sigma's historical `glm` compatibility
-provider and endpoint. `agent-model` is only the policy layer: it chooses
-explicit routes, reserves budgets, classifies failures, applies retry/fallback
-rules, and tracks provider health.
-
-Provider credentials and the dynamic model cache are stored separately in
-`~/.sigma/auth.json` and `~/.sigma/models.json`. Both use atomic replacement,
-cross-process locks, and current-user-only permissions. Directory/status reads
-are offline; only an explicit model refresh, login completion, or a normal
-model request may access the network.
-
-Outbound model connections honor `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, and
-`NO_PROXY`. When a Windows desktop or ACP process starts without proxy
-environment variables, Sigma can use the current user's enabled static Windows
-Internet Settings proxy; explicit environment configuration takes precedence,
-and loopback traffic remains bypassed.
-
-Billing is reported as `metered`, `subscription`, or `unpriced`.
-Subscription and unpriced calls retain token usage with a null monetary cost;
-they are never presented as zero-dollar API calls. An unpriced model is
-rejected by default and requires `--allow-unpriced-costs` (or
-`budget.allow_unpriced_costs = true`) for that task. Known metered budget
-limits and token/turn/tool limits remain active.
-
-ChatGPT subscription authentication and API-key billing are separate; see
-OpenAI's [authentication](https://learn.chatgpt.com/docs/auth) and
-[pricing](https://learn.chatgpt.com/docs/pricing) documentation. The backend
-used here is integrated through the version-pinned Pi community adapter rather
-than a public third-party API with a stability commitment, so upgrades require
-an explicit dependency bump and contract-test run. See OpenAI's
-[Codex community projects](https://developers.openai.com/community/codex-for-oss).
-
-DeepSeek uses `DEEPSEEK_API_KEY`. The runtime also recognizes `GLM_API_KEY`, `ZAI_API_KEY`, or `BIGMODEL_API_KEY` for the experimental GLM/Z.ai path. Web search uses the [Exa hosted MCP service](https://exa.ai/docs/reference/exa-mcp); `EXA_API_KEY` is optional, and a 429 response tells the operator to configure it without silently changing providers. A provider is part of a formal claim only when it is frozen in that run's preregistration.
-
-## Evaluation and benchmark boundary
-
-Sigma's formal experience evaluator runs the packaged product in fresh, opaque
-workspaces and reduces the durable event stream into separate correctness,
-safety, experience, and reliability results. Terminal-Bench formal runs require
-a `SigmaFormalRunPreregistration`; code supplies no formal dataset, model,
-quota, retry, or score threshold default.
-
-The evaluator may select a task, launch the packaged CLI, and collect artifacts after the run. It must not send scenario identity, verifier output, scores, rewards, hidden checks, or post-run failures into the solving session, and verifier feedback never triggers another solving attempt. This fairness boundary is enforced by protocol types and production-source scans.
-
-### Terminal-Bench 2.1: Sigma Code + DeepSeek vs OpenCode + DeepSeek
-
-A staged diagnostic run on July 27–28, 2026 compared both agents with
-DeepSeek `deepseek-v4-pro` on the same 89-task Terminal-Bench 2.1 population.
-The Sigma lane used a maximum concurrency of 5, one attempt per task, zero
-retries, and no verifier feedback.
-
-| Agent | Passed | Pass rate |
-| --- | ---: | ---: |
-| **Sigma Code + DeepSeek** | **51/89** | **57.303%** |
-| OpenCode + DeepSeek | 49/89 | 55.056% |
-| **Difference** | **+2 passes** | **+2.247 pp** |
-
-All 89 tasks remain in the reported denominator, including six externally
-caused Sigma infrastructure-invalid observations counted as non-passes. Each
-source revision ran only previously unconsumed tasks, so this is a mixed-source
-diagnostic result rather than a score for the final PR head. No consumed task
-was rerun, and the generic lifecycle fix made after the final observation is
-intentionally not included in the score. See
-[PR #73](https://github.com/hututuQQQ/sigma/pull/73) for the source-boundary,
-stop-loss, and validation record.
-
-```powershell
-# Audit existing sessions without a model call.
-pnpm eval:session -- --workspace . --latest 2
-
-# Live evaluation uses explicitly supplied provider/model controls.
-pnpm eval:agent -- --suite quick
-pnpm eval:agent -- --suite experience --repeat 3
-
-# Create and consume an immutable formal run manifest.
-pnpm bench:tb:preregister -- --draft formal-draft.json --output formal-run.json
-pnpm bench:tb:formal -- --preregistration-file formal-run.json --expected-preregistration-sha256 <sha256> --batch <batch-id>
-```
-
-No cross-provider benchmark conclusion should be inferred from these results.
-
-## Build and develop
+## Develop
 
 The repository pins Node.js `26.4.0`, pnpm `11.7.0`, and Rust `1.96.0`.
 
@@ -560,42 +118,12 @@ corepack enable
 corepack prepare pnpm@11.7.0 --activate
 pnpm install --frozen-lockfile
 pnpm build
-cargo build --release --locked --manifest-path native/sigma-exec/Cargo.toml
-
 pnpm lint
 pnpm test:coverage
-
-# Requires a packaged CLI, a model-provider key, and live network access.
-pnpm smoke:web:live
 ```
 
-Build and verify the current Windows preview candidate:
-
-```powershell
-pnpm package:agent-cli:windows
-pnpm verify:release:windows
-```
-
-After packaging, put the development key in the repository-local, gitignored `.env` file:
-
-```dotenv
-DEEPSEEK_API_KEY=your-api-key
-# Optional; the hosted Exa MCP endpoint can be used without it.
-EXA_API_KEY=your-exa-key
-```
-
-Then launch the development TUI:
-
-```powershell
-pnpm tui:deepseek
-```
-
-Fake-gateway tests do not require provider credentials. See [VALIDATION.md](VALIDATION.md) for coverage thresholds, real-terminal boundaries, native sandbox checks, packaging proofs, and release gates.
+See [CONTRIBUTING.md](CONTRIBUTING.md) and [VALIDATION.md](VALIDATION.md) before changing runtime, sandbox, persistence, or evaluation behavior.
 
 ## License
 
 Sigma Code is available under the [MIT License](LICENSE).
-
-## Direction
-
-Sigma's near-term focus is deliberately narrow: keep improving Windows desktop and ACP reliability, deepen long-session convergence, improve real task performance, and keep evaluation feedback outside the solving boundary. Broader formal platform/provider claims should follow reproducible preregistration and demonstrated product reliability rather than lead it.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,12 +1,12 @@
 <p align="center">
-  <img src="assets/sigma-code-mark.png" alt="Sigma Code Logo" width="170">
+  <img src="assets/sigma-code-mark.png" alt="Sigma Code 标志" width="170">
 </p>
 
 <h1 align="center">Sigma Code</h1>
 
 <p align="center">
-  一个不会因中断丢进度、不会在没有验证时宣称完成的开源 Coding Agent。<br>
-  在原生沙箱中运行长任务，随时恢复，并用证据完成交付。
+  一个能越过中断、并用证据证明改动的开源 Coding Agent。<br>
+  在原生沙箱中执行长任务，随时恢复，验证完成后再交付。
 </p>
 
 <p align="center">
@@ -16,13 +16,13 @@
 <p align="center">
   <a href="https://github.com/hututuQQQ/sigma/releases/tag/v0.1.5"><img alt="状态：0.1.5 稳定版" src="https://img.shields.io/badge/status-0.1.5%20stable-2ea44f"></a>
   <img alt="发布目标：Linux 稳定版与 Windows 未签名预览版" src="https://img.shields.io/badge/release%20targets-Linux%20stable%20%2B%20Windows%20unsigned%20preview-0078d4">
-  <img alt="正式评估：预注册" src="https://img.shields.io/badge/formal%20evaluation-preregistered-4cc9c0">
+  <img alt="正式评测：已预注册" src="https://img.shields.io/badge/formal%20evaluation-preregistered-4cc9c0">
 </p>
 
 <p align="center">
   <a href="https://sigmacode.biz"><strong>官方网站</strong></a>
+  · <a href="https://sigmacode.biz/docs/getting-started"><strong>使用文档</strong></a>
   · <a href="https://github.com/hututuQQQ/sigma/releases/tag/v0.1.5"><strong>下载 v0.1.5</strong></a>
-  · <a href="https://github.com/hututuQQQ/sigma-code">桌面客户端源码</a>
   · <a href="SECURITY.md">安全策略</a>
 </p>
 
@@ -30,64 +30,33 @@
   <img src="assets/sigma-code-desktop.png" alt="Sigma Code 桌面端通过 Sigma Runtime 分析代码仓库" width="1200">
 </p>
 
-<p align="center">
-  <sub>
-    <a href="https://github.com/hututuQQQ/sigma-code">Sigma Code 桌面客户端</a>是
-    <a href="https://github.com/pingdotgg/t3code">T3 Code</a> 的独立维护下游，通过 ACP v1 连接本仓库的 Runtime。
-  </sub>
-</p>
+Sigma Code 面向不能丢失现场、也不能过早宣布完成的真实代码任务。命令必须在原生沙箱中运行，完整工作会话会持久化以支持恢复；发生改动后，只有当前验证和必要审查都满足，任务才会完成。
 
-Sigma Code 面向那些不能丢失任务现场、也不能只凭模型一句“完成了”就结束的编码任务。它在必需的原生沙箱中运行命令，持久保存完整工作会话以便中断后继续，并且只有在当前改动通过验证、满足必要审查后才会完成。本仓库维护 Sigma Runtime、CLI 与 TUI；桌面、Web 和移动客户端位于 [hututuQQQ/sigma-code](https://github.com/hututuQQQ/sigma-code)。所有界面都使用同一个事件溯源内核、会话仓库、工具、恢复逻辑和结果协议，通过进程内 `RuntimeClient` 或稳定 ACP v1 接入。
-
-`0.1.5` 是当前受支持的产品基线。Linux x64 是稳定发布目标；
-在取得可信 Authenticode 签名之前，Windows x64 仍必须明确标记为未签名预览版。
-提交问题或参与贡献前，请先查看[安全策略](SECURITY.md)和
-[贡献指南](CONTRIBUTING.md)。
-
-> [!TIP]
-> **OpenCode 对比——同一模型、完整 89 项：** Sigma Code + DeepSeek 完成 **51/89（57.303%）**，OpenCode + DeepSeek 完成 **49/89（55.056%）**，Sigma 多完成 **2 项 / +2.247 个百分点**。双方都在相同的 Terminal-Bench 2.1 任务集合上使用 DeepSeek `deepseek-v4-pro`；Sigma 每项只尝试 1 次、重试为 0，也没有接收 Verifier 反馈。方法与限制见[评估与 Benchmark 边界](#评估与-benchmark-边界)。
+本仓库维护 Sigma Runtime、CLI、TUI 与 ACP v1 服务。独立维护的 [Sigma Code 桌面、Web 与移动客户端](https://github.com/hututuQQQ/sigma-code) 是 [T3 Code](https://github.com/pingdotgg/t3code) 的下游项目，通过 ACP v1 连接本运行时。
 
 > [!IMPORTANT]
-> **当前产品边界**
->
-> - **[Sigma Code 0.1.5](https://github.com/hututuQQQ/sigma/releases/tag/v0.1.5) 在 Linux x64 上是稳定版；Windows x64 是未签名预览版。** Windows 安装包同时包含 Sigma Code 桌面 UI 和经过验证的 Sigma Runtime，用户无需另外安装 Node.js 或 Agent CLI。发布候选必须通过原生沙箱、打包产品、校验和、SBOM 与签名来源证明门禁；Windows 可执行文件目前没有可信 Authenticode 签名，可能触发 Windows 安全警告。
-> - **正式评估由预注册清单约束，而不是写死 Provider。** SHA 绑定的运行清单会在执行前冻结 Provider、模型、源码、归档、任务选择、网络、超时、并发、尝试次数和重试次数。
-> - 只有 SHA 绑定的运行清单中的控制条件可比时，Provider 对比才有效；harness 不会根据模型名称推断可比性。
+> **0.1.5 是当前支持基线。** Linux x64 为稳定版；Windows x64 为未签名预览版，可能触发 Windows 安全警告。安装前请核对发布的 SHA-256 侧文件与签名来源证明。
 
-## 为什么是 Sigma Code
+## 为什么选择 Sigma Code
 
-| 核心能力 | 对你意味着什么 |
+| 能力 | 意义 |
 | --- | --- |
-| 原生沙箱执行 | 命令始终处于必需的操作系统级隔离中；沙箱不健康时，Sigma 会拒绝执行。 |
-| 中断后继续 | 命令、模型轮次、工具回执、计划和结果都会持久保存为带校验的事件，因此同一任务可以恢复和重放。 |
-| 有证据才算完成 | 模型的一段自然语言总结不能把改动标记为完成；Sigma 要求当前状态验证和必要的审查证据。 |
+| 原生沙箱执行 | 命令必须在操作系统级隔离中运行；沙箱异常时，Sigma 会拒绝执行。 |
+| 耐久会话 | 计划、模型回合、工具回执、检查点和结果不会随终端关闭或进程重启而消失。 |
+| 证据式完成 | 模型的一段总结不能关闭已发生改动的任务；必须具备当前验证和必要审查证据。 |
+| 一套运行时，多种界面 | 桌面端、TUI、单次 CLI 与自动化共用同一事件驱动运行时。 |
 
-## Sigma Code 桌面端与 T3 接入
+## 快速开始
 
-[Sigma Code 客户端](https://github.com/hututuQQQ/sigma-code)是 [T3 Code](https://github.com/pingdotgg/t3code) 的独立维护桌面、Web 与移动下游。该仓库保留了 T3 Code 原有的许可证和归属说明；此下游项目与 T3 Tools, Inc. 没有关联，也未获得其赞助或背书。
+### Windows 桌面端
 
-本仓库发布的 Windows 安装包会把客户端与同一 Release 中经过验证的 Sigma Runtime 打包在一起。客户端内置的 Sigma Provider 会启动长驻的 `sigma acp` Server，并通过 stdio 上的换行分隔 JSON-RPC 通信。v0.1.5 的 ACP Bridge 支持：
+从 [v0.1.5 发布页](https://github.com/hututuQQQ/sigma/releases/tag/v0.1.5)下载 `Sigma-Code-0.1.5-x64.exe`。安装包已经包含桌面 UI 与经过验证的 Sigma Runtime，不需要单独安装 Node.js 或 Agent CLI。
 
-- 创建、列出、加载、恢复、关闭、取消和纠偏持久会话；
-- 流式模型与 Reasoning 文本、计划、工具调用、授权、用量、上下文窗口状态、Hook 和子 Agent 生命周期事件；
-- 图片输入、结构化用户问题、以持久事件为准的历史记录，以及仅追加的消息回滚；
-- 模型与模型专属推理等级选择、受信任 Skill 发现，以及由客户端提供的 Streamable HTTP MCP Server。
+Windows 产物目前仍是未签名预览版。运行前请阅读[安装与验证说明](https://sigmacode.biz/docs/getting-started)。
 
-使用内置 Sigma Provider 时，客户端只负责产品界面；执行、权限、沙箱、持久化、验证、审查与恢复仍由 Sigma Runtime 统一负责。
+### Linux CLI 与 TUI
 
-<details>
-<summary><strong>终端界面</strong></summary>
-
-<p align="center">
-  <img src="assets/sigma-code-tui.png" alt="在 Windows PowerShell 中运行的 Sigma Code 终端界面" width="960">
-</p>
-
-</details>
-
-## Linux 快速开始
-
-从经过验证的项目 Release 获取 `0.1.5` Linux x64 稳定版归档，或从源码构建；
-核对 SHA-256 侧文件与签名来源证明后再解压：
+下载并核对 Linux x64 发布包，然后初始化目标仓库：
 
 ```sh
 SIGMA="$HOME/.local/share/sigma-code"
@@ -100,426 +69,61 @@ export DEEPSEEK_API_KEY="your-api-key"
 "$SIGMA/bin/agent" tui --workspace "$WORKSPACE"
 ```
 
-## Windows 快速开始（未签名预览版）
+不要把密钥写入 `.agent/config.toml` 或版本控制。Windows 终端包、其他 Provider、权限、会话命令和 reasoning level 请查阅 [CLI 与配置参考](https://sigmacode.biz/docs/cli-and-configuration)。
 
-> [!WARNING]
-> Windows x64 归档是未签名预览版，不是受信任的正式 Windows 二进制发布。解压前请核对 SHA-256 侧文件与签名来源证明。可执行文件目前没有可信 Authenticode 签名，因此 Windows SmartScreen 或 Smart App Control 可能警告或阻止运行。
+## 能做什么
 
-如需完整桌面产品，请从 [Sigma Code v0.1.5 Release](https://github.com/hututuQQQ/sigma/releases/tag/v0.1.5)
-下载 `Sigma-Code-0.1.5-x64.exe`，核对 SHA-256 侧文件后运行安装程序。
-安装包会同时安装 Sigma Code UI 与经过验证的 Sigma Runtime，无需另外安装
-Node.js 或 Agent CLI。
+- 通过桌面客户端、支持 CJK/IME 的 TUI、单次 `run` 或只读 `inspect` 工作。
+- 在进程中断后恢复、重放、steer、取消和审计耐久会话。
+- 读取和修改仓库、运行命令、使用 LSP 代码智能，并连接显式信任的 MCP Server。
+- 在 Windows AppContainer 或 Linux namespace 中执行，并声明文件、进程和网络影响。
+- 通过明确的 writer 隔离和集成流程协调有边界的子 Agent。
+- 在类型化证据账本中记录测试、验证、审查、工作区变化和检查点。
+- 通过固定版本的 Pi 网关连接多个模型 Provider，包括实验性的 ChatGPT/Codex 订阅连接。
 
-安装包中的 UI 来自 [hututuQQQ/sigma-code](https://github.com/hututuQQQ/sigma-code)，并通过 `sigma acp` 启动 Runtime。在 Settings 中选择 Sigma 模型连接，再使用对应 Provider 暴露的方式完成认证。桌面端默认使用实验性的 ChatGPT/Codex 订阅连接；受支持的 Pi Provider 可以通过同一套 Runtime 接口提供 API Key 或 OAuth 登录。
+## 文档
 
-`agent-cli-win32-x64.zip` 仍可用于纯终端或便携场景，其中包含固定版本的
-Node.js、原生 `sigma-exec` Broker、TUI 运行时、TypeScript/Python Language
-Server 资源和 Tokenizer 数据。
+完整产品与技术文档放在官网：
 
-```powershell
-$Sigma = "C:\Tools\sigma-code"
-$Workspace = "D:\path\to\your\repository"
-
-$env:DEEPSEEK_API_KEY = "your-api-key"
-
-# 当前 Windows 用户只需要执行一次。
-& "$Sigma\bin\agent.cmd" sandbox setup
-
-# 创建工作区配置，检查运行环境与模型连接，然后进入 TUI。
-& "$Sigma\bin\agent.cmd" init --workspace $Workspace --provider deepseek
-& "$Sigma\bin\agent.cmd" doctor --workspace $Workspace --check-api
-& "$Sigma\bin\agent.cmd" tui --workspace $Workspace
-```
-
-上面的 API Key 只对当前 PowerShell 进程生效。不要把密钥写进 `.agent/config.toml` 或提交到版本库。
-
-发布的归档都会带有 SHA-256 校验和、CycloneDX SBOM、签名的来源证明和
-公开验证密钥。Linux x64 在 `0.1.5` 是稳定发布；Windows x64 仍属于未签名预览。
-信任边界见 [SECURITY.md](SECURITY.md)，维护者发布流程见
-[RELEASING.md](RELEASING.md)。
-
-执行一次性的修改任务：
-
-```powershell
-& "$Sigma\bin\agent.cmd" run "修复失败的测试并解释修改" `
-  --workspace $Workspace `
-  --permission-mode auto
-```
-
-只读分析仓库：
-
-```powershell
-& "$Sigma\bin\agent.cmd" inspect "梳理请求链路并找出可靠性风险" `
-  --workspace $Workspace `
-  --permission-mode auto
-```
-
-`run` 使用 **change** 模式。`inspect` 使用 **analyze** 模式，会拒绝声明了文件写入、不受限进程启动或破坏性影响的工具。
-
-## Sigma 能做什么
-
-- **桌面与终端交互：** 通过 ACP v1 使用 [Sigma Code 桌面客户端](https://github.com/hututuQQQ/sigma-code)，或使用适配 CJK、IME 和 Emoji 的终端界面；两者都支持实时活动、运行中纠偏和授权交互。
-- **统一模型接入：** 搜索固定版本的 Pi 模型目录、管理 Provider 认证、选择模型专属推理等级，并明确区分按量计费、订阅与价格未知三种账单语义。
-- **仓库理解：** 有界的文件列表与搜索、仓库统计、Git status/diff、工作区及已声明宿主机输入的稳定哈希读取、嵌套 `AGENTS.md` 发现，以及在 Server 可用时启用的 LSP 代码智能。
-- **范围明确的修改：** 写入和编辑文件、原子化应用多文件 Patch、删除单个文件、识别无变化写入、创建修改检查点，并恢复当前运行最近一次已密封检查点。
-- **沙箱命令执行：** 直接运行可执行文件或平台 Shell、执行语义验证，通过 Broker 会话句柄管理后台进程和 PTY，并显式交接已验证的 Linux 交付服务。
-- **只读 Web 研究：** 使用 `web_run`（文档中写作 `web.run`）搜索、打开、查找和跟随编号静态链接；结果保留持久引用，并始终标记为不受信任的外部内容。
-- **证据化交付：** 把工作区变更、命令、验证、诊断、审查、子 Agent 结果和检查点统一写入类型化证据账本。
-- **持久会话：** 支持列出、查看、重放、恢复、取消、纠偏、授权和继续会话，进程退出不等于任务记录消失。
-- **子 Agent 协作：** 把计划节点委托给受预算约束的子会话；写入任务进入 Git Worktree 或窄范围单写者租约，保留的修改需要显式集成。
-- **长会话可靠性：** 在耗尽 Provider 上下文窗口前触发压缩，对瞬态流关闭执行有界恢复，并把 Reviewer 会话和子 Agent Run 与后续轮次隔离。
-- **扩展能力：** 在冻结并受信任的边界内加载 Skill、Profile 和 Hook，连接经过显式信任的只读 MCP stdio Server，也可以接收 ACP 客户端提供的只读 Streamable HTTP MCP Server。
-
-## 架构
-
-`agent-runtime.createConfiguredRuntime` 是唯一的生产组合根。模型路由、上下文、纯内核、影响感知工具、MCP Client、分段事件仓库、检查点、Reviewer、Supervisor、执行 Broker 和进程内 `RuntimeClient` 都在这里组装。CLI 负责创建 Runtime；TUI 只接收 RuntimeClient，不会复制一套 Agent 循环，`sigma acp` 则把同一 Runtime 投影给 Sigma Code 等客户端。
-
-```mermaid
-flowchart TB
-  USER["终端用户"] --> CLI["agent-cli<br/>命令 + TUI"]
-  DESKTOP["Sigma Code 桌面端<br/>T3 Code 下游"] <--> ACP["sigma acp<br/>稳定 ACP v1"]
-  CLI --> ROOT["agent-runtime<br/>唯一生产组合根"]
-  ACP --> ROOT
-  ROOT --> CLIENT["RuntimeClient<br/>会话命令总线"]
-  CLIENT --> KERNEL["agent-kernel<br/>纯 Reducer + Effect 决策"]
-
-  KERNEL --> MODEL["agent-model<br/>路由、预算、重试策略"]
-  MODEL --> PI["agent-pi + pi-ai<br/>Provider 认证与模型传输"]
-  KERNEL --> CONTEXT["agent-context<br/>指令、检索、Token 预算"]
-  KERNEL --> TOOLS["agent-tools<br/>类型化影响计划与回执"]
-  KERNEL --> STORE["agent-store<br/>事件、快照、Artifact"]
-
-  TOOLS --> MCP["agent-mcp<br/>受信任 stdio + ACP HTTP Bridge"]
-  TOOLS --> SUP["agent-supervisor<br/>子 Agent、邮箱、写入隔离"]
-  TOOLS --> EXEC["agent-execution<br/>唯一任意进程边界"]
-  EXEC --> NATIVE["sigma-exec (Rust)<br/>Windows AppContainer / Linux Namespace 沙箱"]
-
-  MODEL --> EVENTS["AgentEventEnvelope"]
-  CONTEXT --> EVENTS
-  TOOLS --> EVENTS
-  SUP --> EVENTS
-  EVENTS --> STORE
-  EVENTS --> KERNEL
-  EVENTS --> PRESENT["agent-presentation<br/>增量投影"]
-  PRESENT --> TUI["agent-tui<br/>OpenTUI 渲染器"]
-  EVENTS --> ACP
-
-  EVAL["外部评估与 Benchmark Harness"] -.->|"只启动正式包；运行结束后收集结果"| CLI
-```
-
-### 核心事件循环
-
-1. CLI、TUI 或 ACP 命令先变成类型化会话命令和持久事件。
-2. `agent-kernel` 把事件流归约为状态并决定下一个 Effect；内核本身不执行 I/O。
-3. `agent-runtime` 通过协议端口把决策交给模型、上下文、工具、Store、Reviewer 或 Supervisor。
-4. 工具执行前，Sigma 会冻结精确的读写根、网络模式、进程模式、幂等性和检查点范围，再对计划执行模式校验、授权、加锁和信任检查。
-5. 执行回执和证据作为新事件追加。内核根据持久状态继续决策，`agent-presentation` 与 ACP Bridge 则把同一批事件投影成终端或桌面端更新。
-6. 一次运行只能以类型化结果结束：`Completed`、`NeedsInput`、`Cancelled`、`RecoverableFailure` 或 `Fatal`。
-
-因此，重放和恢复不是 UI 上额外补出来的功能，而是正常执行模型的一部分。
-
-### 包与分层
-
-| 层 | Package | 职责 |
-| --- | --- | --- |
-| 协议与配置 | `agent-protocol`、`agent-config` | 事件、命令、结果、端口、工具影响、模型能力，以及统一的 CLI/环境变量/TOML Schema。 |
-| 决策引擎 | `agent-kernel` | 纯状态归约、收敛规则、终止协议修复和 Effect 选择。 |
-| 智能与上下文 | `agent-model`、`agent-pi`、`agent-context`、`agent-code-intel`、`agent-extensions` | 模型策略、统一 Pi Provider 传输、上下文压缩、仓库指令、LSP、Skill、Profile 与 Hook。 |
-| 工具能力 | `agent-tools`、`agent-web`、`agent-mcp` | 仓库、文件、进程、控制、Supervisor、Brokered Web 研究与 MCP Bridge，全部受声明影响约束。 |
-| 安全边界 | `agent-execution`、`agent-platform`、`agent-checkpoint`、`native/sigma-exec` | 路径约束、进程策略、原生沙箱、输出脱敏与 Artifact、事务式恢复。 |
-| 持久化与协调 | `agent-store`、`agent-supervisor`、`agent-runtime` | 事件持久化、快照、会话所有权、子 Agent 隔离、恢复、审查和组合。 |
-| 产品界面 | `agent-presentation`、`agent-tui`、`agent-cli`；下游 `sigma-code` | 事件投影、终端交互、自动化命令、ACP v1、桌面交互、会话管理与诊断。 |
-
-生产依赖图会检查循环依赖，各 Package 只能通过公开 Export 交互。
-
-## 安全、权限与恢复
-
-### 执行边界
-
-`agent-execution` 是生产代码中唯一允许启动任意进程的 Package。它通过分帧协议与正式包中的 Rust `sigma-exec` Broker 通信。在 Windows 上，每条沙箱命令都使用独立的 AppContainer 身份和范围化文件 ACL，并通过 kill-on-close Job Object 限制整个进程树；网络能力按调用授予，交互进程使用 ConPTY。Linux 使用原生 Namespace 沙箱和进程树清理 Watchdog。
-
-配置 Schema 1 默认使用 `permission_mode=workspace-auto`、
-`sandbox=required`、`read_scope=workspace`、`network=full`、`web.mode=auto`、
-`process_handoff=allow` 和原生沙箱 Backend。工作区内读取与声明范围内写入自动执行；外部读取、完整网络
-和仓库元数据写入仍单独授权。显式设置 `network=none` 或 `network=loopback` 会收窄
-能力。沙箱失败绝不回退宿主执行；`container` 模式在真实 OCI 后端不可用时返回
-`container_unavailable`。
-
-只有完整网络已启用、Web 模式未禁用且 Broker 声明受限 Web 协议时，Runtime 才会暴露 `web_run`。该会话授权只允许只读 Web 访问，不能授权 Shell、进程或 MCP 网络；Broker 只允许公共 HTTP(S) 80/443 端口，把请求绑定到获批的 Origin 与 Method，并拒绝本地、私有、保留地址、带凭据 URL 和主动浏览器内容。
-
-绝对外部输入通过不跟随链接的稳定遍历读取，并生成包含路径、摘要和大小的 `input_access` 证据；进程只挂载已声明的稳定读取根。目标中读取失败的输入会持续阻止完成，直到同一路径稳定读取成功，本轮生成的替代 Fixture 不能清除义务。
-
-路径约束和操作系统隔离是两道独立防线。工作区工具拒绝词法逃逸和符号链接/Junction 祖先逃逸；创建虚拟环境解释器这类“工作区内链接对象”不会被误判为写入外部目标。`.git` 与 `.agent` 不会获得沙箱写权限。
-
-Linux 仅在安全转交可用时公布 `processHandoff`。`deliverable` 进程使用分离的 stdio，不支持 PTY/stdin，必须先通过独立接口健康检查再调用 `process_handoff`。交接后它脱离会话清理；未交接进程在失败、取消、超时或 Broker 丢失时仍会被终止。Windows 当前不公布该能力并保持 fail closed。
-
-### 检查点与持久状态
-
-运行状态保存在 Agent 无法写入的工作区之外，目录按工作区哈希隔离：
-
-```text
-<user-state>/sigma/workspaces/<workspace-sha256>/stores/v1/sessions/<session-id>/
-  meta.json
-  events/000001.jsonl
-  snapshots/000000000250.json
-  artifacts/<sha256>
-```
-
-事件带校验和与单调递增序号；日志达到 8 MiB 或 10,000 条事件时分段，每 250 条事件和分段时写入快照，末尾撕裂记录可在追加锁内修复。恢复会重新加载待处理授权、Follow-up、动态发现的指令、预算和可安全重试的幂等工作。中断的非幂等 Effect 会进入 `NeedsInput`，不会被静默重放。
-
-### “完成”是协议动作
-
-Provider 返回 `stop` 只会产生 `model_stopped`。Completion Coordinator 独立推导当前变更所需的 assurance 与 review；只有 `model_stopped`、`assurance_satisfied` 和 `review_satisfied` 同时成立才会写入 `run.completed`。失败、过期、弱化或不完整的语义验证会进入修复或 typed blocker，模型没有可以绕过完成门的工具。
-
-所有净变更都需要当前状态上的语义验证。已密封的 no-op 检查点不会推进 frontier；
-会写文件的验证在检查点密封后重新绑定最终 frontier。标准 Profile 要求当前 frontier
-的审查通过，或由用户显式使用一次性 waiver；严格 Profile 不接受 waiver，并要求审查者
-亲自执行检查后通过。所有非 Detached 子 Agent 会在父任务结束前 Join；仍未集成的
-Writer Worktree 也会让父任务保持未完成状态。
-
-### 当前序列化与工具契约
-
-- Sigma 自有序列化边界只接受严格的 `schemaVersion: 1`（TOML 使用
-  `schema_version = 1`；本地 Provider、工作区 Trust 和 ACP Index 使用 `version: 1`）。
-  未知 Schema、当前版本但结构损坏的文档、其他 Store Layout 和旧 Checkpoint Journal
-  分别以 `unsupported_schema_version`、`persisted_state_invalid` 或
-  `unsupported_store_layout` 拒绝；原文件不会被迁移、覆盖或删除。
-- 经过验证的 Shell 只暴露一个用于前台执行、验证、后台进程和一次性环境的 `shell`
-  契约；只有无法提供已验证 Shell 时，才注册直接 `exec`、`validate` 与
-  `process_spawn`。已退役的工具名与参数形状不会为了重放重新注册。
-- 主动审查是只读的，并在一次性 Overlay 中执行检查。它可以查看已认证的当前 frontier
-  与持久进程生命周期证据，但不能写入父工作区。
-- 普通求解预算耗尽时，已经启动的 session 进程可在总 Deadline 内完成结算。
-  Deliverable 进程在独立健康检查和 `process_handoff` 成功之前仍归 session 管理。
-- `write` 与 `edit` 返回结果字节数和 SHA-256；`write_chunk` 以预映像长度与摘要做原子
-  追加。未指定 Shell 时由 Broker 确定性选择。非 UTF-8 进程输出必须保存在字节安全
-  Artifact 中；只有解码错误而没有 Artifact 会被视为 Broker 协议错误。
-- `inspect_image` 与 `inspect_document` 是面向纯文本模型的有界、离线、只读兜底；
-  OCR 或提取元数据只是检查信息，不是完成证据。
-
-## 常用命令
-
-| 命令 | 用途 |
+| 指南 | 内容 |
 | --- | --- |
-| `agent tui --workspace .` | 打开交互式终端界面。 |
-| `agent run "..." --workspace .` | 执行允许修改工作区的任务。 |
-| `agent inspect "..." --workspace .` | 使用只读工具分析工作区。 |
-| `sigma acp` | 通过 stdio 上的换行分隔 JSON-RPC 提供稳定 ACP v1，供 Sigma Code 等客户端使用。 |
-| `agent sessions --workspace . --json` | 列出持久会话。 |
-| `agent session show --latest --workspace .` | 查看最近会话。 |
-| `agent replay --latest --workspace . --timeline` | 重放事件时间线。 |
-| `agent resume <session-id> --workspace .` | 继续一个持久会话。 |
-| `agent cancel <session-id> --workspace .` | 取消活动会话。 |
-| `agent approval <session-id> <request-id> --decision allow --workspace .` | 处理待确认授权。 |
-| `agent doctor --workspace . --check-api` | 检查配置、沙箱、工具链和 Provider。 |
-| `sigma auth list --json` | 离线列出 Pi Provider 的认证方式及本地/环境认证状态。 |
-| `sigma auth status <provider> --json` | 离线读取指定 Provider 的本地认证状态，不刷新 OAuth。 |
-| `sigma auth login <provider> --method <method-id> --json` | 启动机器可读的 API Key 或 OAuth 登录流程。 |
-| `sigma auth logout <provider> --json` | 删除该 Provider 的本地凭据；环境凭据仍会显示。 |
-| `sigma models list --json` | 读取固定版本的静态模型目录与离线动态缓存。 |
-| `sigma models refresh <provider> --json` | 显式刷新动态 Provider 的模型目录。 |
-| `agent sandbox setup` | 准备并自检 Windows 沙箱。 |
-| `agent init --workspace .` | 创建 `.agent/config.toml`。 |
+| [快速入门](https://sigmacode.biz/docs/getting-started) | 发行包、验证、Linux 与 Windows 设置、第一个任务 |
+| [CLI、配置与 Provider](https://sigmacode.biz/docs/cli-and-configuration) | 命令、TUI 控制、权限、认证与 reasoning level |
+| [Runtime 架构](https://sigmacode.biz/docs/architecture) | 组合根、事件循环、包边界与 ACP v1 |
+| [安全、权限与恢复](https://sigmacode.biz/docs/security-and-recovery) | 原生沙箱、路径和网络边界、耐久状态与完成协议 |
+| [耐久会话](https://sigmacode.biz/features/durable-sessions) | 事件流、检查点、重放与恢复 |
+| [原生沙箱](https://sigmacode.biz/features/native-sandbox) | Windows AppContainer 与 Linux namespace |
+| [证据式完成](https://sigmacode.biz/features/evidence-backed-completion) | 验证、审查与当前状态证据 |
+| [评测方法](https://sigmacode.biz/docs/evaluation) | 预注册、公平边界、结果与限制 |
 
-稳定退出码：`0` 表示 `Completed`，`2` 表示 `NeedsInput`，`130` 表示 `Cancelled`，`1` 表示可恢复或致命失败。
+仓库维护者资料继续与代码放在一起：
 
-### TUI 操作
+- [CONTRIBUTING.md](CONTRIBUTING.md) — 开发流程与贡献要求
+- [VALIDATION.md](VALIDATION.md) — 测试层级、覆盖率、原生检查与发布证据
+- [RELEASING.md](RELEASING.md) — 打包和发布流程
+- [SECURITY.md](SECURITY.md) — 支持版本、信任边界与漏洞报告
 
-- `Enter`：空闲时提交；运行中立即纠偏
-- `Shift+Enter` / `Ctrl+J`：插入换行
-- `Alt+Enter`：把消息加入 Follow-up 队列
-- `Ctrl+O`：展开或折叠活动信息
-- `PgUp` / `PgDn`、`Ctrl+U` / `Ctrl+D`、鼠标滚轮：滚动会话
-- `/new`、`/mode analyze|change`、`/followup`、`/activity`、`/help`、`/quit`：会话命令
-- 第一次 `Ctrl+C`：取消；1.5 秒内再次按下：退出
+## 透明评测
 
-## 配置
+2026 年 7 月 27–28 日的分阶段 Terminal-Bench 2.1 诊断使用 DeepSeek `deepseek-v4-pro`、相同的 89 个任务、Sigma 每任务一次尝试、零重试、无验证器反馈。Sigma Code 完成 **51/89（57.303%）**，OpenCode 完成 **49/89（55.056%）**。
 
-优先级为 **CLI 参数 → 环境变量 → 工作区 `.agent/config.toml` → Home `~/.sigma/config.toml` → 默认值**。未知参数和未知 TOML Key 会立即报错。由仓库提供的 MCP Server 和可执行 Hook 必须获得与内容摘要绑定的显式信任。
+这是混合源码的工程诊断，不是“全面优于其他工具”的结论，也不是最终源码 Head 的单一得分。比较数字前请先阅读[方法、公平规则与限制](https://sigmacode.biz/docs/evaluation)。
 
-正式包默认使用实验性的 `openai-codex` 订阅 Provider，并自动选择模型。下面的示例显式选择 DeepSeek，适用于 API Key 配置：
+## 开发
 
-```toml
-schema_version = 1
-
-[model]
-provider = "deepseek"
-name = "auto"
-reasoning_effort = "auto"
-
-[permissions]
-mode = "workspace-auto"
-
-[security]
-sandbox = "required"
-read_scope = "workspace"
-network = "full"
-process_handoff = "allow"
-
-[web]
-mode = "auto"
-search_provider = "exa"
-
-[runtime]
-run_deadline_sec = 0
-model_deadline_sec = 120
-stream_idle_sec = 45
-
-[tools]
-max_parallel = 4
-
-[agents]
-max_parallel = 4
-
-[ui]
-output_format = "text"
-
-[tui]
-fps = 30
-```
-
-`runtime.run_deadline_sec = 0` 表示交互式 Run 不设置整体墙钟时限。只有调用方确实需要限制整次任务时才应改为正数；Provider 请求和工具调用仍有独立的活性超时，因此不会因为取消整体 Deadline 而失去中断挂起请求或进程的能力。
-
-如需逐次申请更宽的外部能力：
-
-```toml
-schema_version = 1
-
-[security]
-sandbox = "required"
-read_scope = "host"
-network = "full"
-process_handoff = "deny"
-```
-
-`agent init` 会直接写入当前 Schema。Sigma 不提供配置迁移命令，也不会读取其他持久
-Store Layout。需要保留的不兼容状态应由用户自行备份或移动；拒绝过程始终只读。
-
-### ChatGPT/Codex 订阅 Provider（实验性）
-
-Sigma 可以继续使用自己的 Runtime、工具、恢复、预算、Reviewer、Strategist 和持久状态，只把模型请求发送到 ChatGPT/Codex 订阅：
-
-```toml
-[model]
-provider = "openai-codex"
-name = "gpt-5.6-terra"
-reasoning_effort = "max"
-```
-
-这条路径使用 ChatGPT OAuth 与 `https://chatgpt.com/backend-api/codex/responses`，不会读取 `OPENAI_API_KEY`，也不使用 API Key 计费。凭据由同一主机上的 Sigma 进程共享并保存在 `~/.sigma/auth.json`。订阅调用仍记录 Token 用量，但 `billingMode` 为 `subscription`，API 成本为 null。认证、额度、限流、网络、超时和 Server 错误会原样返回；内置订阅路径只有一个候选，不会静默回退到 DeepSeek、GLM 或 `api.openai.com/v1`。
-
-`reasoning_effort` 支持 `auto`、`none`、`low`、`medium`、`high`、`xhigh` 与 `max`；等价 CLI 参数为 `--reasoning-effort`。实际可选等级来自具体模型的 Pi 元数据，不支持的等级不会出现在 ACP 或模型目录中。
-
-供可信桌面客户端使用的 JSONL 登录接口为：
-
-```text
-sigma auth status openai-codex --json
-sigma auth login openai-codex --method browser --json
-sigma auth login openai-codex --method device-code --json
-sigma auth logout openai-codex --json
-```
-
-对 Codex Transport，Sigma 会保持稳定的 Prompt 前缀以使用带缓存的 WebSocket Continuation，在流开始前可以回退到 SSE，把过早关闭的流归类为可有界重试的瞬态失败，并隔离 Solver 与 Reviewer 的传输会话。上下文压缩会在耗尽 Provider 窗口之前启动，而不是等到硬溢出后再处理。
-
-### 统一 Pi Provider 网关
-
-所有模型 I/O 都由 `agent-pi` 负责，并固定使用 `@earendil-works/pi-ai@0.82.1`。固定目录包含 Pi 的 38 个内置 Provider、1,109 个静态模型，以及 Sigma 历史 `glm` 兼容 Provider 与 Endpoint。`agent-model` 只承担策略层职责：选择显式路由、预留预算、分类失败、执行重试/回退规则并跟踪 Provider 健康状态。
-
-Provider 凭据与动态模型缓存分别存储在 `~/.sigma/auth.json` 和 `~/.sigma/models.json`，都采用原子替换、跨进程锁和仅当前用户可读写的权限。读取目录或认证状态不会联网；只有显式刷新模型、完成登录或正常模型请求才会访问网络。
-
-模型连接支持 `HTTP_PROXY`、`HTTPS_PROXY`、`ALL_PROXY` 与 `NO_PROXY`。Windows 桌面端或 ACP 进程在没有代理环境变量时，可以读取当前用户已启用的静态 Windows Internet Settings 代理；显式环境变量优先，回环流量始终绕过代理。
-
-计费状态明确区分 `metered`、`subscription` 与 `unpriced`。订阅或价格未知的调用仍保留 Token 用量，并以 null 表示未知金额，不会显示为 0 美元。价格未知的模型默认被拒绝，只有当前任务显式使用 `--allow-unpriced-costs` 或 `budget.allow_unpriced_costs = true` 时才可执行；已知模型的金额、Token、轮次和工具预算仍然有效。
-
-ChatGPT 订阅认证与 API Key 计费彼此独立。这里使用的 Backend 通过固定版本的 Pi 社区 Adapter 接入，并不是具有稳定性承诺的公开第三方 API，因此升级必须显式更新依赖并通过契约测试。
-
-DeepSeek 使用 `DEEPSEEK_API_KEY`。实验性的 GLM/Z.ai 路径也可以读取 `GLM_API_KEY`、`ZAI_API_KEY` 或 `BIGMODEL_API_KEY`。Web 搜索使用 [Exa 托管 MCP 服务](https://exa.ai/docs/reference/exa-mcp)；`EXA_API_KEY` 可选，429 响应会提示操作者配置密钥，不会静默切换 Provider。只有 Provider 被明确冻结进本次预注册清单时，它才属于该次正式结果的一部分。
-
-## 评估与 Benchmark 边界
-
-Sigma 的正式体验评估器会在全新、不透明的工作区中运行已打包产品，再把持久事件流
-归约为正确性、安全性、体验与可靠性结果。Terminal-Bench 正式运行必须提供
-`SigmaFormalRunPreregistration`；代码不提供正式 dataset、模型、配额、重试或分数
-阈值默认值。
-
-评估器可以选择任务、启动正式包，并在运行结束后收集 Artifact；它不能把场景身份、Verifier 输出、分数、Reward、隐藏检查或运行后失败传给求解会话，也不能利用 Verifier 反馈重试求解。协议类型和生产源码扫描会共同约束这条公平性边界。
-
-### Terminal-Bench 2.1：Sigma Code + DeepSeek 对比 OpenCode + DeepSeek
-
-2026 年 7 月 27–28 日完成的分阶段诊断运行，使用 DeepSeek
-`deepseek-v4-pro`，在同一组 89 个 Terminal-Bench 2.1 任务上对比两个
-Agent。Sigma 侧最大并发为 5，每个任务只尝试 1 次，重试为 0，也没有把
-Verifier 反馈传回求解 Agent。
-
-| Agent | 完成项 | 通过率 |
-| --- | ---: | ---: |
-| **Sigma Code + DeepSeek** | **51/89** | **57.303%** |
-| OpenCode + DeepSeek | 49/89 | 55.056% |
-| **差值** | **+2 项** | **+2.247 个百分点** |
-
-报告始终使用完整 89 项作为分母，其中 6 个经审计确认由外部原因造成的 Sigma 基础设施无效观测仍按未通过计入。每个源码修订只运行此前尚未消费的任务，因此这是混合源码诊断结果，不是最终 PR HEAD 的单版本分数。没有重跑已消费任务，最后一次观测后完成的通用生命周期修复也有意不计入本次分数。源码边界、止损与验证记录见
-[PR #73](https://github.com/hututuQQQ/sigma/pull/73)。
-
-```powershell
-# 不调用模型，只审计已经存在的会话。
-pnpm eval:session -- --workspace . --latest 2
-
-# 在线评估需要显式提供 Provider/模型控制。
-pnpm eval:agent -- --suite quick
-pnpm eval:agent -- --suite experience --repeat 3
-
-# 创建并消费不可变的正式运行清单。
-pnpm bench:tb:preregister -- --draft formal-draft.json --output formal-run.json
-pnpm bench:tb:formal -- --preregistration-file formal-run.json --expected-preregistration-sha256 <sha256> --batch <batch-id>
-```
-
-这些结果不能外推为跨 Provider 的性能结论。
-
-## 构建与开发
-
-仓库固定使用 Node.js `26.4.0`、pnpm `11.7.0` 和 Rust `1.96.0`。
+仓库固定使用 Node.js `26.4.0`、pnpm `11.7.0` 与 Rust `1.96.0`。
 
 ```powershell
 corepack enable
 corepack prepare pnpm@11.7.0 --activate
 pnpm install --frozen-lockfile
 pnpm build
-cargo build --release --locked --manifest-path native/sigma-exec/Cargo.toml
-
 pnpm lint
 pnpm test:coverage
-
-# 需要已打包 CLI、模型 Provider 密钥和实时网络。
-pnpm smoke:web:live
 ```
 
-构建并验证当前 Windows 预览候选：
-
-```powershell
-pnpm package:agent-cli:windows
-pnpm verify:release:windows
-```
-
-打包完成后，把开发密钥写入仓库内已被 Git 忽略的 `.env` 文件：
-
-```dotenv
-DEEPSEEK_API_KEY=your-api-key
-# 可选；托管 Exa MCP Endpoint 不配置密钥也可以使用。
-EXA_API_KEY=your-exa-key
-```
-
-然后启动开发 TUI：
-
-```powershell
-pnpm tui:deepseek
-```
-
-使用 Fake Gateway 的测试不需要 Provider 密钥。覆盖率阈值、真实终端边界、原生沙箱检查、打包证明与发布 Gate 见 [VALIDATION.md](VALIDATION.md)。
+修改 Runtime、沙箱、持久化或评测行为前，请先阅读 [CONTRIBUTING.md](CONTRIBUTING.md) 与 [VALIDATION.md](VALIDATION.md)。
 
 ## 许可证
 
-Sigma Code 采用 [MIT License](LICENSE) 开源。
-
-## 接下来的方向
-
-Sigma 当前有意保持聚焦：继续提高 Windows 桌面端与 ACP 的可靠性，深化长会话收敛能力，缩小真实任务表现差距，同时坚持把评估反馈隔离在求解边界之外。更多平台和 Provider 的正式声明，应该建立在可复现的预注册和已经被证明的产品可靠性之上。
+Sigma Code 采用 [MIT License](LICENSE)。


### PR DESCRIPTION
## What changed

- reduce the English README from 601 lines to 129
- reduce the Chinese README from 401 lines to 129
- keep the product pitch, release boundary, screenshots, shortest setup path, capability summary, evaluation caveat, and developer bootstrap
- replace the embedded manual with a bilingual website documentation index
- keep maintainer workflows linked to CONTRIBUTING.md, VALIDATION.md, RELEASING.md, and SECURITY.md

## Why

The README was serving new users, operators, runtime maintainers, and evaluation readers at once. That made the repository landing page difficult to scan and duplicated content that is better maintained as navigable, bilingual website documentation.

## User and developer impact

New visitors can understand the product and reach a first task quickly. Operators get focused website references, while maintainer-specific material remains close to the source.

## Checks

- `git diff --check`
- verified every local Markdown link in both README files

## Companion website PR

- https://github.com/hututuQQQ/sigma-code-website/pull/4

Merge and publish the website PR before this README PR so the new documentation links are live when the README changes land.