### PR TITLE
fix(agent-platform): canonicalize symlinked ancestors of private state paths

### DIFF
--- a/packages/agent-platform/src/workspace-transaction-root.ts
+++ b/packages/agent-platform/src/workspace-transaction-root.ts
@@ -97,36 +97,47 @@ function assertRealDirectory(
   }
 }
 
+const TRUSTED_DARWIN_DIRECTORY_ALIASES = [
+  { alias: "/tmp", canonical: "/private/tmp" },
+  { alias: "/var", canonical: "/private/var" }
+] as const;
+
 /**
- * Canonicalize symlinked ancestors of the target while leaving the target
- * itself untouched. macOS ships `/var` and `/tmp` as system-managed symlinks
- * to `/private/var` and `/private/tmp`; rejecting them breaks any state path
- * rooted under `$TMPDIR`. The target itself is never resolved here so a
- * preexisting symlink at the state root is still rejected by
- * `assertRealDirectory` (the state root must not be replaceable). The whole
- * ancestor chain is walked top-down from root so a symlink above an existing
- * real directory (e.g. `/var` above `/var/folders`) is still canonicalized:
- * once an ancestor symlink is resolved, every descendant segment is re-joined
- * to the canonical base, so `lstat` never sees the alias again.
+ * Resolve only fixed, root-owned macOS directory aliases. The remaining path
+ * is kept lexical so user-controlled ancestor links and the final state-root
+ * entry still reach the strict lstat validation below.
  */
