### PR TITLE
Slim agent harness reliability improvements

### DIFF
--- a/native/sigma-exec/src/sandbox.rs
+++ b/native/sigma-exec/src/sandbox.rs
@@ -1307,6 +1307,7 @@ fn build_sandboxed_command(
         &execution_roots,
         &protected_roots,
         params.policy.enclosing_container_root,
+        &helper_source,
     )?;
     let executable =
         authorize_linux_executable(params, &system_roots, &execution_roots, &runtime_cwd_source)?;
@@ -1770,21 +1771,54 @@ fn verify_pinned_root_hierarchy(
 }
 
 #[cfg(target_os = "linux")]
+fn pinned_source_at_destination_under_root(
+    source: &PinnedMountSource,
+    destination: &Path,
+    root: &PinnedMountSource,
+) -> Result<bool, RpcError> {
+    Ok(source.destination() == destination && source.is_descendant_of(root)?)
+}
+
+#[cfg(target_os = "linux")]
 fn reject_internal_mount_conflicts(
     read_roots: &[PinnedMountSource],
     write_roots: &[PinnedMountSource],
     execution_roots: &[PinnedMountSource],
     protected_roots: &[PinnedMountSource],
     enclosing_container_root: bool,
+    helper_source: &PinnedMountSource,
 ) -> Result<(), RpcError> {
     let reserved = [
         Path::new(INTERNAL_HELPER_MOUNT),
         Path::new(crate::linux_hardening::INTERNAL_CWD_PIN_MOUNT),
     ];
     for destination in reserved {
-        for root in read_roots
+        for root in read_roots {
+            if enclosing_container_root && root.destination() == Path::new("/") {
+                continue;
+            }
+            // Packaged container runners may execute the helper from the
+            // reserved destination itself. An ancestor read-only root that
+            // contains this exact pinned inode is safe because the final
+            // descriptor bind is applied after policy mounts. A replacement
+            // tree, writable root, or any other occupancy still fails closed.
+            if destination == Path::new(INTERNAL_HELPER_MOUNT)
+                && pinned_source_at_destination_under_root(helper_source, destination, root)?
+            {
+                continue;
+            }
+            if root.occupies_destination(destination)? {
+                return Err(RpcError::new(
+                    "policy_denied",
+                    format!(
+                        "sandbox policy collides with reserved internal mount '{}'",
+                        destination.display()
+                    ),
+                ));
+            }
+        }
+        for root in write_roots
             .iter()
-            .chain(write_roots)
             .chain(execution_roots)
             .chain(protected_roots)
         {
@@ -2568,6 +2602,45 @@ mod tests {
         verify_pinned_root_hierarchy(&read_roots, &[], &independent_execution, &[])
             .expect("independent execution root should remain allowed");
         std::fs::remove_dir_all(root).expect("remove test root");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn identifies_only_the_same_pinned_helper_inside_a_read_root() {
+        let base = std::env::temp_dir().join(format!(
+            "sigma-pinned-helper-{}-{}",
+            std::process::id(),
+            PROTECTED_GUARD_SEQUENCE.fetch_add(1, Ordering::Relaxed)
+        ));
+        let root = base.join("declared");
+        let helper_path = root.join("helper");
+        let moved = base.join("original");
+        std::fs::create_dir_all(&root).expect("create helper root");
+        std::fs::write(&helper_path, "original").expect("create helper");
+        let read_root = PinnedMountSource::pin(&root).expect("pin read root");
+        let helper = PinnedMountSource::pin(&helper_path).expect("pin helper");
+        assert!(
+            pinned_source_at_destination_under_root(&helper, &helper_path, &read_root)
+                .expect("verify helper tree")
+        );
+        assert!(
+            !pinned_source_at_destination_under_root(
+                &helper,
+                &root.join("other-helper"),
+                &read_root
+            )
+            .expect("reject a different destination")
+        );
+
+        std::fs::rename(&root, &moved).expect("move original helper tree");
+        std::fs::create_dir_all(&root).expect("create replacement helper root");
+        std::fs::write(root.join("helper"), "replacement").expect("replace helper");
+        let replacement = PinnedMountSource::pin(&root).expect("pin replacement root");
+        assert!(
+            !pinned_source_at_destination_under_root(&helper, &helper_path, &replacement)
+                .expect("reject replacement helper tree")
+        );
+        std::fs::remove_dir_all(base).expect("remove helper test root");
     }
 
     #[cfg(target_os = "linux")]

--- a/packages/agent-code-intel/src/client.ts
+++ b/packages/agent-code-intel/src/client.ts
@@ -33,6 +33,7 @@ function languageId(filePath: string): string {
   const extension = path.extname(filePath).toLowerCase();
   return ({
     ".ts": "typescript", ".tsx": "typescriptreact", ".js": "javascript", ".jsx": "javascriptreact",
+    ".mts": "typescript", ".cts": "typescript", ".mjs": "javascript", ".cjs": "javascript",
     ".py": "python", ".rs": "rust", ".go": "go"
   } as Record<string, string>)[extension] ?? "plaintext";
 }

--- a/packages/agent-context/src/repository-regex-search.ts
+++ b/packages/agent-context/src/repository-regex-search.ts
@@ -3,12 +3,28 @@ import { textLines } from "agent-platform";
 
 export const MAX_REPOSITORY_REGEX_CHARACTERS = 4_096;
 
+export interface RepositoryRegexPattern {
+  source: string;
+  flags: string;
+}
+
+/** Accept leading inline flags commonly emitted for PCRE/Python regexes while
+ * retaining JavaScript's bounded worker execution. */
+export function repositoryRegexPattern(query: string): RepositoryRegexPattern {
+  const inline = /^\(\?([ims]+)\)/u.exec(query);
+  const requested = inline?.[1] ?? "";
+  return {
+    source: inline ? query.slice(inline[0].length) : query,
+    flags: [...new Set(`${requested}u`)].join("")
+  };
+}
+
 const workerSource = String.raw`
 const { parentPort, workerData } = require("node:worker_threads");
 let matcher;
 let initializationError;
 try {
-  matcher = new RegExp(workerData.query, "u");
+  matcher = new RegExp(workerData.source, workerData.flags);
 } catch (error) {
   initializationError = error instanceof Error ? error.message : String(error);
 }
@@ -102,7 +118,10 @@ export class BoundedRegexMatcher {
         `Regex exceeds the ${MAX_REPOSITORY_REGEX_CHARACTERS}-character safety limit.`
       );
     }
-    this.worker = new Worker(workerSource, { eval: true, workerData: { query } });
+    this.worker = new Worker(workerSource, {
+      eval: true,
+      workerData: repositoryRegexPattern(query)
+    });
   }
 
   async search(

--- a/packages/agent-context/src/repository-text-search.ts
+++ b/packages/agent-context/src/repository-text-search.ts
@@ -4,6 +4,7 @@ import {
   BoundedRegexMatcher,
   literalLineMatches,
   MAX_REPOSITORY_REGEX_CHARACTERS,
+  repositoryRegexPattern,
   type RepositoryLineMatch
 } from "./repository-regex-search.js";
 import { withHostRepositorySnapshot } from "./repository-host-snapshot.js";
@@ -264,7 +265,8 @@ function resolvedOptions(
   }
   if (regex) {
     try {
-      RegExp(options.query, "u");
+      const pattern = repositoryRegexPattern(options.query);
+      RegExp(pattern.source, pattern.flags);
     } catch (error) {
       throw new Error(
         `Invalid repository regex: ${error instanceof Error ? error.message : String(error)}`,

--- a/packages/agent-kernel/src/model-event-parsing.ts
+++ b/packages/agent-kernel/src/model-event-parsing.ts
@@ -59,6 +59,7 @@ export function modelMessage(value: JsonValue | undefined): ModelMessage | null 
     ...(images.length > 0 ? { images } : {}),
     ...(typeof item.reasoningContent === "string" ? { reasoningContent: item.reasoningContent } : {}),
     ...(typeof item.toolCallId === "string" ? { toolCallId: item.toolCallId } : {}),
+    ...(typeof item.isError === "boolean" ? { isError: item.isError } : {}),
     ...(toolCalls.length > 0 ? { toolCalls } : {}),
     ...(providerState ? { providerState } : {})
   };

--- a/packages/agent-kernel/src/receipt-parsing.ts
+++ b/packages/agent-kernel/src/receipt-parsing.ts
@@ -115,14 +115,22 @@ export function toolReceipt(value: unknown): ToolReceipt | null {
 
 export function receiptContent(receipt: ToolReceipt): string {
   const heading = `Tool result: ${receipt.ok ? "succeeded" : "failed"}`;
+  const serializedResult = receipt.result === undefined
+    ? undefined
+    : JSON.stringify(receipt.result);
+  const outputAlreadyProjectsResult = serializedResult !== undefined
+    && serializedResult === receipt.output;
   const diagnostics = [...new Set([
     ...receipt.outcome.diagnosticCodes,
     ...receipt.diagnostics
   ])].slice(0, 12).map((code) => compactString(code, 96));
-  const artifacts = (receipt.artifactRefs ?? []).slice(0, 6).map((artifact) =>
-    [compactString(artifact.artifactId, 128), compactString(artifact.name, 96), artifact.sizeBytes]
-      .filter((item) => item !== undefined)
-      .join(":"));
+  const artifacts = (receipt.artifactRefs ?? []).slice(0, 6).map((artifact) => ({
+    // artifactId is an opaque capability. Keep it exact and separate from
+    // presentation metadata so the model can pass it back to read_artifact.
+    artifactId: artifact.artifactId,
+    name: compactString(artifact.name, 96),
+    ...(artifact.sizeBytes === undefined ? {} : { sizeBytes: artifact.sizeBytes })
+  }));
   const delta = receipt.workspaceDelta;
   const changes = delta ? {
     added: delta.added.slice(0, 6).map((item) => compactString(item, 120)),
@@ -139,7 +147,9 @@ export function receiptContent(receipt: ToolReceipt): string {
       evidence: receipt.evidence.slice(0, 6).map((item) =>
         `${item.kind}:${item.status}:${compactString(item.summary, 120)}`)
     } : {}),
-    ...(receipt.result === undefined ? {} : { result: boundedJson(receipt.result) }),
+    ...(receipt.result === undefined || outputAlreadyProjectsResult
+      ? {}
+      : { result: boundedJson(receipt.result) }),
     ...(changes ? { changes } : {}),
     ...(receipt.artifacts.length > 0 && artifacts.length === 0
       ? { artifactIds: receipt.artifacts.slice(0, 6).map((item) => compactString(item, 128)) } : {}),

--- a/packages/agent-kernel/src/reducer-helpers.ts
+++ b/packages/agent-kernel/src/reducer-helpers.ts
@@ -88,6 +88,7 @@ export function supersededToolMessages(state: KernelState): ModelMessage[] {
   return state.pendingTools.map((pending) => ({
     role: "tool",
     toolCallId: pending.request.callId,
+    isError: true,
     content: `Failed tool receipt ID: ${pending.request.callId}\n`
       + "Superseded by a newer user instruction; no successful receipt or side effect may be inferred."
   }));

--- a/packages/agent-kernel/src/reducer.ts
+++ b/packages/agent-kernel/src/reducer.ts
@@ -157,7 +157,8 @@ const toolFinished: EventReducer = (state, event) => {
   const messages = [...state.messages, {
     role: "tool" as const,
     content: receiptContent(receipt),
-    toolCallId: receipt.callId
+    toolCallId: receipt.callId,
+    isError: !receipt.ok
   }];
   const next: KernelState = {
     ...state,

--- a/packages/agent-model/src/route-policy.ts
+++ b/packages/agent-model/src/route-policy.ts
@@ -84,7 +84,9 @@ function tokenizerMargin(spec: ModelSpec): number {
 function contextRequirement(spec: ModelSpec, constraints: ModelRouteConstraints): number {
   const margin = tokenizerMargin(spec);
   const input = Math.ceil((constraints.estimatedInputTokens ?? 0) * margin);
-  const output = Math.ceil((constraints.maxOutputTokens ?? spec.capabilities.maxOutputTokens) * margin);
+  // Only the locally counted prompt is approximate. The provider request's
+  // output limit is exact and must not consume tokenizer uncertainty again.
+  const output = Math.ceil(constraints.maxOutputTokens ?? spec.capabilities.maxOutputTokens);
   return input + output;
 }
 

--- a/packages/agent-model/src/router-retry.ts
+++ b/packages/agent-model/src/router-retry.ts
@@ -1,4 +1,8 @@
-import type { ModelFailureCategory, ModelSpec } from "./catalog.js";
+import {
+  failureDiagnostics,
+  type ModelFailureCategory,
+  type ModelSpec
+} from "./catalog.js";
 import type { ModelResolution } from "./route-policy.js";
 
 function retrySameProvider(category: ModelFailureCategory, spec: ModelSpec | undefined): boolean {
@@ -6,6 +10,7 @@ function retrySameProvider(category: ModelFailureCategory, spec: ModelSpec | und
     || category === "network"
     || category === "server"
     || category === "timeout"
+    || category === "protocol"
     || (category === "capacity" && spec?.providerId === "deepseek");
 }
 
@@ -80,4 +85,27 @@ export function nextExecutionIndex(
   const nextProvider = attempts.findIndex((spec, index) =>
     index > currentIndex && spec.id !== current?.id);
   return nextProvider < 0 ? undefined : nextProvider;
+}
+
+export function safeProtocolRetry(
+  error: unknown,
+  category: ModelFailureCategory,
+  attempts: readonly ModelSpec[],
+  currentIndex: number,
+  nextIndex: number | undefined,
+  semanticOutputCommitted: boolean
+): boolean {
+  if (category !== "protocol" || semanticOutputCommitted || nextIndex === undefined) return false;
+  const current = attempts[currentIndex];
+  const next = attempts[nextIndex];
+  if (!current || next?.id !== current.id) return false;
+  // Protocol failures are frequently deterministic. Allow only one recovery
+  // attempt for an otherwise opaque, pre-commit stream failure; structured
+  // provider 4xx/policy failures remain terminal and cross-model fallback is
+  // still prohibited.
+  if (currentIndex > 0 && attempts[currentIndex - 1]?.id === current.id) return false;
+  const diagnostics = failureDiagnostics(error);
+  return diagnostics?.doneReceived === false
+    && diagnostics.providerErrorCode === undefined
+    && diagnostics.httpStatus === undefined;
 }

--- a/packages/agent-model/src/router.ts
+++ b/packages/agent-model/src/router.ts
@@ -28,7 +28,8 @@ import {
   abortableDelay,
   executionCandidates,
   nextExecutionIndex,
-  retryDelay
+  retryDelay,
+  safeProtocolRetry
 } from "./router-retry.js";
 import {
   incompleteRoutedStreamError,
@@ -272,7 +273,16 @@ export class ModelRouter {
         const category = classifyModelFailure(error);
         const semanticDelta = errorSemanticDelta(error);
         const nextIndex = nextExecutionIndex(planned, index, category);
-        if (!canFallback(resolution.route, category, semanticDelta) || nextIndex === undefined) {
+        const retryProtocol = safeProtocolRetry(
+          error,
+          category,
+          planned,
+          index,
+          nextIndex,
+          semanticDelta
+        );
+        if ((!retryProtocol && !canFallback(resolution.route, category, semanticDelta))
+          || nextIndex === undefined) {
           throw new ModelRouteExecutionError(
             routeId,
             spec.id,
@@ -334,7 +344,16 @@ export class ModelRouter {
         lifecycle.semanticDelta ||= errorSemanticDelta(error);
         const nextIndex = nextExecutionIndex(planned, index, category);
         const next = nextIndex === undefined ? undefined : planned[nextIndex];
-        if (!canFallback(resolution.route, category, blocksStreamRetry(lifecycle, spec, next))
+        const blocksRetry = blocksStreamRetry(lifecycle, spec, next);
+        const retryProtocol = safeProtocolRetry(
+          error,
+          category,
+          planned,
+          index,
+          nextIndex,
+          blocksRetry
+        );
+        if ((!retryProtocol && !canFallback(resolution.route, category, blocksRetry))
           || nextIndex === undefined) {
           throw new ModelRouteExecutionError(
             routeId,

--- a/packages/agent-pi/src/gateway-adapter.ts
+++ b/packages/agent-pi/src/gateway-adapter.ts
@@ -189,7 +189,7 @@ function contextParts(
       toolCallId: message.toolCallId,
       toolName: toolNames.get(message.toolCallId) ?? "tool",
       content: [{ type: "text", text: message.content }],
-      isError: false,
+      isError: message.isError === true,
       timestamp: Date.now()
     };
     result.push(toolResult);

--- a/packages/agent-pi/src/gateway.ts
+++ b/packages/agent-pi/src/gateway.ts
@@ -82,6 +82,15 @@ function newPiStreamLifecycle(): PiStreamLifecycle {
   };
 }
 
+function piSamplingOptions(
+  capabilities: ModelCapabilities,
+  request: ModelRequest
+): Partial<Pick<ModelRequest, "temperature">> {
+  return capabilities.temperatureControl === false || request.temperature === undefined
+    ? {}
+    : { temperature: request.temperature };
+}
+
 function observePiStreamEvent(
   lifecycle: PiStreamLifecycle,
   event: ModelStreamEvent
@@ -170,7 +179,7 @@ export class PiModelGateway implements ModelGateway {
       ? undefined
       : Math.max(1, Math.trunc(options.activeStreamTimeoutMs));
     this.reasoningEffort = options.reasoningEffort;
-    this.capabilities = options.capabilities ?? {
+    const capabilities = options.capabilities ?? {
       contextWindowTokens: piModel.contextWindow,
       maxOutputTokens: piModel.maxTokens,
       tools: true,
@@ -181,6 +190,11 @@ export class PiModelGateway implements ModelGateway {
       promptCache: true,
       tokenizer: "approximate",
       imageInput: piModel.input.includes("image")
+    };
+    this.capabilities = {
+      ...capabilities,
+      temperatureControl: capabilities.temperatureControl
+        ?? piModel.api !== "openai-codex-responses"
     };
   }
 
@@ -205,7 +219,7 @@ export class PiModelGateway implements ModelGateway {
         const options = {
           signal,
           maxTokens: request.maxOutputTokens,
-          temperature: request.temperature,
+          ...piSamplingOptions(this.capabilities, request),
           toolChoice: request.toolChoice,
           maxRetries: 0,
           ...(request.sessionId ? { sessionId: request.sessionId } : {}),

--- a/packages/agent-protocol/src/event-payload-schemas-foundation.ts
+++ b/packages/agent-protocol/src/event-payload-schemas-foundation.ts
@@ -41,6 +41,7 @@ export const modelMessageSchema = z.object({
   images: z.array(modelImageSchema).optional(),
   reasoningContent: z.string().optional(),
   toolCallId: z.string().optional(),
+  isError: z.boolean().optional(),
   toolCalls: z.array(modelToolCallSchema).optional(),
   providerState: z.object({
     provider: nonEmptyStringSchema,

--- a/packages/agent-protocol/src/model.ts
+++ b/packages/agent-protocol/src/model.ts
@@ -26,6 +26,8 @@ export interface ModelMessage {
   images?: ModelImage[];
   reasoningContent?: string;
   toolCallId?: string;
+  /** Provider-native tool result status. Only meaningful for tool messages. */
+  isError?: boolean;
   toolCalls?: ModelToolCall[];
   providerState?: ModelProviderState;
 }
@@ -72,6 +74,12 @@ export interface ModelCapabilities {
   structuredOutput: boolean;
   promptCache: boolean;
   tokenizer: "provider" | "approximate";
+  /**
+   * The active provider/wire profile accepts an explicit sampling temperature.
+   * Omitted means unknown and preserves the caller's request for third-party
+   * gateways; `false` requires the harness to omit the field entirely.
+   */
+  temperatureControl?: boolean;
   /** The selected model accepts image blocks in user messages. */
   imageInput?: boolean;
   /**

--- a/packages/agent-runtime/src/agent-profile-hook-runner.ts
+++ b/packages/agent-runtime/src/agent-profile-hook-runner.ts
@@ -21,6 +21,7 @@ import {
   prepareModelBudget,
   successfulModelUsage
 } from "./model-accounting.js";
+import { deterministicSamplingOptions } from "./model-request-policy.js";
 import type { RuntimeSession } from "./types.js";
 import type { RuntimeEventEmitter } from "./runtime-event-emitter.js";
 
@@ -297,7 +298,7 @@ export class ModelAgentProfileHookRunner implements HookRunnerPort {
         messages: hookMessages,
         tools: [],
         maxOutputTokens,
-        temperature: 0,
+        ...deterministicSamplingOptions(gateway),
         signal
       }, prepared.routeConstraints);
     } catch (error) {

--- a/packages/agent-runtime/src/long-horizon-coordinator.ts
+++ b/packages/agent-runtime/src/long-horizon-coordinator.ts
@@ -36,6 +36,7 @@ import {
   type PreparedModelBudget
 } from "./model-accounting.js";
 import { fitPreparedBudget } from "./model-budget-convergence.js";
+import { deterministicSamplingOptions } from "./model-request-policy.js";
 import { currentFrontierReview } from "./mutation-evidence.js";
 import type { RuntimeEventEmitter } from "./runtime-event-emitter.js";
 import type { RuntimeOptions, RuntimeSession } from "./types.js";
@@ -286,7 +287,7 @@ export class LongHorizonCoordinator {
         signal,
         tools: [],
         toolChoice: "none",
-        temperature: 0,
+        ...deterministicSamplingOptions(prepared.gateway),
         maxOutputTokens: prepared.maximumOutput,
         messages: prepared.messages
       };

--- a/packages/agent-runtime/src/model-request-policy.ts
+++ b/packages/agent-runtime/src/model-request-policy.ts
@@ -1,0 +1,14 @@
+import type { ModelGateway, ModelRequest } from "agent-protocol";
+
+/**
+ * Request deterministic auxiliary output only when the provider accepts an
+ * explicit temperature. Some reasoning endpoints reject the field instead of
+ * ignoring it, so `false` must omit the property entirely.
+ */
+export function deterministicSamplingOptions(
+  gateway: ModelGateway
+): Partial<Pick<ModelRequest, "temperature">> {
+  return gateway.capabilities.temperatureControl === false
+    ? {}
+    : { temperature: 0 };
+}

--- a/packages/agent-runtime/src/model-summarizer.ts
+++ b/packages/agent-runtime/src/model-summarizer.ts
@@ -20,6 +20,7 @@ import {
   availableModelBudget,
   fitPreparedBudget
 } from "./model-budget-convergence.js";
+import { deterministicSamplingOptions } from "./model-request-policy.js";
 import type { RuntimeSession } from "./types.js";
 
 const SUMMARY_HEADINGS = [
@@ -122,7 +123,7 @@ async function complete(
     messages,
     tools: [],
     toolChoice: "none",
-    temperature: 0,
+    ...deterministicSamplingOptions(gateway),
     maxOutputTokens
   };
   const constrained = gateway as ModelGateway & {

--- a/packages/agent-runtime/src/model-turn-preparation.ts
+++ b/packages/agent-runtime/src/model-turn-preparation.ts
@@ -50,6 +50,17 @@ interface ProjectedModelHistory {
 
 type BudgetedModelTurn = Awaited<ReturnType<typeof prepareBudgetedModelTurn>>;
 
+function contextBudgetExhausted(error: unknown): boolean {
+  return Boolean(error && typeof error === "object"
+    && (error as { code?: unknown }).code === "context_overflow");
+}
+
+function contextBudgetFailure(): PreparedModelAttempt {
+  return { failure: budgetFailure(
+    "The remaining input-token ledger cannot fit mandatory context and the newest user turn."
+  ) };
+}
+
 async function projectedToolHistory(
   options: EffectRunnerOptions,
   session: RuntimeSession,
@@ -152,6 +163,97 @@ async function applyProjectedResourceBoundary(
   return prepared;
 }
 
+async function prepareTerminalContextFallback(
+  options: EffectRunnerOptions,
+  session: RuntimeSession,
+  preparation: TurnPreparationInput
+): Promise<{ prepared: BudgetedModelTurn; available: BudgetAmounts } | undefined> {
+  const available = availableOrchestratorBudget(session);
+  const projection = await projectedModelHistory(options, session);
+  try {
+    const prepared = await prepareBudgetedModelTurn({
+      ...preparation,
+      // The ordinary turn has already failed its provider or aggregate input
+      // boundary. Drop optional repository context and tool schemas, then use
+      // at most one final text-only turn instead of failing without a reply.
+      descriptors: [],
+      dynamic: [],
+      available,
+      history: projection.history,
+      archive: projection.archiveProjection.archive?.item,
+      modelTurnBoundaryStage: "final"
+    });
+    return { prepared, available };
+  } catch (error) {
+    if (contextBudgetExhausted(error)) return undefined;
+    throw error;
+  }
+}
+
+async function prepareOrdinaryModelTurn(
+  options: EffectRunnerOptions,
+  session: RuntimeSession,
+  preparation: TurnPreparationInput,
+  projection: ProjectedModelHistory,
+  available: BudgetAmounts,
+  signal: AbortSignal,
+  summarizer: ModelSummarizer
+): Promise<{ prepared: BudgetedModelTurn; available: BudgetAmounts }> {
+  let prepared = await prepareBudgetedModelTurn(preparation);
+  ({ prepared, available } = await refreshContextArchive({
+    session,
+    preparation,
+    initial: prepared,
+    initialProjection: projection.archiveProjection,
+    available,
+    signal,
+    summarizer,
+    emit: options.emit
+  }));
+  prepared = await applyProjectedResourceBoundary(
+    options, session, preparation, available, prepared
+  );
+  return { prepared, available };
+}
+
+async function fitPreparedModelTurn(
+  options: EffectRunnerOptions,
+  session: RuntimeSession,
+  preparation: TurnPreparationInput,
+  initial: BudgetedModelTurn,
+  initialAvailable: BudgetAmounts,
+  usedTerminalFallback: boolean
+): Promise<PreparedModelAttempt> {
+  let prepared = initial;
+  let available = initialAvailable;
+  let fittedBudget = fitPreparedBudget(
+    prepared.turn.budget,
+    available,
+    Number.MAX_SAFE_INTEGER
+  );
+  if (!fittedBudget && !usedTerminalFallback) {
+    const fallback = await prepareTerminalContextFallback(options, session, preparation);
+    if (fallback) {
+      prepared = fallback.prepared;
+      available = fallback.available;
+      fittedBudget = fitPreparedBudget(
+        prepared.turn.budget,
+        available,
+        Number.MAX_SAFE_INTEGER
+      );
+    }
+  }
+  if (!fittedBudget) {
+    return { failure: budgetFailure(
+      "The hard resource ledger cannot fund another model request after bounded context compaction."
+    ) };
+  }
+  return {
+    turn: { ...prepared.turn, budget: fittedBudget },
+    plan: prepared.plan
+  };
+}
+
 export async function prepareModelAttempt(
   options: EffectRunnerOptions,
   repositoryContext: RepositoryContextProvider,
@@ -201,34 +303,21 @@ export async function prepareModelAttempt(
     history: projected.history,
     archive: projected.archiveProjection.archive?.item
   };
-  let prepared = await prepareBudgetedModelTurn(preparation);
-  ({ prepared, available } = await refreshContextArchive({
-    session,
-    preparation,
-    initial: prepared,
-    initialProjection: projected.archiveProjection,
-    available,
-    signal,
-    summarizer,
-    emit: options.emit
-  }));
-  prepared = await applyProjectedResourceBoundary(
-    options, session, preparation, available, prepared
-  );
-  const fittedBudget = fitPreparedBudget(
-    prepared.turn.budget,
-    available,
-    Number.MAX_SAFE_INTEGER
-  );
-  if (!fittedBudget) {
-    return {
-      failure: budgetFailure(
-        "The hard resource ledger cannot fund another model request after bounded context compaction."
-      )
-    };
+  let prepared: BudgetedModelTurn;
+  let usedTerminalFallback = false;
+  try {
+    ({ prepared, available } = await prepareOrdinaryModelTurn(
+      options, session, preparation, projected, available, signal, summarizer
+    ));
+  } catch (error) {
+    if (!contextBudgetExhausted(error)) throw error;
+    const fallback = await prepareTerminalContextFallback(options, session, preparation);
+    if (!fallback) return contextBudgetFailure();
+    prepared = fallback.prepared;
+    available = fallback.available;
+    usedTerminalFallback = true;
   }
-  return {
-    turn: { ...prepared.turn, budget: fittedBudget },
-    plan: prepared.plan
-  };
+  return await fitPreparedModelTurn(
+    options, session, preparation, prepared, available, usedTerminalFallback
+  );
 }

--- a/packages/agent-runtime/src/reviewer.ts
+++ b/packages/agent-runtime/src/reviewer.ts
@@ -36,6 +36,7 @@ import { aggregateReviewerUsage } from "./reviewer-accounting.js";
 import {
   protocolFailureResponse
 } from "./reviewer-turn-protocol.js";
+import { deterministicSamplingOptions } from "./model-request-policy.js";
 import {
   activeInspectionRequired,
   isVerdictTool,
@@ -196,7 +197,7 @@ export class ModelReviewer implements ReviewerPort {
       signal,
       tools,
       ...(toolChoice ? { toolChoice } : {}),
-      temperature: 0,
+      ...deterministicSamplingOptions(this.gateway),
       maxOutputTokens: prepared.maxOutputTokens,
       messages: requestMessages
     };

--- a/packages/agent-runtime/src/runtime-inspection-control.ts
+++ b/packages/agent-runtime/src/runtime-inspection-control.ts
@@ -11,6 +11,16 @@ import {
 import type { RuntimeControlServiceOptions } from "./runtime-control-contracts.js";
 import type { RuntimeSession } from "./types.js";
 
+function legacyArtifactReference(value: {
+  artifactId: string;
+  name: string;
+  sizeBytes?: number;
+}): string {
+  return [value.artifactId, value.name, value.sizeBytes]
+    .filter((item) => item !== undefined)
+    .join(":");
+}
+
 export class RuntimeInspectionControl {
   constructor(private readonly options: RuntimeControlServiceOptions) {}
 
@@ -108,11 +118,16 @@ export class RuntimeInspectionControl {
       ...session.durable.state.receipts,
       ...session.durable.state.reviewReceipts.map((item) => item.receipt)
     ];
+    const receiptArtifactRefs = receipts.flatMap((receipt) => receipt.artifactRefs ?? []);
     const allowed = new Set(receipts.flatMap((receipt) => [
         ...receipt.artifacts,
         ...(receipt.artifactRefs ?? []).map((item) => item.artifactId)
       ]).concat(lifecycleArtifacts));
-    if (!allowed.has(input.artifactId)) {
+    const artifactId = allowed.has(input.artifactId)
+      ? input.artifactId
+      : receiptArtifactRefs.find((item) =>
+        legacyArtifactReference(item) === input.artifactId)?.artifactId;
+    if (!artifactId) {
       throw Object.assign(
         new Error(
           "Artifact is not referenced by a receipt or runtime lifecycle evidence in the current session."
@@ -121,13 +136,13 @@ export class RuntimeInspectionControl {
       );
     }
     const raw = this.options.readArtifactBytes
-      ? await this.options.readArtifactBytes(session.identity.sessionId, input.artifactId)
-      : Buffer.from(await this.options.readArtifact(session.identity.sessionId, input.artifactId), "utf8");
+      ? await this.options.readArtifactBytes(session.identity.sessionId, artifactId)
+      : Buffer.from(await this.options.readArtifact(session.identity.sessionId, artifactId), "utf8");
     const external = receipts.some((receipt) =>
       receipt.contentTrust === "external_untrusted"
-      && (receipt.artifacts.includes(input.artifactId)
-        || (receipt.artifactRefs ?? []).some((item) => item.artifactId === input.artifactId)));
-    return this.artifactPage(input, Buffer.from(raw), external);
+      && (receipt.artifacts.includes(artifactId)
+        || (receipt.artifactRefs ?? []).some((item) => item.artifactId === artifactId)));
+    return this.artifactPage({ ...input, artifactId }, Buffer.from(raw), external);
   }
 
   private artifactPage(

--- a/packages/agent-tools/src/control-tools.ts
+++ b/packages/agent-tools/src/control-tools.ts
@@ -149,7 +149,7 @@ function readArtifactTool(): RegisteredEffectTool {
   return {
     descriptor: descriptor(
       "read_artifact",
-      "Read a byte range from a large artifact referenced by a receipt in this session. Continue with nextOffset until eof.",
+      "Read a byte range from a large artifact referenced by a receipt in this session. Pass exactly the artifactId field from artifactRefs, without appending its name or size. Continue with nextOffset until eof.",
       {
         artifactId: { type: "string" },
         offsetBytes: { type: "number", minimum: 0 },

--- a/packages/agent-tools/src/lsp-tools.ts
+++ b/packages/agent-tools/src/lsp-tools.ts
@@ -52,7 +52,7 @@ function position(input: Record<string, JsonValue>): LspPosition {
 
 function languageFor(file: string): string {
   return ({
-    ".ts": "typescript", ".tsx": "typescriptreact", ".js": "javascript", ".jsx": "javascriptreact",
+    ".ts": "typescript", ".tsx": "typescriptreact", ".js": "javascript", ".jsx": "javascriptreact", ".mts": "typescript", ".cts": "typescript", ".mjs": "javascript", ".cjs": "javascript",
     ".py": "python", ".rs": "rust", ".go": "go"
   } as Record<string, string>)[path.extname(file).toLowerCase()] ?? "";
 }

--- a/portable/harbor/sigma_harbor_agent.py
+++ b/portable/harbor/sigma_harbor_agent.py
@@ -54,6 +54,9 @@ SUPPORTED_NETWORK_MODES = {"none", "full"}
 MAX_CONTEXT_TEXT_CHARS = 8_192
 MAX_PARTIAL_ARTIFACT_CHARS = 1_048_576
 MAX_TRACE_ARTIFACT_BYTES = 4 * 1_048_576
+TRACE_FLUSH_BYTES = 64 * 1_024
+TRACE_FLUSH_INTERVAL_SECONDS = 0.25
+RECOVERY_SNAPSHOT_INTERVAL_SECONDS = 1.0
 MAX_STREAM_LINE_CHARS = 65_536
 MAX_STREAM_RECORD_BYTES = 16 * 1_048_576
 MAX_CREDENTIAL_BRIDGE_BYTES = 1_048_576
@@ -692,15 +695,27 @@ def _write_utf8_artifact(path: pathlib.Path, value: str) -> None:
 
 
 class _BoundedJsonlWriter:
-    """Append-only JSONL writer with bounded recovery from artifact I/O failures."""
+    """Append-only JSONL writer with bounded, periodically flushed recovery."""
 
-    def __init__(self, path: pathlib.Path, maximum: int, *, reset: bool = False) -> None:
+    def __init__(
+        self,
+        path: pathlib.Path,
+        maximum: int,
+        *,
+        reset: bool = False,
+        flush_bytes: int = TRACE_FLUSH_BYTES,
+        flush_interval_seconds: float = TRACE_FLUSH_INTERVAL_SECONDS,
+    ) -> None:
         self.path = path
         self.maximum = max(0, maximum)
+        self._flush_bytes = max(1, flush_bytes)
+        self._flush_interval_seconds = max(0.0, flush_interval_seconds)
         self._lock = threading.Lock()
         self._pending = bytearray()
         self._write_failures = 0
         self._last_write_error: str | None = None
+        self._last_flush_monotonic = time.monotonic()
+        self._has_flushed_since_init = False
         self.path.parent.mkdir(parents=True, exist_ok=True)
         if reset:
             self.path.unlink(missing_ok=True)
@@ -747,6 +762,8 @@ class _BoundedJsonlWriter:
         for attempt in range(max(1, attempts)):
             try:
                 self._write_pending_once()
+                self._last_flush_monotonic = time.monotonic()
+                self._has_flushed_since_init = True
                 return not self._pending
             except OSError as error:
                 self._record_failure(error)
@@ -777,10 +794,18 @@ class _BoundedJsonlWriter:
             reserve = min(len(marker), self.maximum)
             if logical_size + len(line) <= self.maximum - reserve:
                 self._pending.extend(line)
-                return self._flush_pending()
+                flush_due = (
+                    not self._has_flushed_since_init
+                    or len(self._pending) >= self._flush_bytes
+                    or time.monotonic() - self._last_flush_monotonic
+                    >= self._flush_interval_seconds
+                )
+                return self._flush_pending() if flush_due else True
             if logical_size + len(marker) <= self.maximum:
                 self._pending.extend(marker)
             self.truncated = True
+            # Make the terminal marker observable immediately; subsequent
+            # records are intentionally discarded.
             return self._flush_pending()
 
     def flush(self) -> bool:
@@ -991,6 +1016,12 @@ class _OutputRecorder:
         self.state_path = logs_dir / "runtime.partial.json"
         self._artifact_failures: dict[str, dict[str, Any]] = {}
         self._buffers = {"stdout": "", "stderr": ""}
+        self._stream_snapshot_dirty = {"stdout": False, "stderr": False}
+        self._last_stream_snapshot_monotonic: dict[str, float | None] = {
+            "stdout": None,
+            "stderr": None,
+        }
+        self._last_state_snapshot_monotonic: float | None = None
         self._pending_stdout = ""
         self._stream_chunks: dict[str, dict[str, Any]] = {}
         self._seen: set[tuple[str, ...]] = set()
@@ -1013,7 +1044,10 @@ class _OutputRecorder:
         self._trace_writer = _BoundedJsonlWriter(
             self.trace_path, MAX_TRACE_ARTIFACT_BYTES, reset=True
         )
-        self._write_state()
+        self._write_state(force=True)
+        # The empty initialization snapshot must not delay the first useful
+        # event snapshot.
+        self._last_state_snapshot_monotonic = None
 
     def _record_artifact_failure(self, path: pathlib.Path, error: OSError) -> None:
         key = path.name
@@ -1030,14 +1064,8 @@ class _OutputRecorder:
         self._buffers[stream] = _bounded_utf8_text(
             self._buffers[stream] + (text or ""), MAX_PARTIAL_ARTIFACT_CHARS
         )
-        path = self.stdout_path if stream == "stdout" else self.stderr_path
-        try:
-            _write_utf8_artifact(path, self._buffers[stream])
-        except OSError as error:
-            # Partial stdout/stderr are observational artifacts. The full
-            # bounded buffer remains in memory and the next callback rewrites
-            # it, so a transient host lock must not abort the agent process.
-            self._record_artifact_failure(path, error)
+        self._stream_snapshot_dirty[stream] = True
+        self._write_stream_snapshot(stream)
         if stream == "stdout" and text:
             lines = (self._pending_stdout + text).splitlines(keepends=True)
             self._pending_stdout = ""
@@ -1045,6 +1073,26 @@ class _OutputRecorder:
                 self._pending_stdout = _bounded_text(lines.pop(), MAX_STREAM_LINE_CHARS)
             for line in lines:
                 self._consume_line(line)
+
+    def _write_stream_snapshot(self, stream: str, *, force: bool = False) -> None:
+        if not self._stream_snapshot_dirty[stream]:
+            return
+        now = time.monotonic()
+        previous = self._last_stream_snapshot_monotonic[stream]
+        if (not force and previous is not None
+                and now - previous < RECOVERY_SNAPSHOT_INTERVAL_SECONDS):
+            return
+        # Count attempts, not only successes, so a transient host lock cannot
+        # turn a high-frequency model stream into an artifact retry storm.
+        self._last_stream_snapshot_monotonic[stream] = now
+        path = self.stdout_path if stream == "stdout" else self.stderr_path
+        try:
+            _write_utf8_artifact(path, self._buffers[stream])
+            self._stream_snapshot_dirty[stream] = False
+        except OSError as error:
+            # Partial stdout/stderr are observational artifacts. The bounded
+            # buffer remains in memory and a later or final snapshot retries.
+            self._record_artifact_failure(path, error)
 
     def _consume_line(self, line: str) -> None:
         for value in _decode_stream_line(line, self._stream_chunks):
@@ -1091,12 +1139,12 @@ class _OutputRecorder:
                 self.retry_count += 1
                 self.last_retry = _bounded_event(event)
             self.append_trace(_trace_record(event))
-            self._write_state()
+            self._write_state(force=event_type in TERMINAL_EVENT_TYPES)
             return
         if value.get("kind") == "result" or value.get("type") == "result":
             candidate = value.get("result")
             self.output_result = dict(candidate) if isinstance(candidate, dict) else dict(value)
-            self._write_state()
+            self._write_state(force=True)
             return
         if value.get("kind") == "error":
             error = value.get("error")
@@ -1108,7 +1156,7 @@ class _OutputRecorder:
                 "message": str(error_record.get("message") or "agent CLI returned an error"),
                 **({"failureKind": failure} if failure else {}),
             }
-            self._write_state()
+            self._write_state(force=True)
 
     def append_trace(self, record: dict[str, Any]) -> None:
         self._trace_writer.append(record)
@@ -1125,6 +1173,7 @@ class _OutputRecorder:
 
     def finish_artifacts(self) -> list[str]:
         """Flush recoverable artifact state and return bounded diagnostics."""
+        self.flush_recovery_snapshots()
         self._trace_writer.flush()
         warnings = []
         trace_warning = self._trace_writer.artifact_warning()
@@ -1136,6 +1185,12 @@ class _OutputRecorder:
                 f"last error: {state['last_error']}"
             )
         return warnings
+
+    def flush_recovery_snapshots(self) -> None:
+        """Persist the latest bounded stream and accounting state."""
+        for stream in self._buffers:
+            self._write_stream_snapshot(stream, force=True)
+        self._write_state(force=True)
 
     def snapshot(self) -> dict[str, Any]:
         return {
@@ -1164,7 +1219,13 @@ class _OutputRecorder:
             ),
         }
 
-    def _write_state(self) -> None:
+    def _write_state(self, *, force: bool = False) -> None:
+        now = time.monotonic()
+        if (not force and self._last_state_snapshot_monotonic is not None
+                and now - self._last_state_snapshot_monotonic
+                < RECOVERY_SNAPSHOT_INTERVAL_SECONDS):
+            return
+        self._last_state_snapshot_monotonic = now
         state = self.snapshot()
         try:
             self.state_path.write_text(
@@ -2332,6 +2393,8 @@ printf '{{"pid_recorded":true,"pid":%s,"pgid":%s,"target":"%s","term_status":%s,
         process_cleanup: dict[str, Any] | None = None,
     ) -> tuple[pathlib.Path, pathlib.Path]:
         self.logs_dir.mkdir(parents=True, exist_ok=True)
+        if recorder is not None:
+            recorder.flush_recovery_snapshots()
         stdout = _bounded_utf8_text(_stdout_text(result), MAX_PARTIAL_ARTIFACT_CHARS)
         stderr = _bounded_utf8_text(_stderr_text(result), MAX_PARTIAL_ARTIFACT_CHARS)
         if recorder is not None:
@@ -2460,6 +2523,7 @@ printf '{{"pid_recorded":true,"pid":%s,"pgid":%s,"target":"%s","term_status":%s,
             writer = _BoundedJsonlWriter(trace_path, MAX_TRACE_ARTIFACT_BYTES, reset=True)
             for record in self._trace_records(events, summary):
                 writer.append(record)
+            writer.flush()
         return summary_path, trace_path
 
     def _tarball_from_env(self) -> pathlib.Path | None:

--- a/tests/agent-code-intel.test.ts
+++ b/tests/agent-code-intel.test.ts
@@ -22,6 +22,7 @@ import { codeIntelTool } from "../packages/agent-tools/src/index.js";
 
 class FakeTransport implements LspTransport {
   readonly methods: string[] = [];
+  readonly openedLanguageIds: string[] = [];
   private readonly decoder = new LspFrameDecoder();
   private readonly queued: Uint8Array[] = [];
   private readonly waiters: Array<(value: IteratorResult<Uint8Array>) => void> = [];
@@ -52,7 +53,11 @@ class FakeTransport implements LspTransport {
       }
       if (message.method === "shutdown") this.push({ jsonrpc: "2.0", id: message.id, result: null });
       if (message.method === "textDocument/didOpen") {
-        const uri = (message.params as { textDocument: { uri: string } }).textDocument.uri;
+        const textDocument = (message.params as {
+          textDocument: { uri: string; languageId: string };
+        }).textDocument;
+        const uri = textDocument.uri;
+        this.openedLanguageIds.push(textDocument.languageId);
         this.push({
           jsonrpc: "2.0",
           method: "textDocument/publishDiagnostics",
@@ -230,6 +235,26 @@ describe("agent-code-intel", () => {
     await writeFile(path.join(workspace, "fixture.ts"), "const answer = 43;", "utf8");
     await expect(client.symbols("fixture.ts")).resolves.toEqual([{ name: "answer", kind: 12 }]);
     expect(transport.methods.filter((method) => method === "textDocument/didChange")).toHaveLength(1);
+    await client.close();
+  });
+
+  it("uses JavaScript and TypeScript language IDs for modern module extensions", async () => {
+    const workspace = await mkdtemp(path.join(os.tmpdir(), "sigma-lsp-module-extensions-"));
+    const expected = [
+      ["fixture.mts", "typescript"],
+      ["fixture.cts", "typescript"],
+      ["fixture.mjs", "javascript"],
+      ["fixture.cjs", "javascript"]
+    ] as const;
+    for (const [file] of expected) {
+      await writeFile(path.join(workspace, file), "export const answer = 42;", "utf8");
+    }
+    const transport = new FakeTransport();
+    const client = new LspClient({ rootPath: workspace, transport });
+    for (const [file] of expected) {
+      await expect(client.symbols(file)).resolves.toEqual([{ name: "answer", kind: 12 }]);
+    }
+    expect(transport.openedLanguageIds).toEqual(expected.map(([, language]) => language));
     await client.close();
   });
 
@@ -448,6 +473,33 @@ describe("agent-code-intel", () => {
       expect.objectContaining({ ok: true })
     ]);
     expect(tool.descriptor).toMatchObject({ executionMode: "parallel", resourceKeys: [] });
+    expect(broker.spawnRequests).toHaveLength(1);
+  });
+
+  it("selects the TypeScript server for modern JavaScript and TypeScript modules", async () => {
+    const workspace = await mkdtemp(path.join(os.tmpdir(), "sigma-lsp-module-presets-"));
+    const files = ["fixture.mts", "fixture.cts", "fixture.mjs", "fixture.cjs"];
+    for (const file of files) {
+      await writeFile(path.join(workspace, file), "export const answer = 42;", "utf8");
+    }
+    const broker = new FakeLspBroker();
+    const tool = codeIntelTool({
+      broker,
+      presets: [{
+        id: "typescript", languages: ["typescript", "javascript"], executable: process.execPath,
+        args: ["server.mjs", "--stdio"], source: "configured", available: true
+      }]
+    });
+    const context = {
+      sessionId: "session", runId: "run", workspacePath: workspace, runMode: "analyze" as const,
+      signal: new AbortController().signal, heartbeat() {}, progress: async () => undefined,
+      createArtifact: async () => "artifact"
+    };
+    for (const [index, file] of files.entries()) {
+      await expect(tool.execute({
+        callId: `module-${index}`, name: "lsp", arguments: { operation: "symbols", file }
+      }, context)).resolves.toMatchObject({ ok: true });
+    }
     expect(broker.spawnRequests).toHaveLength(1);
   });
 

--- a/tests/agent-kernel.boundary-branches.test.ts
+++ b/tests/agent-kernel.boundary-branches.test.ts
@@ -274,6 +274,22 @@ describe("agent-kernel boundary contracts", () => {
     expect(content).toContain('"changes"');
     expect(content).toContain("artifactRefs");
     expect(receiptContent(receipt("minimal"))).not.toContain("workspaceDelta");
+
+    const projectedOnce = {
+      ...receipt("structured"),
+      output: JSON.stringify({ status: "updated", revision: 3 }),
+      result: { status: "updated", revision: 3 }
+    };
+    const deduplicated = receiptContent(projectedOnce);
+    expect(deduplicated.match(/"revision":3/gu)).toHaveLength(1);
+    expect(deduplicated).not.toContain('\\"revision\\"');
+
+    const distinct = receiptContent({
+      ...projectedOnce,
+      result: { status: "updated", revision: 4 }
+    });
+    expect(distinct).toContain('"revision":3');
+    expect(distinct).toContain('\\"revision\\":4');
   });
 
   it("projects pending tools and optimistic outcome revisions", () => {

--- a/tests/agent-kernel.coverage.test.ts
+++ b/tests/agent-kernel.coverage.test.ts
@@ -244,7 +244,9 @@ describe("agent-kernel protocol behavior", () => {
     state = settle(state, "write", false, ["filesystem.write"]);
     expect(state.phase).toBe("ready_model");
     expect(state.receipts).toHaveLength(1);
-    expect(state.messages.at(-1)).toMatchObject({ role: "tool", toolCallId: "write" });
+    expect(state.messages.at(-1)).toMatchObject({
+      role: "tool", toolCallId: "write", isError: true
+    });
     expect(state.proposedOutcome).toBeUndefined();
     assertKernelInvariants(state);
   });

--- a/tests/agent-kernel.semantic-failure.test.ts
+++ b/tests/agent-kernel.semantic-failure.test.ts
@@ -77,7 +77,10 @@ describe("model-visible tool receipts", () => {
     const content = receiptContent(parsed!);
     expect(content.length).toBeLessThanOrEqual(12_000);
     expect(content).toContain("receipt output omitted");
-    expect(content).toContain("artifact-1");
+    expect(content).toContain(
+      '"artifactRefs":[{"artifactId":"artifact-1","name":"stdout.log","sizeBytes":123456}]'
+    );
+    expect(content).not.toContain("artifact-1:stdout.log:123456");
     expect(content).toContain("sha256=");
     expect(content).toContain("tail");
   });

--- a/tests/agent-model.routing.test.ts
+++ b/tests/agent-model.routing.test.ts
@@ -935,6 +935,97 @@ describe("capability-aware model routing", () => {
     });
   });
 
+  it("retries one opaque protocol failure on the same model before committed output", async () => {
+    const only = spec("deepseek/a");
+    let completeAttempts = 0;
+    const completeGateway = gateway(only.id, async () => {
+      completeAttempts += 1;
+      if (completeAttempts === 1) {
+        throw Object.assign(new Error("opaque response failure"), {
+          category: "protocol",
+          diagnostics: { doneReceived: false, lastEventType: "error" }
+        });
+      }
+      return response("recovered");
+    });
+    const completeRouter = new ModelRouter(
+      [only],
+      [route({ candidates: [only.id], maxAttempts: 1 })],
+      () => completeGateway,
+      { maxRetriesPerCandidate: 3 }
+    );
+
+    await expect(completeRouter.complete("orchestrator", "main", request()))
+      .resolves.toMatchObject({ attempt: 1, message: { content: "recovered" } });
+    expect(completeAttempts).toBe(2);
+
+    let streamAttempts = 0;
+    const streamGateway: ModelGateway = {
+      ...gateway(only.id, async () => response("unused")),
+      async *stream() {
+        streamAttempts += 1;
+        yield { type: "reasoning", delta: "uncommitted reasoning" } as const;
+        if (streamAttempts === 1) {
+          throw Object.assign(new Error("opaque stream failure"), {
+            category: "protocol",
+            diagnostics: { doneReceived: false, lastEventType: "error" }
+          });
+        }
+        yield { type: "done", response: response("stream recovered") } as const;
+      }
+    };
+    const streamRouter = new ModelRouter(
+      [only],
+      [route({ candidates: [only.id], maxAttempts: 1 })],
+      () => streamGateway,
+      { maxRetriesPerCandidate: 3 }
+    );
+    const events = [];
+    for await (const event of streamRouter.stream("orchestrator", "main", request())) events.push(event);
+    expect(streamAttempts).toBe(2);
+    expect(events.at(-1)).toMatchObject({
+      type: "done",
+      response: { attempt: 1, message: { content: "stream recovered" } }
+    });
+  });
+
+  it("does not retry structured or repeatedly failing protocol responses", async () => {
+    const only = spec("deepseek/a");
+    let structuredAttempts = 0;
+    const structured = new ModelRouter(
+      [only],
+      [route({ candidates: [only.id], maxAttempts: 1 })],
+      () => gateway(only.id, async () => {
+        structuredAttempts += 1;
+        throw Object.assign(new Error("invalid request"), {
+          category: "protocol",
+          diagnostics: { providerErrorCode: "invalid_prompt", httpStatus: 400 }
+        });
+      }),
+      { maxRetriesPerCandidate: 3 }
+    );
+    await expect(structured.complete("orchestrator", "main", request()))
+      .rejects.toMatchObject({ category: "protocol", attempts: 1 });
+    expect(structuredAttempts).toBe(1);
+
+    let opaqueAttempts = 0;
+    const opaque = new ModelRouter(
+      [only],
+      [route({ candidates: [only.id], maxAttempts: 1 })],
+      () => gateway(only.id, async () => {
+        opaqueAttempts += 1;
+        throw Object.assign(new Error("opaque response failure"), {
+          category: "protocol",
+          diagnostics: { doneReceived: false, lastEventType: "error" }
+        });
+      }),
+      { maxRetriesPerCandidate: 3 }
+    );
+    await expect(opaque.complete("orchestrator", "main", request()))
+      .rejects.toMatchObject({ category: "protocol", attempts: 2 });
+    expect(opaqueAttempts).toBe(2);
+  });
+
   it("uses abortable exponential backoff only between same-provider retries", async () => {
     vi.useFakeTimers();
     try {

--- a/tests/agent-model.routing.test.ts
+++ b/tests/agent-model.routing.test.ts
@@ -666,6 +666,51 @@ describe("capability-aware model routing", () => {
     }));
   });
 
+  it("applies approximate tokenizer margin only to locally estimated input", () => {
+    const fits = spec("deepseek/context-fit", {
+      capabilities: { ...capabilities, contextWindowTokens: 1_600, maxOutputTokens: 100 }
+    });
+    const fittingRouter = new ModelRouter(
+      [fits],
+      [route({ candidates: [fits.id], maxAttempts: 1 })],
+      (item) => gateway(item.id, async () => response("ok"))
+    );
+    expect(fittingRouter.resolve("main", {
+      estimatedInputTokens: 1_000,
+      maxOutputTokens: 100
+    }).candidates.map((item) => item.id)).toEqual([fits.id]);
+
+    const tooSmall = spec("deepseek/context-small", {
+      capabilities: { ...capabilities, contextWindowTokens: 1_599, maxOutputTokens: 100 }
+    });
+    const constrainedRouter = new ModelRouter(
+      [tooSmall],
+      [route({ candidates: [tooSmall.id], maxAttempts: 1 })],
+      (item) => gateway(item.id, async () => response("ok"))
+    );
+    try {
+      constrainedRouter.resolve("main", {
+        estimatedInputTokens: 1_000,
+        maxOutputTokens: 100
+      });
+      throw new Error("Expected the undersized context window to be rejected.");
+    } catch (error) {
+      expect(error).toMatchObject({
+        code: "model_route_unavailable",
+        rejected: [expect.objectContaining({
+          modelSpecId: tooSmall.id,
+          reason: "context",
+          detail: expect.stringContaining("1600 tokens")
+        })]
+      });
+    }
+
+    expect(modelReservationEstimate(fits, {
+      estimatedInputTokens: 1_000,
+      maxOutputTokens: 100
+    })).toMatchObject({ inputTokens: 1_500, outputTokens: 150 });
+  });
+
   it("routes image prompts by model-visible cost instead of base64 transport size", async () => {
     const imageModel = spec("deepseek/image", {
       capabilities: {

--- a/tests/agent-pi.api-families.test.ts
+++ b/tests/agent-pi.api-families.test.ts
@@ -234,7 +234,8 @@ function replayMessages(model: PiModel<Api>): ModelMessage[] {
     {
       role: "tool",
       content: "gateway matches",
-      toolCallId: "prior_search"
+      toolCallId: "prior_search",
+      isError: true
     },
     { role: "user", content: "Continue." }
   ];
@@ -265,6 +266,7 @@ function request(model: PiModel<Api>): ModelRequest {
     ],
     toolChoice: "auto",
     maxOutputTokens: 4_096,
+    temperature: 0,
     signal: new AbortController().signal
   };
 }
@@ -338,6 +340,11 @@ describe.each(apiFamilies)("Pi %s API family contract", (api) => {
       "toolResult",
       "user"
     ]);
+    expect(call.context.messages.filter((message) => message.role === "toolResult"))
+      .toEqual([
+        expect.objectContaining({ toolCallId: "prior_read", isError: false }),
+        expect.objectContaining({ toolCallId: "prior_search", isError: true })
+      ]);
     const replay = call.context.messages[1] as AssistantMessage;
     expect(replay).toMatchObject({
       api,
@@ -353,6 +360,12 @@ describe.each(apiFamilies)("Pi %s API family contract", (api) => {
     expect(call.options.maxTokens).toBe(api === "anthropic-messages" ? 16_384 : 4_096);
     expect(call.options.signal).toBeInstanceOf(AbortSignal);
     expect(call.options.toolChoice).toBe("auto");
+    expect(gateway.capabilities.temperatureControl)
+      .toBe(api !== "openai-codex-responses");
+    expect(Object.hasOwn(call.options, "temperature"))
+      .toBe(api !== "openai-codex-responses");
+    expect(call.options.temperature)
+      .toBe(api === "openai-codex-responses" ? undefined : 0);
     expect(call.options.transport).toBe(
       api === "openai-codex-responses" ? "auto" : undefined
     );

--- a/tests/agent-repository-context.test.ts
+++ b/tests/agent-repository-context.test.ts
@@ -391,6 +391,14 @@ describe("host repository context", () => {
       expect(regex.complete).toBe(true);
       expect(regex.matches.map((match) => match.text)).toEqual(["alpha123", "alpha456"]);
 
+      const inlineFlags = await searchRepositoryText(
+        workspace,
+        new AbortController().signal,
+        { query: "(?i)^ALPHA[0-9]+$", regex: true, glob: "src/**/*.ts", limit: 10 }
+      );
+      expect(inlineFlags.matches.map((match) => match.text))
+        .toEqual(["alpha123", "alpha456"]);
+
       const outputLimited = await searchRepositoryText(workspace, new AbortController().signal, {
         query: "alpha",
         maxOutputBytes: 20,

--- a/tests/agent-runtime.control.test.ts
+++ b/tests/agent-runtime.control.test.ts
@@ -42,7 +42,7 @@ function commandEvidence(sessionId: string, runId: string): CommandEvidence {
   };
 }
 
-function receipt(artifactId: string): ToolReceipt {
+function receipt(artifactId: string, sizeBytes?: number): ToolReceipt {
   return {
     callId: "large-output",
     ok: true,
@@ -55,7 +55,8 @@ function receipt(artifactId: string): ToolReceipt {
       artifactId,
       name: "large.txt",
       digest: artifactId,
-      mediaType: "text/plain; charset=utf-8"
+      mediaType: "text/plain; charset=utf-8",
+      ...(sizeBytes === undefined ? {} : { sizeBytes })
     }],
     diagnostics: [],
     evidence: [],
@@ -247,12 +248,19 @@ describe("runtime control tools", () => {
     const content = Buffer.from("你好，Sigma🙂", "utf8");
     const artifactId = createHash("sha256").update(content).digest("hex");
     const session = runtimeSessionFixture();
-    session.durable.state.receipts.push(receipt(artifactId));
+    session.durable.state.receipts.push(receipt(artifactId, content.length));
     const service = new RuntimeControlService({
       readArtifact: async () => content.toString("utf8"),
       readArtifactBytes: async () => content
     } as RuntimeControlServiceOptions);
     const control = service.forSession(session);
+    await expect(control.readArtifact({
+      artifactId: `${artifactId}:large.txt:${content.length}`
+    })).resolves.toMatchObject({
+      artifactId,
+      digest: artifactId,
+      eof: true
+    });
     const pieces: Buffer[] = [];
     let offset: number | undefined;
     do {

--- a/tests/agent-runtime.measured-budget.test.ts
+++ b/tests/agent-runtime.measured-budget.test.ts
@@ -125,6 +125,15 @@ class InspectableGateway implements ModelGateway {
   async countTokens(): Promise<number> { return 100; }
 }
 
+class ToolSchemaHeavyGateway extends InspectableGateway {
+  override async countTokens(
+    _messages: ModelMessage[],
+    tools: ModelToolDefinition[] = []
+  ): Promise<number> {
+    return tools.length > 0 ? 200 : 100;
+  }
+}
+
 function requestInputResponse(): ModelResponse {
   return {
     message: {
@@ -450,6 +459,52 @@ describe("provider-measured model budget settlement", () => {
       type: "run.failed",
       payload: { kind: "recoverable_failure", code: "budget_exhausted" }
     });
+  });
+
+  it("uses a final text-only fallback when tool schemas no longer fit the measured ledger", async () => {
+    const workspace = await mkdtemp(path.join(os.tmpdir(), "sigma-context-fallback-workspace-"));
+    const state = await mkdtemp(path.join(os.tmpdir(), "sigma-context-fallback-state-"));
+    await writeFile(path.join(workspace, "seed.txt"), "seed\n", "utf8");
+    const gateway = new ToolSchemaHeavyGateway([{
+      message: {
+        role: "assistant",
+        content: "I inspected the workspace before the input boundary.",
+        toolCalls: [{
+          id: "read-before-context-fallback",
+          name: "read",
+          arguments: { path: "seed.txt" }
+        }]
+      },
+      finishReason: "tool_calls",
+      usage: measuredUsage(450, 10)
+    }, stopResponse("Completed work preserved at the input boundary.")]);
+    const runtime = createRuntime({
+      gateway,
+      store: new SegmentedJsonlStore({ rootDir: state }),
+      storeRootDir: state,
+      tools: registerBuiltinTools(new EffectToolRegistry()),
+      permissionMode: "auto",
+      outputReserveTokens: 100
+    });
+    const session = await runtime.createSession({ workspacePath: workspace, mode: "analyze" }, {
+      inputTokens: 600, outputTokens: 1_000, costMicroUsd: 10_000_000, modelTurns: 10,
+      toolCalls: 1_000, children: 32, maxDepth: 4
+    });
+    await runtime.command({
+      type: "submit",
+      sessionId: session.sessionId,
+      text: "Inspect the workspace and report the result."
+    });
+
+    await expect(runtime.waitForOutcome(session.sessionId)).resolves.toMatchObject({
+      kind: "completed",
+      message: "Completed work preserved at the input boundary."
+    });
+    expect(gateway.requests).toHaveLength(2);
+    expect(gateway.requests[0]!.tools.length).toBeGreaterThan(0);
+    expect(gateway.requests[1]).toMatchObject({ toolChoice: "none", tools: [] });
+    expect(gateway.requests[1]!.messages.some((message) =>
+      message.content.includes("final model turn allowed"))).toBe(true);
   });
 
   it("continues useful work while an explicit deadline is still live", async () => {

--- a/tests/agent-runtime.model-summarizer.test.ts
+++ b/tests/agent-runtime.model-summarizer.test.ts
@@ -171,6 +171,19 @@ describe("ModelSummarizer", () => {
     expect(test.usage[0]).toMatchObject({ role: "summarizer" });
   });
 
+  it("omits temperature when the provider wire profile rejects that control", async () => {
+    const gateway = new SummaryGateway(summaryContent());
+    gateway.capabilities.temperatureControl = false;
+    const test = harness(gateway);
+    await expect(test.summarizer.summarize(
+      test.session,
+      summaryInput(),
+      new AbortController().signal
+    )).resolves.toBeDefined();
+    expect(gateway.requests).toHaveLength(1);
+    expect(Object.hasOwn(gateway.requests[0]!, "temperature")).toBe(false);
+  });
+
   it("rejects malformed output after one attempt so the caller can fall back", async () => {
     const gateway = new SummaryGateway("A free-form answer without the required sections.");
     const test = harness(gateway);

--- a/tests/test_harbor_agent.py
+++ b/tests/test_harbor_agent.py
@@ -2192,6 +2192,73 @@ class HarborAgentTest(unittest.IsolatedAsyncioTestCase):
                 module.MAX_PARTIAL_ARTIFACT_CHARS,
             )
 
+    async def test_stream_and_state_snapshots_are_coalesced_then_flushed(self):
+        module = import_portable_agent_module()
+        with TemporaryDirectory() as tmp:
+            recorder = module._OutputRecorder(Path(tmp) / "logs")
+            first = {
+                "kind": "event",
+                "event": {
+                    "eventId": "event-1",
+                    "sessionId": "session",
+                    "seq": 1,
+                    "type": "model.reasoning_delta",
+                    "payload": {"delta": "first"},
+                },
+            }
+            second = {
+                "kind": "event",
+                "event": {
+                    "eventId": "event-2",
+                    "sessionId": "session",
+                    "seq": 2,
+                    "type": "model.reasoning_delta",
+                    "payload": {"delta": "second"},
+                },
+            }
+
+            recorder.record(json.dumps(first) + "\n", "stdout")
+            first_stdout = recorder.stdout_path.read_text(encoding="utf-8")
+            first_state = json.loads(recorder.state_path.read_text(encoding="utf-8"))
+            recorder.record(json.dumps(second) + "\n", "stdout")
+
+            self.assertEqual(recorder.stdout_path.read_text(encoding="utf-8"), first_stdout)
+            self.assertEqual(first_state["last_event"]["eventId"], "event-1")
+            self.assertEqual(
+                json.loads(recorder.state_path.read_text(encoding="utf-8"))["last_event"]["eventId"],
+                "event-1",
+            )
+
+            recorder.finish_artifacts()
+            self.assertIn('"eventId": "event-2"', recorder.stdout_path.read_text(encoding="utf-8"))
+            self.assertEqual(
+                json.loads(recorder.state_path.read_text(encoding="utf-8"))["last_event"]["eventId"],
+                "event-2",
+            )
+
+    async def test_high_frequency_stream_uses_bounded_snapshot_writes(self):
+        module = import_portable_agent_module()
+        with TemporaryDirectory() as tmp:
+            writes: list[Path] = []
+            original_write = module._write_utf8_artifact
+
+            def record_write(path: Path, value: str) -> None:
+                writes.append(path)
+                original_write(path, value)
+
+            with patch.object(module, "_write_utf8_artifact", side_effect=record_write):
+                recorder = module._OutputRecorder(Path(tmp) / "logs")
+                for _index in range(100):
+                    recorder.record("stream chunk\n", "stderr")
+                recorder.finish_artifacts()
+
+            stderr_writes = [path for path in writes if path == recorder.stderr_path]
+            self.assertEqual(len(stderr_writes), 2)
+            self.assertEqual(
+                recorder.stderr_path.read_text(encoding="utf-8"),
+                "stream chunk\n" * 100,
+            )
+
     async def test_incremental_trace_is_bounded_and_keeps_stable_prefix(self):
         module = import_portable_agent_module()
         with TemporaryDirectory() as tmp:
@@ -2206,6 +2273,30 @@ class HarborAgentTest(unittest.IsolatedAsyncioTestCase):
             trace_lines = trace_path.read_text(encoding="utf-8").splitlines()
             self.assertTrue(any(json.loads(line).get("type") == "trace_truncated" for line in trace_lines))
             self.assertEqual(json.loads(trace_lines[-1]).get("type"), "trace_truncated")
+
+    async def test_incremental_trace_batches_nonterminal_records_until_flush(self):
+        module = import_portable_agent_module()
+        with TemporaryDirectory() as tmp:
+            trace_path = Path(tmp) / "trace.jsonl"
+            writer = module._BoundedJsonlWriter(
+                trace_path,
+                16_384,
+                reset=True,
+                flush_bytes=16_384,
+                flush_interval_seconds=60,
+            )
+            writer.append({"type": "event", "seq": 0})
+            first_size = trace_path.stat().st_size
+            writer.append({"type": "event", "seq": 1})
+            writer.append({"type": "event", "seq": 2})
+
+            self.assertEqual(trace_path.stat().st_size, first_size)
+            self.assertTrue(writer.flush())
+            records = [
+                json.loads(line)
+                for line in trace_path.read_text(encoding="utf-8").splitlines()
+            ]
+            self.assertEqual([record["seq"] for record in records], [0, 1, 2])
 
     async def test_stream_trace_buffers_transient_host_lock_without_aborting_callback(self):
         module = import_portable_agent_module()


### PR DESCRIPTION
## Summary

This is the conservative, main-based replacement for the earlier #95 implementation.

- rebuild directly from `main` (`da41608`), not from `b2071a4`
- preserve exact tool failure status and artifact capabilities across durable history/provider replay
- retry only one opaque protocol failure on the same model before any semantic output is committed
- omit unsupported temperature fields for the Codex Responses wire profile
- remove only losslessly duplicated receipt result text
- allow one final text-only response only after the ordinary context/resource path cannot fit
- accept the exact pinned packaged sandbox helper while keeping replacement and writable mount collisions fail-closed
- batch Harbor trace/recovery snapshot writes while force-flushing terminal state

The prior branch was 68 files with 2,176 additions / 288 deletions relative to `main`. This rewrite is 23 files with 676 additions / 73 deletions; 285 added lines are regression tests.

## Deliberately removed

The rewrite drops the broad changes that could alter normal solving behavior or inflate cost:

- context-window reservation and route-policy changes
- prompt, repository-context, tool-projection, and strategist changes
- validation/readiness and completion-policy changes
- process polling/default timeout changes
- cost-accounting/reporting expansion
- benchmark runner, release workflow, and documentation changes

No benchmark, task, fixture, verifier, package, or known-output identity is exposed to production code. No verifier result is used for retry or adaptation.

## Conservative behavior boundary

The retained changes either preserve protocol truth, remove exact duplicate bytes, reduce adapter-only disk I/O, or activate only on a path that would otherwise terminate unsuccessfully. Protocol retry is limited to one same-model attempt with no committed semantic output and no structured provider/HTTP error. The terminal context fallback does not restore tools or optional repository context and preserves the typed budget failure if the minimal request still cannot fit.

## Validation

- `pnpm build`
- full Vitest suite: 1,533 passed, 26 skipped
- `python -m unittest tests.test_harbor_agent tests.test_codex_harbor_agent`: 58 passed
- `cargo test --locked --manifest-path native/sigma-exec/Cargo.toml`: 104 passed
- `pnpm lint`
- `pnpm eval:fairness`
- `git diff --check`

A fresh, disjoint Terminal-Bench 2.1 sample will be frozen before execution. The first four tasks are the preregistered stop/go gate; the remainder runs only if that gate shows no clear regression.

## Terminal-Bench 2.1 gate result

A neutral SHA-ranked sample was frozen before execution, disjoint from the immediately preceding PR95 canary and root-fix gate. The candidate archive was pinned to `5763c8ce70451259ac46b91c996ec44e81594b0755d6bea719ea58172`; concurrency, provider/model, sandbox topology, attempts, and retries matched the main baseline controls.

The first-four stop/go gate **failed**:

- main baseline: 3/4 passed
- candidate: 2/4 passed
- one main pass became a candidate failure
- on the two pass-pass tasks, aggregate input tokens were 1.3461× main (frozen maximum: 1.15×)
- comparable provider-reported model records were 1.2759× main
- commands were 1.0976× and duration was 1.1355×
- all four candidate observations were valid; no harness retry occurred

Per the preregistered policy, the remaining eight tasks were not run. This PR remains draft and does **not** currently meet the acceptance condition of matching or improving on main.

Baseline provenance caveat: the archived baseline report records its package SHA but does not cryptographically bind that package to a Git revision. The main attribution is supported by contemporaneous HEAD evidence and by `a0db138` and `da41608` having identical production trees, but it is not a source-attested package proof.