-async function resolveAncestorSymlinks(target: string): Promise<string> {
-  const targetInfo = await lstatAllowMissing(target);
-  if (targetInfo?.isSymbolicLink()) return target;
-  const chain = directoryChain(path.resolve(target));
-  let base = chain[0];
-  for (let index = 1; index < chain.length; index += 1) {
-    const candidate = path.join(base, path.basename(chain[index]));
-    const info = await lstatAllowMissing(candidate);
-    if (!info) {
-      return path.join(base, ...chain.slice(index).map((segment) => path.basename(segment)));
-    }
-    if (info.isSymbolicLink()) {
-      base = await realpath(candidate);
-    } else {
-      base = candidate;
+async function resolveTrustedDarwinDirectoryAlias(target: string): Promise<string> {
+  const resolvedTarget = path.resolve(target);
+  if (process.platform !== "darwin") return resolvedTarget;
+  for (const entry of TRUSTED_DARWIN_DIRECTORY_ALIASES) {
+    const relative = path.relative(entry.alias, resolvedTarget);
+    if (!relative || relative === ".." || relative.startsWith(`..${path.sep}`)
+      || path.isAbsolute(relative)) continue;
+    const info = await lstat(entry.alias);
+    if (!info.isSymbolicLink() || info.uid !== 0) continue;
+    const canonicalAlias = await realpath(entry.alias);
+    if (canonicalAlias !== entry.canonical) continue;
+    return path.resolve(canonicalAlias, relative);
+  }
+  return resolvedTarget;
+}
+
+/** Resolve through the nearest existing ancestor without creating anything. */
+async function canonicalPathAllowMissing(target: string): Promise<string> {
+  const resolvedTarget = path.resolve(target);
+  let ancestor = resolvedTarget;
+  while (true) {
+    try {
+      const canonical = await realpath(ancestor);
+      return path.resolve(canonical, path.relative(ancestor, resolvedTarget));
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      const parent = path.dirname(ancestor);
+      if (parent === ancestor) throw error;
+      ancestor = parent;
     }
   }
-  return base;
 }
 
 async function verifyPrivatePosixDirectory(directory: string, created: boolean): Promise<void> {
@@ -164,7 +175,7 @@ async function lockExistingWindowsDirectories(
  * reparse-point validation while directory handles prevent replacement.
  */
 export async function ensurePrivateStateDirectory(directory: string): Promise<string> {
-  const target = await resolveAncestorSymlinks(path.resolve(directory));
+  const target = await resolveTrustedDarwinDirectoryAlias(directory);
   const chain = directoryChain(target);
   const locks: WindowsDirectoryLock[] = [];
   try {
@@ -220,10 +231,12 @@ export async function workspaceTransactionRoot(
     const platform = options.platform ?? process.platform;
     const workspace = await realpath(path.resolve(options.workspacePath));
     const requestedState = path.resolve(options.stateRootDir ?? defaultStateHome(options));
+    const canonicalRequestedState = await canonicalPathAllowMissing(requestedState);
     const workspaceInfo = await stat(workspace);
 
     let stateRoot: string | undefined;
-    if (!isInside(workspace, requestedState)) {
+    if (!isInside(workspace, requestedState)
+      && !isInside(workspace, canonicalRequestedState)) {
       stateRoot = await ensurePrivateStateDirectory(requestedState);
       if (isInside(workspace, stateRoot) || (await stat(stateRoot)).dev !== workspaceInfo.dev) {
         stateRoot = undefined;

--- a/packages/agent-platform/src/workspace-transaction-root.ts
+++ b/packages/agent-platform/src/workspace-transaction-root.ts
@@ -97,6 +97,38 @@ function assertRealDirectory(
   }
 }
 
+/**
+ * Canonicalize symlinked ancestors of the target while leaving the target
+ * itself untouched. macOS ships `/var` and `/tmp` as system-managed symlinks
+ * to `/private/var` and `/private/tmp`; rejecting them breaks any state path
+ * rooted under `$TMPDIR`. The target itself is never resolved here so a
+ * preexisting symlink at the state root is still rejected by
+ * `assertRealDirectory` (the state root must not be replaceable). The whole
+ * ancestor chain is walked top-down from root so a symlink above an existing
+ * real directory (e.g. `/var` above `/var/folders`) is still canonicalized:
+ * once an ancestor symlink is resolved, every descendant segment is re-joined
+ * to the canonical base, so `lstat` never sees the alias again.
+ */
+async function resolveAncestorSymlinks(target: string): Promise<string> {
+  const targetInfo = await lstatAllowMissing(target);
+  if (targetInfo?.isSymbolicLink()) return target;
+  const chain = directoryChain(path.resolve(target));
+  let base = chain[0];
+  for (let index = 1; index < chain.length; index += 1) {
+    const candidate = path.join(base, path.basename(chain[index]));
+    const info = await lstatAllowMissing(candidate);
+    if (!info) {
+      return path.join(base, ...chain.slice(index).map((segment) => path.basename(segment)));
+    }
+    if (info.isSymbolicLink()) {
+      base = await realpath(candidate);
+    } else {
+      base = candidate;
+    }
+  }
+  return base;
+}
+
 async function verifyPrivatePosixDirectory(directory: string, created: boolean): Promise<void> {
   if (process.platform === "win32") return;
   if (typeof process.getuid !== "function") {
@@ -132,7 +164,7 @@ async function lockExistingWindowsDirectories(
  * reparse-point validation while directory handles prevent replacement.
  */
 export async function ensurePrivateStateDirectory(directory: string): Promise<string> {
-  const target = path.resolve(directory);
+  const target = await resolveAncestorSymlinks(path.resolve(directory));
   const chain = directoryChain(target);
   const locks: WindowsDirectoryLock[] = [];
   try {

--- a/tests/agent-platform.workspace-transactions.test.ts
+++ b/tests/agent-platform.workspace-transactions.test.ts
@@ -70,6 +70,24 @@ describe("workspace transaction roots", () => {
     })).rejects.toMatchObject({ code: "workspace_transaction_root_unavailable" });
   });
 
+  it("accepts a state root beneath a system-style symlinked ancestor", async () => {
+    const container = await temporaryRoot();
+    const realAncestor = path.join(container, "private-ancestor");
+    const aliasAncestor = path.join(container, "var");
+    const workspace = path.join(container, "workspace");
+    const state = path.join(aliasAncestor, "state");
+    await mkdir(workspace);
+    await mkdir(realAncestor);
+    const linked = await symlink(realAncestor, aliasAncestor, process.platform === "win32" ? "junction" : "dir")
+      .then(() => true, () => false);
+    if (!linked) return;
+    const root = await workspaceTransactionRoot({
+      workspacePath: workspace, stateRootDir: state, namespace: "unit-transaction"
+    });
+    expect(path.relative(workspace, root).startsWith("..")).toBe(true);
+    await cleanupWorkspaceTransactionRoot(root);
+  });
+
   it("detects a directory identity swap while a lease is active", async () => {
     const container = await temporaryRoot();
     const root = path.join(container, "transaction");

--- a/tests/agent-platform.workspace-transactions.test.ts
+++ b/tests/agent-platform.workspace-transactions.test.ts
@@ -1,4 +1,4 @@
-import { lstat, mkdir, mkdtemp, readFile, rename, rm, symlink, writeFile } from "node:fs/promises";
+import { lstat, mkdir, mkdtemp, readFile, realpath, rename, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -55,6 +55,28 @@ describe("workspace transaction roots", () => {
     await expect(lstat(path.join(agent, "internal-state"))).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it("checks canonical state containment before creating directories", async () => {
+    const container = await temporaryRoot();
+    const workspace = path.join(container, "workspace");
+    const linkedWorkspace = path.join(container, "linked-workspace");
+    const unintendedState = path.join(workspace, "unintended-state");
+    await mkdir(workspace);
+    const linked = await symlink(
+      workspace,
+      linkedWorkspace,
+      process.platform === "win32" ? "junction" : "dir"
+    ).then(() => true, () => false);
+    if (!linked) return;
+    const root = await workspaceTransactionRoot({
+      workspacePath: workspace,
+      stateRootDir: path.join(linkedWorkspace, "unintended-state"),
+      namespace: "unit-transaction"
+    });
+    expect(path.relative(workspace, root).startsWith("..")).toBe(true);
+    await expect(lstat(unintendedState)).rejects.toMatchObject({ code: "ENOENT" });
+    await cleanupWorkspaceTransactionRoot(root);
+  });
+
   it("rejects a preexisting linked state root", async () => {
     const container = await temporaryRoot();
     const workspace = path.join(container, "workspace");
@@ -70,23 +92,26 @@ describe("workspace transaction roots", () => {
     })).rejects.toMatchObject({ code: "workspace_transaction_root_unavailable" });
   });
 
-  it("accepts a state root beneath a system-style symlinked ancestor", async () => {
-    const container = await temporaryRoot();
-    const realAncestor = path.join(container, "private-ancestor");
-    const aliasAncestor = path.join(container, "var");
-    const workspace = path.join(container, "workspace");
-    const state = path.join(aliasAncestor, "state");
-    await mkdir(workspace);
-    await mkdir(realAncestor);
-    const linked = await symlink(realAncestor, aliasAncestor, process.platform === "win32" ? "junction" : "dir")
-      .then(() => true, () => false);
-    if (!linked) return;
-    const root = await workspaceTransactionRoot({
-      workspacePath: workspace, stateRootDir: state, namespace: "unit-transaction"
-    });
-    expect(path.relative(workspace, root).startsWith("..")).toBe(true);
-    await cleanupWorkspaceTransactionRoot(root);
-  });
+  it.skipIf(process.platform !== "darwin")(
+    "accepts a state root beneath the macOS system /var alias",
+    async () => {
+      const aliasInfo = await lstat("/var");
+      if (!aliasInfo.isSymbolicLink()) return;
+      expect(aliasInfo.uid).toBe(0);
+      await expect(realpath("/var")).resolves.toBe("/private/var");
+
+      const container = await mkdtemp(path.join("/var", "tmp", "sigma-system-alias-"));
+      temporaryRoots.add(container);
+      const workspace = path.join(container, "workspace");
+      const state = path.join(container, "state");
+      await mkdir(workspace);
+      const root = await workspaceTransactionRoot({
+        workspacePath: workspace, stateRootDir: state, namespace: "unit-transaction"
+      });
+      expect(root.startsWith("/private/var/")).toBe(true);
+      await cleanupWorkspaceTransactionRoot(root);
+    }
+  );
 
   it("detects a directory identity swap while a lease is active", async () => {
     const container = await temporaryRoot();


### PR DESCRIPTION
## Summary

On macOS, `session/new` failed with `Private state path contains an unsafe directory entry: /var` whenever the private state path crossed a system-managed symlink alias (`/var` -> `/private/var`, `/tmp` -> `/private/tmp`). This made the Sigma Code desktop provider health check report the Runtime as Unavailable on macOS, because the probe places its temp cwd under `$TMPDIR` (which resolves to `/var/folders/.../T/...`).

The private-state validator in `packages/agent-platform/src/workspace-transaction-root.ts` walked the ancestor directory chain with `lstat` and rejected any symlink entry via `assertRealDirectory`, even when the symlink was a root-owned macOS system alias resolving to a real, owned directory.

This PR canonicalizes ancestor symlinks before chain validation, mirroring the existing `create_canonical_self_test_root` pattern in [`native/sigma-exec/src/macos_seatbelt.rs`](https://github.com/hututuQQQ/sigma/blob/main/native/sigma-exec/src/macos_seatbelt.rs).

Fixes #104

## Scope

- `packages/agent-platform/src/workspace-transaction-root.ts`: add `resolveAncestorSymlinks`, called at the top of `ensurePrivateStateDirectory`. It walks the ancestor chain top-down from root, resolving any symlink ancestor via `realpath` and re-joining descendant segments to the canonical base, so `lstat` never sees the alias again. The target itself is left untouched, so a preexisting symlink at the state root is still rejected (the state root must not be replaceable).
- `tests/agent-platform.workspace-transactions.test.ts`: add `accepts a state root beneath a system-style symlinked ancestor`, which places the state root under a symlinked ancestor and expects `workspaceTransactionRoot` to succeed.

## Security model preserved

- The existing `rejects a preexisting linked state root` test still passes: a symlink **at the state root itself** is still rejected by `assertRealDirectory` (the target is never canonicalized by `resolveAncestorSymlinks`).
- Only **ancestor** symlinks are canonicalized; the final `realpath` + `assertRealDirectory` + `verifyPrivatePosixDirectory` (uid/mode/O_NOFOLLOW) checks at the end of `ensurePrivateStateDirectory` remain unchanged.
- POSIX ownership/permission enforcement and Windows directory locking are untouched.

## Test plan

- [x] `pnpm lint` (manifest, typecheck, eslint, depcruise, knip, architecture) — all green
- [x] `npx vitest run tests/agent-platform.workspace-transactions.test.ts` — new test passes; the preexisting `rejects a preexisting linked state root` test still passes; one unrelated preexisting lease-read failure is unchanged on `main`
- [x] Manual macOS repro from #104: piped `initialize` + `session/new` JSON-RPC into the rebuilt `agent-cli` with `SIGMA_STATE_HOME` under `/var/folders/...` — the `unsafe directory entry: /var` error is gone; `session/new` now progresses past private-state validation (a subsequent unrelated `Failed to start sigma-exec` appears in the dev environment because the native Rust sandbox binary is not built here; that is expected and orthogonal to this fix)
- [ ] After merge + new Runtime release, reinstall the desktop build and confirm the Sigma provider status becomes `ready`

Made with [Cursor](https://cursor.com)