### PR TITLE
Add inspect-only Harness identity and evaluation foundation

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "eval:experiment": "node scripts/eval/optimization-experiment.mjs",
     "eval:fairness": "node scripts/eval/fairness-scan.mjs",
     "eval:conformance": "node scripts/eval/conformance.mjs",
+    "eval:harness-development": "pnpm build && node scripts/eval/harness-development.mjs",
     "product:readiness": "node scripts/product-readiness-report.mjs",
     "smoke:harbor": "node scripts/run-bash.mjs scripts/smoke-harbor.sh",
     "verify:containment": "cargo build --locked --manifest-path native/sigma-exec/Cargo.toml && node scripts/verify-containment.mjs",

--- a/packages/agent-cli/src/commands/harness.ts
+++ b/packages/agent-cli/src/commands/harness.ts
@@ -1,0 +1,71 @@
+import { createConfiguredRuntime, type RuntimeFactoryDeps } from "agent-runtime";
+import {
+  loadCliConfig,
+  parseArgs,
+  workspaceCustomizationTrustMessage,
+  workspaceMcpTrustMessage
+} from "../config.js";
+
+interface HarnessCommandDeps {
+  stdout?: NodeJS.WritableStream;
+  stderr?: NodeJS.WritableStream;
+  runtimeFactoryDeps?: RuntimeFactoryDeps;
+  createRuntime?: typeof createConfiguredRuntime;
+}
+
+function help(stdout: NodeJS.WritableStream): void {
+  stdout.write(
+    "Usage: sigma harness inspect [--json] [--initial-mode analyze|change] [configuration options]\n"
+  );
+}
+
+export async function runHarnessCommand(
+  argv: string[],
+  deps: HarnessCommandDeps = {}
+): Promise<number> {
+  const stdout = deps.stdout ?? process.stdout;
+  const stderr = deps.stderr ?? process.stderr;
+  const { flags, positionals } = parseArgs(argv);
+  if (flags.help === true) {
+    help(stdout);
+    return 0;
+  }
+  if (positionals.length !== 1 || positionals[0] !== "inspect") {
+    stderr.write("Harness command requires the action 'inspect'.\n");
+    help(stderr);
+    return 1;
+  }
+  const config = loadCliConfig(flags);
+  const trustMessage = workspaceMcpTrustMessage(config)
+    ?? workspaceCustomizationTrustMessage(config);
+  if (trustMessage) {
+    stderr.write(`${trustMessage}\n`);
+    return 2;
+  }
+  const configured = await (deps.createRuntime ?? createConfiguredRuntime)(
+    config,
+    deps.runtimeFactoryDeps,
+    { surface: "cli" }
+  );
+  try {
+    const build = configured.inspectHarness(config.initialMode);
+    if (flags.json === true) {
+      stdout.write(`${JSON.stringify(build)}\n`);
+    } else {
+      stdout.write([
+        `compiler=${build.compilerVersion}`,
+        `activation=${build.activation}`,
+        `runtime_modified=${String(build.modifiesRuntime)}`,
+        `subject=${build.subject.provider}/${build.subject.model}`,
+        `mode=${build.subject.runMode}`,
+        `profile=${build.subject.profileId}`,
+        `policy_packs=${build.policyPackIds.join(",")}`,
+        `initial_tools=${build.toolPolicy.initialTools.join(",")}`,
+        `digest=${build.digest}`
+      ].join("\n") + "\n");
+    }
+    return 0;
+  } finally {
+    await configured.close();
+  }
+}

--- a/packages/agent-cli/src/index.ts
+++ b/packages/agent-cli/src/index.ts
@@ -20,6 +20,7 @@ import { runVersionCommand } from "./commands/version.js";
 import { runAcpCommand } from "./commands/acp.js";
 import { runAuthCommand } from "./commands/auth.js";
 import { runModelsCommand } from "./commands/models.js";
+import { runHarnessCommand } from "./commands/harness.js";
 import {
   loadCliConfig, parseArgs, workspaceCustomizationTrustMessage, workspaceMcpTrustMessage
 } from "./config.js";
@@ -29,6 +30,7 @@ import { configureCredentialBridgeFromEnvironment, configureOutboundProxy } from
 export interface AgentCliMainOptions {
   tuiRunner?: (options: TuiAppOptions) => Promise<void>;
   stderr?: NodeJS.WritableStream;
+  stdout?: NodeJS.WritableStream;
   runtimeFactoryDeps?: RuntimeFactoryDeps;
   runtime?: RuntimeClient;
 }
@@ -109,6 +111,11 @@ async function dispatchCommand(
     });
     case "auth": return await runAuthCommand(argv);
     case "models": return await runModelsCommand(argv);
+    case "harness": return await runHarnessCommand(argv, {
+      runtimeFactoryDeps: options.runtimeFactoryDeps,
+      stdout: options.stdout,
+      stderr: options.stderr
+    });
     case "session": return await runSessionDefinition(definition, argv, options);
     case "replay": return await runReplayCommand(argv, { runtime: options.runtime });
     case "doctor": return await runDoctorCommand(argv, { runtimeFactoryDeps: options.runtimeFactoryDeps });

--- a/packages/agent-config/src/commands.ts
+++ b/packages/agent-config/src/commands.ts
@@ -5,7 +5,7 @@ export interface CommandDefinition {
   aliases?: string[];
   summary: string;
   mode?: RunMode;
-  handler: "run" | "tui" | "acp" | "auth" | "models" | "session" | "replay" | "doctor" | "sandbox" | "version" | "init" | "completion";
+  handler: "run" | "tui" | "acp" | "auth" | "models" | "harness" | "session" | "replay" | "doctor" | "sandbox" | "version" | "init" | "completion";
   sessionAction?: "list" | "cancel" | "resume" | "approve";
 }
 
@@ -16,6 +16,7 @@ export const SIGMA_COMMANDS: readonly CommandDefinition[] = [
   { name: "acp", summary: "Serve ACP v1 over JSON-RPC stdio", handler: "acp" },
   { name: "auth", summary: "Manage model-provider authentication", handler: "auth" },
   { name: "models", summary: "List or refresh model catalogs", handler: "models" },
+  { name: "harness", summary: "Inspect the compiled Harness identity", handler: "harness" },
   { name: "session", summary: "Inspect or resume sessions", handler: "session" },
   { name: "sessions", summary: "List sessions", handler: "session", sessionAction: "list" },
   { name: "cancel", summary: "Cancel an active session", handler: "session", sessionAction: "cancel" },

--- a/packages/agent-runtime/src/configured-runtime-assembly.ts
+++ b/packages/agent-runtime/src/configured-runtime-assembly.ts
@@ -8,7 +8,7 @@ import { connectMcpServers } from "./composition-mcp.js";
 import type { RuntimeMcpHttpServerConfig } from "./composition-mcp.js";
 import { createRuntime } from "./create-runtime.js";
 import { auditDurableChildren } from "./durable-children.js";
-import { brokerRuntimeEnvironment } from "./execution-capabilities.js";
+import { configuredRuntimeEnvironment } from "./execution-capabilities.js";
 import type { RuntimeCustomization } from "./customization.js";
 import type { createRoleGateways } from "./model-composition.js";
 import type { SubjectAttestationContext } from "./subject-attestation.js";
@@ -126,13 +126,7 @@ export function createComposedRuntime(input: {
     execution,
     managedEnvironmentMode: config.managedEnvironmentMode ?? "disabled",
     managedNetworkMode: config.networkMode ?? "full",
-    runtimeEnvironment: {
-      ...brokerRuntimeEnvironment(executionReport),
-      executionMode: config.executionMode ?? "sandboxed",
-      writeScope: config.writeScope ?? "workspace",
-      enclosingContainerAttestationDigest:
-        executionReport.capabilities.enclosingContainerRoot?.attestationDigest
-    },
+    runtimeEnvironment: configuredRuntimeEnvironment(executionReport, config),
     subjectAttestation,
     skills: customization.skills,
     hooks: customization.hookDefinitions,

--- a/packages/agent-runtime/src/configured-runtime-harness.ts
+++ b/packages/agent-runtime/src/configured-runtime-harness.ts
@@ -1,9 +1,11 @@
 import type { ModelReasoningEffort } from "agent-model";
+import type { BrokerDoctorReport } from "agent-execution";
 import type { ModelGateway, RunMode } from "agent-protocol";
 import { isToolAllowed } from "agent-tools";
 import type { RuntimeCustomization } from "./customization.js";
 import type { createConfiguredTools } from "./configured-runtime-tools.js";
 import { modelTools } from "./effect-helpers.js";
+import { configuredRuntimeEnvironment } from "./execution-capabilities.js";
 import {
   compileHarnessBuild,
   type FrozenHarnessBuild,
@@ -33,9 +35,10 @@ export function createConfiguredHarnessInspector(input: {
   customization: RuntimeCustomization;
   tools: ReturnType<typeof createConfiguredTools>;
   gateways: { orchestrator: ModelGateway };
+  executionReport: BrokerDoctorReport;
   options: HarnessInspectionOptions;
 }): (mode: RunMode) => FrozenHarnessBuild {
-  const { config, customization, tools, gateways, options } = input;
+  const { config, customization, tools, gateways, executionReport, options } = input;
   return (mode: RunMode): FrozenHarnessBuild => {
     const profile = customization.profile.profile;
     const sourceDescriptors = tools.modelDescriptors?.() ?? tools.descriptors();
@@ -73,7 +76,8 @@ export function createConfiguredHarnessInspector(input: {
         writeScope: config.writeScope ?? "workspace",
         managedEnvironment: (config.managedEnvironmentMode ?? "disabled") === "required",
         network: config.networkMode ?? "full",
-        interactiveApprovals: options.interactiveApprovals ?? options.surface !== "cli"
+        interactiveApprovals: options.interactiveApprovals ?? options.surface !== "cli",
+        environment: configuredRuntimeEnvironment(executionReport, config)
       },
       resolvedAgentProfile: profile
     });

--- a/packages/agent-runtime/src/configured-runtime-harness.ts
+++ b/packages/agent-runtime/src/configured-runtime-harness.ts
@@ -1,0 +1,81 @@
+import type { ModelReasoningEffort } from "agent-model";
+import type { ModelGateway, RunMode } from "agent-protocol";
+import { isToolAllowed } from "agent-tools";
+import type { RuntimeCustomization } from "./customization.js";
+import type { createConfiguredTools } from "./configured-runtime-tools.js";
+import { modelTools } from "./effect-helpers.js";
+import {
+  compileHarnessBuild,
+  type FrozenHarnessBuild,
+  type HarnessReasoningEffort
+} from "./harness-compiler.js";
+import {
+  projectModelToolDescriptors,
+  sessionSkillProjectionCapabilities
+} from "./model-tool-projection.js";
+import { withReadBatchDescriptor } from "./read-batch-tool.js";
+
+interface HarnessInspectionConfig {
+  reasoningEffort?: ModelReasoningEffort;
+  executionMode?: "sandboxed" | "container";
+  writeScope?: "workspace" | "enclosing-container";
+  managedEnvironmentMode?: "disabled" | "required";
+  networkMode?: "none" | "loopback" | "full";
+}
+
+interface HarnessInspectionOptions {
+  interactiveApprovals?: boolean;
+  surface?: "cli" | "tui" | "acp";
+}
+
+export function createConfiguredHarnessInspector(input: {
+  config: HarnessInspectionConfig;
+  customization: RuntimeCustomization;
+  tools: ReturnType<typeof createConfiguredTools>;
+  gateways: { orchestrator: ModelGateway };
+  options: HarnessInspectionOptions;
+}): (mode: RunMode) => FrozenHarnessBuild {
+  const { config, customization, tools, gateways, options } = input;
+  return (mode: RunMode): FrozenHarnessBuild => {
+    const profile = customization.profile.profile;
+    const sourceDescriptors = tools.modelDescriptors?.() ?? tools.descriptors();
+    const skillCapabilities = sessionSkillProjectionCapabilities({
+      frozenCustomization: { skills: customization.skills.descriptors },
+      profileSkillNames: profile.skills
+    });
+    const capabilities = {
+      ...skillCapabilities,
+      environmentMutationAvailable: mode === "change",
+      processControlsAvailable: false,
+      childControlsAvailable: false,
+      planReadRequired: false
+    };
+    const allowed = sourceDescriptors.filter((descriptor) =>
+      isToolAllowed(descriptor, mode)
+      && !profile.toolDeny.includes(descriptor.name)
+      && (profile.toolAllow === null || profile.toolAllow.includes(descriptor.name))
+    );
+    const projected = projectModelToolDescriptors(
+      withReadBatchDescriptor(projectModelToolDescriptors(allowed, capabilities)),
+      capabilities
+    );
+    const gateway = gateways.orchestrator;
+    return compileHarnessBuild({
+      provider: gateway.provider,
+      model: gateway.model,
+      reasoningEffort: (config.reasoningEffort ?? "provider_default") as HarnessReasoningEffort,
+      modelRole: "orchestrator",
+      runMode: mode,
+      modelCapabilities: gateway.capabilities,
+      runtimeCapabilities: {
+        tools: modelTools(projected),
+        executionMode: config.executionMode ?? "sandboxed",
+        writeScope: config.writeScope ?? "workspace",
+        managedEnvironment: (config.managedEnvironmentMode ?? "disabled") === "required",
+        network: config.networkMode ?? "full",
+        interactiveApprovals: options.interactiveApprovals ?? options.surface !== "cli"
+      },
+      resolvedAgentProfile: profile
+    });
+  };
+}

--- a/packages/agent-runtime/src/configured-runtime.ts
+++ b/packages/agent-runtime/src/configured-runtime.ts
@@ -189,7 +189,7 @@ export async function createConfiguredRuntime(
     });
     runtimeReference.current = runtime;
     const inspectHarness = createConfiguredHarnessInspector({
-      config, customization, tools, gateways, options
+      config, customization, tools, gateways, executionReport, options
     });
     return {
       workspace,

--- a/packages/agent-runtime/src/configured-runtime.ts
+++ b/packages/agent-runtime/src/configured-runtime.ts
@@ -5,7 +5,7 @@ import type {
   WorkspaceCustomizationTrustAttestation,
   WorkspaceMcpTrustAttestation
 } from "agent-config";
-import type { ModelGateway, RuntimeClient } from "agent-protocol";
+import type { ModelGateway, RunMode, RuntimeClient } from "agent-protocol";
 import { loadPiRuntimeModelCatalog } from "agent-model";
 import type { ModelReasoningEffort } from "agent-model";
 import type {
@@ -34,6 +34,8 @@ import { createSubjectAttestationContext, type SubjectProductAttestation } from 
 import { subjectConfiguration } from "./subject-configuration.js";
 import { brokerRuntimeEnvironment } from "./execution-capabilities.js";
 import { createConfiguredTools } from "./configured-runtime-tools.js";
+import type { FrozenHarnessBuild } from "./harness-compiler.js";
+import { createConfiguredHarnessInspector } from "./configured-runtime-harness.js";
 import {
   configuredMcpClients,
   createComposedRuntime,
@@ -102,6 +104,8 @@ export interface ConfiguredRuntime {
   workspace: string;
   storeRootDir: string;
   execution: ExecutionBroker;
+  /** Compile an inspection-only identity for the current, unmodified runtime. */
+  inspectHarness(mode: RunMode): FrozenHarnessBuild;
   close(): Promise<void>;
 }
 export interface RuntimeFactoryOptions {
@@ -184,11 +188,15 @@ export async function createConfiguredRuntime(
       agentProfileHookRunner: deps.agentProfileHookRunner
     });
     runtimeReference.current = runtime;
+    const inspectHarness = createConfiguredHarnessInspector({
+      config, customization, tools, gateways, options
+    });
     return {
       workspace,
       storeRootDir,
       runtime,
       execution,
+      inspectHarness,
       close: async () => await closeComposition(mcpClients, execution)
     };
   } catch (error) {

--- a/packages/agent-runtime/src/execution-capabilities.ts
+++ b/packages/agent-runtime/src/execution-capabilities.ts
@@ -82,3 +82,19 @@ export function brokerRuntimeEnvironment(report: BrokerDoctorReport): RuntimeEnv
     executionCapabilitiesVerified: true
   };
 }
+
+export function configuredRuntimeEnvironment(
+  report: BrokerDoctorReport,
+  config: {
+    executionMode?: "sandboxed" | "container";
+    writeScope?: "workspace" | "enclosing-container";
+  }
+): RuntimeEnvironment {
+  return {
+    ...brokerRuntimeEnvironment(report),
+    executionMode: config.executionMode ?? "sandboxed",
+    writeScope: config.writeScope ?? "workspace",
+    enclosingContainerAttestationDigest:
+      report.capabilities.enclosingContainerRoot?.attestationDigest
+  };
+}

--- a/packages/agent-runtime/src/harness-compiler.ts
+++ b/packages/agent-runtime/src/harness-compiler.ts
@@ -1,0 +1,223 @@
+import { createHash } from "node:crypto";
+import type { ResolvedAgentProfile } from "agent-extensions";
+import type {
+  ModelCapabilities,
+  ModelExecutionRole,
+  ModelToolDefinition,
+  RunMode
+} from "agent-protocol";
+import { baseContext } from "./runtime-context.js";
+
+export const HARNESS_BUILD_SCHEMA_VERSION = 1 as const;
+export const HARNESS_COMPILER_VERSION = "identity-1.0.0";
+
+export type HarnessReasoningEffort =
+  | "provider_default" | "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
+
+export interface HarnessRuntimeCapabilities {
+  /** Exact initial model-visible tool definitions in runtime order. */
+  tools: readonly ModelToolDefinition[];
+  executionMode: "sandboxed" | "container";
+  writeScope: "workspace" | "enclosing-container";
+  managedEnvironment: boolean;
+  network: "none" | "loopback" | "full";
+  interactiveApprovals: boolean;
+}
+
+export interface HarnessCompilerInput {
+  provider: string;
+  model: string;
+  reasoningEffort: HarnessReasoningEffort;
+  modelRole: ModelExecutionRole;
+  runMode: RunMode;
+  modelCapabilities: Readonly<ModelCapabilities>;
+  runtimeCapabilities: Readonly<HarnessRuntimeCapabilities>;
+  resolvedAgentProfile: Readonly<ResolvedAgentProfile>;
+}
+
+export interface FrozenHarnessBuild {
+  schemaVersion: typeof HARNESS_BUILD_SCHEMA_VERSION;
+  compilerVersion: typeof HARNESS_COMPILER_VERSION;
+  policyPackIds: readonly ["sigma.runtime-default.identity.v1"];
+  activation: "inspection_only";
+  modifiesRuntime: false;
+  subject: Readonly<{
+    provider: string;
+    model: string;
+    reasoningEffort: HarnessReasoningEffort;
+    modelRole: ModelExecutionRole;
+    runMode: RunMode;
+    modelCapabilitiesDigest: string;
+    profileId: string;
+    profileDigest: string;
+  }>;
+  promptPolicy: Readonly<{
+    mode: "runtime_default";
+    modifiesPrompt: false;
+    systemBehaviorDigest: string;
+  }>;
+  toolPolicy: Readonly<{
+    mode: "runtime_default";
+    modifiesToolSurface: false;
+    initialTools: readonly string[];
+    initialToolDefinitionsDigest: string;
+  }>;
+  contextPolicy: Readonly<{
+    mode: "runtime_default";
+    modifiesContext: false;
+  }>;
+  observationPolicy: Readonly<{
+    mode: "runtime_default";
+    modifiesObservations: false;
+  }>;
+  runtimeCapabilities: Readonly<Omit<HarnessRuntimeCapabilities, "tools">>;
+  policyDigest: string;
+  canonicalJson: string;
+  digest: string;
+}
+
+const INPUT_KEYS = [
+  "provider",
+  "model",
+  "reasoningEffort",
+  "modelRole",
+  "runMode",
+  "modelCapabilities",
+  "runtimeCapabilities",
+  "resolvedAgentProfile"
+] as const;
+
+const RUNTIME_CAPABILITY_KEYS = [
+  "tools",
+  "executionMode",
+  "writeScope",
+  "managedEnvironment",
+  "network",
+  "interactiveApprovals"
+] as const;
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function jsonValue(value: unknown): unknown {
+  const encoded = JSON.stringify(value);
+  if (encoded === undefined) throw new Error("Harness identity contains a non-JSON value.");
+  return JSON.parse(encoded) as unknown;
+}
+
+export function canonicalHarnessJson(value: unknown): string {
+  const normalized = jsonValue(value);
+  const encode = (item: unknown): string => {
+    if (Array.isArray(item)) return `[${item.map(encode).join(",")}]`;
+    if (item && typeof item === "object") {
+      const record = item as Record<string, unknown>;
+      return `{${Object.keys(record).sort().map((key) =>
+        `${JSON.stringify(key)}:${encode(record[key])}`).join(",")}}`;
+    }
+    return JSON.stringify(item);
+  };
+  return encode(normalized);
+}
+
+function exactKeys(
+  value: object,
+  keys: readonly string[],
+  label: string
+): void {
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(
+      `${label} has an invalid field set (expected ${expected.join(", ")}).`
+    );
+  }
+}
+
+function deepFreeze<T>(value: T): T {
+  if (!value || typeof value !== "object" || Object.isFrozen(value)) return value;
+  for (const item of Object.values(value as Record<string, unknown>)) deepFreeze(item);
+  return Object.freeze(value);
+}
+
+function systemBehaviorDigest(): string {
+  const behavior = baseContext().find((item) => item.id === "system:behavior")?.content;
+  if (!behavior) throw new Error("Sigma runtime behavior context is unavailable.");
+  return sha256(behavior);
+}
+
+/**
+ * Compile a reproducible identity for the unmodified main Harness.
+ *
+ * This build is deliberately inspection-only: `run` does not consume it and
+ * no policy in this artifact may change prompts, tools, context, observations,
+ * admission, or retries. All undeclared data is excluded by the exact input
+ * boundary above.
+ */
+export function compileHarnessBuild(input: HarnessCompilerInput): FrozenHarnessBuild {
+  exactKeys(input, INPUT_KEYS, "Harness compiler input");
+  exactKeys(
+    input.runtimeCapabilities,
+    RUNTIME_CAPABILITY_KEYS,
+    "Harness compiler runtime capabilities"
+  );
+  const modelCapabilitiesDigest = sha256(canonicalHarnessJson(input.modelCapabilities));
+  const profileDigest = sha256(canonicalHarnessJson(input.resolvedAgentProfile));
+  const initialToolDefinitionsDigest = sha256(
+    canonicalHarnessJson(input.runtimeCapabilities.tools)
+  );
+  const policyPackIds = ["sigma.runtime-default.identity.v1"] as const;
+  const promptPolicy = {
+    mode: "runtime_default" as const,
+    modifiesPrompt: false as const,
+    systemBehaviorDigest: systemBehaviorDigest()
+  };
+  const policyDigest = sha256(canonicalHarnessJson({
+    schemaVersion: HARNESS_BUILD_SCHEMA_VERSION,
+    compilerVersion: HARNESS_COMPILER_VERSION as typeof HARNESS_COMPILER_VERSION,
+    policyPackIds,
+    activation: "inspection_only",
+    modifiesRuntime: false,
+    promptPolicy,
+    toolMode: "runtime_default",
+    contextMode: "runtime_default",
+    observationMode: "runtime_default"
+  }));
+  const { tools: _tools, ...runtimeCapabilities } = input.runtimeCapabilities;
+  const stored = {
+    schemaVersion: HARNESS_BUILD_SCHEMA_VERSION,
+    compilerVersion: HARNESS_COMPILER_VERSION as typeof HARNESS_COMPILER_VERSION,
+    policyPackIds,
+    activation: "inspection_only" as const,
+    modifiesRuntime: false as const,
+    subject: {
+      provider: input.provider,
+      model: input.model,
+      reasoningEffort: input.reasoningEffort,
+      modelRole: input.modelRole,
+      runMode: input.runMode,
+      modelCapabilitiesDigest,
+      profileId: input.resolvedAgentProfile.id,
+      profileDigest
+    },
+    promptPolicy,
+    toolPolicy: {
+      mode: "runtime_default" as const,
+      modifiesToolSurface: false as const,
+      initialTools: input.runtimeCapabilities.tools.map((tool) => tool.name),
+      initialToolDefinitionsDigest
+    },
+    contextPolicy: {
+      mode: "runtime_default" as const,
+      modifiesContext: false as const
+    },
+    observationPolicy: {
+      mode: "runtime_default" as const,
+      modifiesObservations: false as const
+    },
+    runtimeCapabilities,
+    policyDigest
+  };
+  const canonicalJson = canonicalHarnessJson(stored);
+  return deepFreeze({ ...stored, canonicalJson, digest: sha256(canonicalJson) });
+}

--- a/packages/agent-runtime/src/harness-compiler.ts
+++ b/packages/agent-runtime/src/harness-compiler.ts
@@ -6,6 +6,7 @@ import type {
   ModelToolDefinition,
   RunMode
 } from "agent-protocol";
+import type { RuntimeEnvironment } from "agent-platform";
 import { baseContext } from "./runtime-context.js";
 
 export const HARNESS_BUILD_SCHEMA_VERSION = 1 as const;
@@ -22,6 +23,8 @@ export interface HarnessRuntimeCapabilities {
   managedEnvironment: boolean;
   network: "none" | "loopback" | "full";
   interactiveApprovals: boolean;
+  /** Exact broker-derived environment used to construct runtime:environment. */
+  environment: Readonly<RuntimeEnvironment>;
 }
 
 export interface HarnessCompilerInput {
@@ -55,6 +58,7 @@ export interface FrozenHarnessBuild {
     mode: "runtime_default";
     modifiesPrompt: false;
     systemBehaviorDigest: string;
+    runtimeEnvironmentDigest: string;
   }>;
   toolPolicy: Readonly<{
     mode: "runtime_default";
@@ -93,7 +97,8 @@ const RUNTIME_CAPABILITY_KEYS = [
   "writeScope",
   "managedEnvironment",
   "network",
-  "interactiveApprovals"
+  "interactiveApprovals",
+  "environment"
 ] as const;
 
 function sha256(value: string): string {
@@ -140,10 +145,20 @@ function deepFreeze<T>(value: T): T {
   return Object.freeze(value);
 }
 
-function systemBehaviorDigest(): string {
-  const behavior = baseContext().find((item) => item.id === "system:behavior")?.content;
-  if (!behavior) throw new Error("Sigma runtime behavior context is unavailable.");
-  return sha256(behavior);
+function promptContextDigests(environment: RuntimeEnvironment): {
+  systemBehaviorDigest: string;
+  runtimeEnvironmentDigest: string;
+} {
+  const context = baseContext(environment);
+  const behavior = context.find((item) => item.id === "system:behavior")?.content;
+  const runtimeEnvironment = context.find((item) => item.id === "runtime:environment")?.content;
+  if (!behavior || !runtimeEnvironment) {
+    throw new Error("Sigma runtime prompt context is unavailable.");
+  }
+  return {
+    systemBehaviorDigest: sha256(behavior),
+    runtimeEnvironmentDigest: sha256(runtimeEnvironment)
+  };
 }
 
 /**
@@ -170,7 +185,7 @@ export function compileHarnessBuild(input: HarnessCompilerInput): FrozenHarnessB
   const promptPolicy = {
     mode: "runtime_default" as const,
     modifiesPrompt: false as const,
-    systemBehaviorDigest: systemBehaviorDigest()
+    ...promptContextDigests(input.runtimeCapabilities.environment)
   };
   const policyDigest = sha256(canonicalHarnessJson({
     schemaVersion: HARNESS_BUILD_SCHEMA_VERSION,

--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -5,6 +5,16 @@ export {
   type RuntimeFactoryOptions
 } from "./configured-runtime.js";
 export type { RuntimeMcpHttpServerConfig } from "./composition-mcp.js";
+export {
+  HARNESS_BUILD_SCHEMA_VERSION,
+  HARNESS_COMPILER_VERSION,
+  canonicalHarnessJson,
+  compileHarnessBuild,
+  type FrozenHarnessBuild,
+  type HarnessCompilerInput,
+  type HarnessReasoningEffort,
+  type HarnessRuntimeCapabilities
+} from "./harness-compiler.js";
 export { configuredExecutionBroker } from "./container-runtime-execution.js";
 export {
   SUBJECT_ATTESTATION_SOURCE,

--- a/packages/agent-runtime/src/testing.ts
+++ b/packages/agent-runtime/src/testing.ts
@@ -14,6 +14,7 @@ export * from "./create-runtime.js";
 export * from "./session-command-bus.js";
 export * from "./restore-session.js";
 export * from "./configured-runtime.js";
+export * from "./harness-compiler.js";
 export * from "./composition-supervision.js";
 export * from "./durable-children.js";
 export * from "./child-workspace-recovery.js";

--- a/scripts/bench-terminal-bench-formal-preregistration.mjs
+++ b/scripts/bench-terminal-bench-formal-preregistration.mjs
@@ -14,6 +14,13 @@ import {
 const SHA256 = /^[a-f0-9]{64}$/u;
 const GIT_COMMIT = /^[a-f0-9]{40}$/u;
 const IDENTIFIER = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/u;
+export const FORMAL_TOKEN_USAGE_PROXY = Object.freeze({
+  id: "uncached_input_plus_output_v1",
+  formula: "max(0,input_tokens-cache_read_tokens)+output_tokens",
+  scope: "all_model_roles",
+  reasoning_accounting: "included_in_output_tokens",
+  provider_cost_fallback: true
+});
 
 function record(value, label) {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
@@ -89,6 +96,26 @@ export function sha256(value) {
     .digest("hex");
 }
 
+export function formalTokenUsageProxy(value) {
+  const usage = record(value, "formal token usage");
+  exactKeys(
+    usage,
+    ["input_tokens", "cache_read_tokens", "output_tokens"],
+    "formal token usage"
+  );
+  for (const [key, amount] of Object.entries(usage)) {
+    if (!Number.isSafeInteger(amount) || amount < 0) {
+      throw new Error(`formal token usage.${key} must be a non-negative safe integer.`);
+    }
+  }
+  const proxy = Math.max(0, usage.input_tokens - usage.cache_read_tokens)
+    + usage.output_tokens;
+  if (!Number.isSafeInteger(proxy)) {
+    throw new Error("Formal token usage proxy exceeds the safe integer range.");
+  }
+  return proxy;
+}
+
 export function formalSourceIdentitySha256(source) {
   return sha256(canonicalJson(source));
 }
@@ -143,6 +170,29 @@ function normalizedSolverControls(value) {
     cleanup_grace_sec: positiveInteger(
       controls.cleanup_grace_sec, "solver_controls.cleanup_grace_sec"
     )
+  };
+}
+
+function normalizedUsageAccounting(value) {
+  const accounting = record(value, "usage_accounting");
+  exactKeys(
+    accounting,
+    ["token_usage_proxy", "gate_precedence"],
+    "usage_accounting"
+  );
+  const proxy = record(accounting.token_usage_proxy, "usage_accounting.token_usage_proxy");
+  exactKeys(
+    proxy,
+    Object.keys(FORMAL_TOKEN_USAGE_PROXY),
+    "usage_accounting.token_usage_proxy"
+  );
+  if (canonicalJson(proxy) !== canonicalJson(FORMAL_TOKEN_USAGE_PROXY)
+    || accounting.gate_precedence !== "provider_cost_usd_then_token_usage_proxy") {
+    throw new Error("usage_accounting must use the registered formal Token usage proxy.");
+  }
+  return {
+    token_usage_proxy: { ...FORMAL_TOKEN_USAGE_PROXY },
+    gate_precedence: "provider_cost_usd_then_token_usage_proxy"
   };
 }
 
@@ -389,7 +439,7 @@ export function sigmaFormalRunPreregistration(draft, options = {}) {
     };
   });
   const payload = {
-    schemaVersion: 1,
+    schemaVersion: 2,
     kind: "SigmaFormalRunPreregistration",
     formal_run_id: identifier(input.formal_run_id, "formal_run_id"),
     source,
@@ -403,6 +453,10 @@ export function sigmaFormalRunPreregistration(draft, options = {}) {
       task_selection_sha256: formalTaskSelectionSha256(tasks)
     },
     solver_controls: normalizedSolverControls(input.solver_controls),
+    usage_accounting: {
+      token_usage_proxy: { ...FORMAL_TOKEN_USAGE_PROXY },
+      gate_precedence: "provider_cost_usd_then_token_usage_proxy"
+    },
     execution: normalizedExecution({ ...executionDraft, batches }, tasks)
   };
   const manifest = {
@@ -416,10 +470,10 @@ export function validateFormalPreregistration(input, options = {}) {
   const manifest = record(input, "formal preregistration");
   exactKeys(manifest, [
     "schemaVersion", "kind", "formal_run_id", "source", "source_identity_sha256",
-    "archive_sha256", "model", "task_selection", "solver_controls", "execution",
+    "archive_sha256", "model", "task_selection", "solver_controls", "usage_accounting", "execution",
     "consumption_identity_sha256"
   ], "formal preregistration");
-  if (manifest.schemaVersion !== 1 || manifest.kind !== "SigmaFormalRunPreregistration") {
+  if (manifest.schemaVersion !== 2 || manifest.kind !== "SigmaFormalRunPreregistration") {
     throw new Error("Formal evaluation requires SigmaFormalRunPreregistration.");
   }
   const source = normalizedSource(manifest.source);
@@ -431,7 +485,7 @@ export function validateFormalPreregistration(input, options = {}) {
     manifest.task_selection, path.resolve(options.baseDir ?? process.cwd())
   );
   const normalized = {
-    schemaVersion: 1,
+    schemaVersion: 2,
     kind: "SigmaFormalRunPreregistration",
     formal_run_id: identifier(manifest.formal_run_id, "formal_run_id"),
     source,
@@ -440,6 +494,7 @@ export function validateFormalPreregistration(input, options = {}) {
     model: normalizedModel(manifest.model),
     task_selection: taskSelection,
     solver_controls: normalizedSolverControls(manifest.solver_controls),
+    usage_accounting: normalizedUsageAccounting(manifest.usage_accounting),
     execution: normalizedExecution(manifest.execution, taskSelection.tasks),
     consumption_identity_sha256: digest(
       manifest.consumption_identity_sha256, "consumption_identity_sha256"

--- a/scripts/bench-terminal-bench-formal.mjs
+++ b/scripts/bench-terminal-bench-formal.mjs
@@ -18,6 +18,7 @@ import {
 import {
   assertFrozenBatchControls,
   canonicalJson,
+  formalTokenUsageProxy,
   loadFormalPreregistration,
   sha256,
   validateFormalPreregistration
@@ -432,6 +433,11 @@ export function aggregateFormalReports(manifest, batchRecords) {
     });
   const status = allBatchesRecorded ? executionComplete ? "complete" : "incomplete" : "running";
   const usage = aggregateNumericObjects(reports, "usage");
+  const tokenUsageProxy = formalTokenUsageProxy({
+    input_tokens: Number(usage.input_tokens ?? 0),
+    cache_read_tokens: Number(usage.cache_read_tokens ?? 0),
+    output_tokens: Number(usage.output_tokens ?? 0)
+  });
   return {
     schemaVersion: 1,
     kind: "SigmaFormalRunReport",
@@ -452,6 +458,13 @@ export function aggregateFormalReports(manifest, batchRecords) {
     failure_categories: aggregateFailureCategories(reports),
     lane_metrics: laneMetrics(tasks, reports[0]?.evaluation_lane ?? null),
     usage,
+    usage_accounting: {
+      ...manifest.usage_accounting,
+      token_usage_proxy: {
+        ...manifest.usage_accounting.token_usage_proxy,
+        value: tokenUsageProxy
+      }
+    },
     cost_usd: sumReports(reports, ["cost_usd"]),
     tasks
   };
@@ -473,6 +486,7 @@ function formalMarkdown(report) {
     `- Verifier reach/pass rate: ${report.lane_metrics.verifier_reached}/${report.lane_metrics.verifier_pass_rate ?? "n/a"}`,
     `- Counts: ${JSON.stringify(report.counts)}`,
     `- Failure categories: ${JSON.stringify(report.failure_categories)}`,
+    `- Token usage proxy (${report.usage_accounting.token_usage_proxy.id}): ${report.usage_accounting.token_usage_proxy.value}`,
     `- Cost USD: ${report.cost_usd}`,
     ""
   ];

--- a/scripts/eval/agent-eval.mjs
+++ b/scripts/eval/agent-eval.mjs
@@ -23,6 +23,10 @@ function evaluationOptions(flags) {
   const repeat = flags.repeat === undefined ? undefined : positiveInteger(flags.repeat, 1, "--repeat");
   return {
     suite: typeof flags.suite === "string" ? flags.suite : "quick",
+    provider: typeof flags.provider === "string" ? flags.provider : undefined,
+    model: typeof flags.model === "string" ? flags.model : undefined,
+    reasoningEffort: typeof flags["reasoning-effort"] === "string"
+      ? flags["reasoning-effort"] : undefined,
     ...(repeat === undefined ? {} : { repeat }),
     scenarios: typeof flags.scenario === "string"
       ? flags.scenario.split(",").map((item) => item.trim()).filter(Boolean) : [],

--- a/scripts/eval/common.mjs
+++ b/scripts/eval/common.mjs
@@ -1,5 +1,6 @@
 import { createHash, randomUUID } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
+import os from "node:os";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -85,6 +86,88 @@ export function loadEvalSecrets(filePath = path.join(rootDir, ".env"), base = pr
   return values;
 }
 
+function validCredential(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  if (value.type === "api_key") {
+    return (value.key === undefined || typeof value.key === "string")
+      && (value.env === undefined || Boolean(value.env && typeof value.env === "object"));
+  }
+  return value.type === "oauth"
+    && typeof value.access === "string"
+    && typeof value.refresh === "string"
+    && typeof value.expires === "number";
+}
+
+function credentialSecretValues(credential) {
+  const candidates = credential.type === "oauth"
+    ? [credential.access, credential.refresh]
+    : [credential.key, ...Object.values(credential.env ?? {})];
+  return candidates.filter((value) => typeof value === "string" && value.length >= 4);
+}
+
+/** Load only the selected provider's access material for an isolated eval
+ * subject. The reduced credential document is written to a disposable home;
+ * the host credential store is never copied wholesale. */
+function deepseekProviderAccess(options) {
+  const base = options.base ?? process.env;
+  const environmentSecrets = loadEvalSecrets(options.envPath, base);
+  return {
+    environmentSecrets,
+    credentialDocument: null,
+    credentialSourcePath: null,
+    secretValues: artifactSecretValues(environmentSecrets, base)
+  };
+}
+
+function evaluationCredentialPath(options) {
+  const base = options.base ?? process.env;
+  const configured = (base.SIGMA_HOST_CREDENTIAL_FILE
+    || base.SIGMA_CREDENTIAL_FILE)?.trim();
+  if (configured && !path.isAbsolute(configured)) {
+    throw new Error("credential_path_invalid: evaluation credential file must be absolute");
+  }
+  return path.resolve(
+    configured || path.join(options.homeDir ?? os.homedir(), ".sigma", "auth.json")
+  );
+}
+
+function storedProviderAccess(provider, options) {
+  const filePath = evaluationCredentialPath(options);
+  let document;
+  try {
+    document = JSON.parse(readFileSync(filePath, "utf8"));
+  } catch (error) {
+    throw new Error(`Evaluation credential store is unavailable at ${filePath}.`, {
+      cause: error
+    });
+  }
+  const credential = document?.version === 1
+    && document.credentials
+    && typeof document.credentials === "object"
+    && !Array.isArray(document.credentials)
+    ? document.credentials[provider]
+    : undefined;
+  if (!validCredential(credential)) {
+    throw new Error(`Evaluation provider '${provider}' is not authenticated in ${filePath}.`);
+  }
+  const credentialDocument = {
+    version: 1,
+    credentials: { [provider]: structuredClone(credential) }
+  };
+  return {
+    environmentSecrets: {},
+    credentialDocument,
+    credentialSourcePath: filePath,
+    secretValues: [...new Set(credentialSecretValues(credential))]
+  };
+}
+
+export function loadEvalProviderAccess(provider, options = {}) {
+  return provider === "deepseek"
+    ? deepseekProviderAccess(options)
+    : storedProviderAccess(provider, options);
+}
+
 const SECRET_ENV_KEY = /(?:api[_-]?key|token|secret|password|passwd|credential|private[_-]?key|authorization|cookie)/iu;
 
 export function artifactSecretValues(subjectSecrets, base = process.env) {
@@ -141,7 +224,9 @@ export function subjectEnvironment({ stateHome, homeDir, tempDir = path.join(hom
     XDG_CONFIG_HOME: path.join(homeDir, ".config"),
     XDG_DATA_HOME: path.join(homeDir, ".local", "share"),
     SIGMA_STATE_HOME: stateHome,
-    DEEPSEEK_API_KEY: secrets.DEEPSEEK_API_KEY,
+    ...(typeof secrets?.DEEPSEEK_API_KEY === "string"
+      ? { DEEPSEEK_API_KEY: secrets.DEEPSEEK_API_KEY }
+      : {}),
     CI: "1",
     NO_COLOR: "1",
     SIGMA_NO_COLOR: "1",

--- a/scripts/eval/common.mjs
+++ b/scripts/eval/common.mjs
@@ -98,7 +98,7 @@ function validCredential(value) {
     && typeof value.expires === "number";
 }
 
-function credentialSecretValues(credential) {
+export function credentialSecretValues(credential) {
   const candidates = credential.type === "oauth"
     ? [credential.access, credential.refresh]
     : [credential.key, ...Object.values(credential.env ?? {})];

--- a/scripts/eval/harness-development.mjs
+++ b/scripts/eval/harness-development.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { runAgentEvalCli } from "./agent-eval.mjs";
+import { parseArgs } from "./common.mjs";
+
+export const HARNESS_DEVELOPMENT_BINDING = Object.freeze({
+  suite: "harness-development",
+  provider: "openai-codex",
+  model: "gpt-5.6-sol",
+  reasoningEffort: "max",
+  repeat: 3,
+  scenarios: Object.freeze([
+    "line-count-readonly",
+    "fix-failing-test",
+    "ambiguity-one-question",
+    "multi-file-change",
+    "already-satisfied-noop",
+    "tool-failure-recovery",
+    "dirty-worktree-preservation",
+    "nested-instructions-unicode",
+    "large-context-lookup",
+    "validation-failure-honesty",
+    "repo-aggregate-total"
+  ])
+});
+
+const ALLOWED_FLAGS = new Set([
+  "run-dir", "eval-root", "env", "subject-workspace", "subject", "skip-package"
+]);
+
+function assertCallerOptions(argv) {
+  const flags = parseArgs(argv[0] === "--" ? argv.slice(1) : argv);
+  const unsupported = [
+    ...flags._,
+    ...Object.keys(flags).filter((key) => key !== "_" && !ALLOWED_FLAGS.has(key))
+  ];
+  if (unsupported.length > 0) {
+    throw new Error(
+      `Harness development controls are frozen; unsupported arguments: ${unsupported.join(", ")}.`
+    );
+  }
+}
+
+export async function runHarnessDevelopmentCli(
+  argv = process.argv.slice(2),
+  deps = {}
+) {
+  assertCallerOptions(argv);
+  const { runAgentEvalCli: injectedRunner, ...evaluationDeps } = deps;
+  const binding = HARNESS_DEVELOPMENT_BINDING;
+  return await (injectedRunner ?? runAgentEvalCli)([
+    ...(argv[0] === "--" ? argv.slice(1) : argv),
+    "--suite", binding.suite,
+    "--provider", binding.provider,
+    "--model", binding.model,
+    "--reasoning-effort", binding.reasoningEffort,
+    "--repeat", String(binding.repeat),
+    "--scenario", binding.scenarios.join(",")
+  ], evaluationDeps);
+}
+
+const isMain = process.argv[1]
+  && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) {
+  runHarnessDevelopmentCli().then((result) => {
+    process.exitCode = result.exitCode;
+  }).catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/eval/runner.mjs
+++ b/scripts/eval/runner.mjs
@@ -4,7 +4,8 @@ import { access, copyFile, cp, lstat, mkdir, readFile, readdir, realpath, rm, wr
 import os from "node:os";
 import path from "node:path";
 import {
-  artifactSecretValues as collectArtifactSecretValues, createRedactor, digest, evalRootDir, fixtureRootDir, loadEvalSecrets,
+  artifactSecretValues as collectArtifactSecretValues, createRedactor, digest, evalRootDir, fixtureRootDir,
+  loadEvalProviderAccess,
   makeRunId, relativeArtifact, rootDir, subjectEnvironment, writeJson
 } from "./common.mjs";
 import { listSessions, readSession, resolveWorkspaceStateRoot } from "./event-store.mjs";
@@ -24,7 +25,7 @@ import {
 import { sigmaManifest } from "../lib/sigma-manifest.mjs";
 
 const DEFAULT_MANIFEST = path.join(fixtureRootDir, "manifest.json");
-let measuredToolchainPromise;
+const measuredToolchainPromises = new Map();
 
 export function packageManagerInvocation(args, options = {}) {
   const platform = options.platform ?? process.platform;
@@ -54,12 +55,14 @@ export async function measureEvaluationToolchain(options = {}) {
     ]);
     const pnpm = parsedVersion(pnpmResult, "pnpm");
     const rust = parsedVersion(rustResult, "rust");
+    const evaluationProvider = options.provider ?? sigmaManifest.evaluation.provider;
+    const evaluationModel = options.model ?? sigmaManifest.evaluation.model;
     const actual = {
       node: process.versions.node,
       pnpm: pnpm.value,
       rust: rust.value,
-      provider: sigmaManifest.evaluation.provider,
-      model: sigmaManifest.evaluation.model,
+      provider: evaluationProvider,
+      model: evaluationModel,
       platform: process.platform,
       arch: process.arch,
       nodeBinaryDigest: digest(nodeBytes)
@@ -68,8 +71,8 @@ export async function measureEvaluationToolchain(options = {}) {
       node: sigmaManifest.toolchains.node,
       pnpm: sigmaManifest.toolchains.pnpm,
       rust: sigmaManifest.toolchains.rust,
-      provider: sigmaManifest.evaluation.provider,
-      model: sigmaManifest.evaluation.model
+      provider: evaluationProvider,
+      model: evaluationModel
     };
     const mismatches = [
       ...(pnpm.error ? [pnpm.error] : []),
@@ -86,8 +89,16 @@ export async function measureEvaluationToolchain(options = {}) {
     };
   };
   if (options.noCache === true) return await perform();
-  measuredToolchainPromise ??= perform();
-  return await measuredToolchainPromise;
+  const cacheKey = JSON.stringify({
+    provider: options.provider ?? sigmaManifest.evaluation.provider,
+    model: options.model ?? sigmaManifest.evaluation.model,
+    platform: process.platform,
+    arch: process.arch
+  });
+  if (!measuredToolchainPromises.has(cacheKey)) {
+    measuredToolchainPromises.set(cacheKey, perform());
+  }
+  return await measuredToolchainPromises.get(cacheKey);
 }
 
 export function resolveEvaluatorHost(platform = process.platform, arch = process.arch) {
@@ -467,11 +478,12 @@ async function appendExternalReport(stateRoot, attempt) {
 
 function subjectConfiguration(context, fixtureSnapshot) {
   const { scenario, subject, sourceGitSha, evaluatorDigest, verifierDigest, frozenRunPolicy,
-    toolchainMeasurement } = context;
+    toolchainMeasurement, provider, model, reasoningEffort } = context;
   const budget = frozenRunPolicy.budget;
   const configuration = {
-    provider: "deepseek",
-    model: sigmaManifest.evaluation.model,
+    provider,
+    model,
+    reasoningEffort,
     surface: scenario.surface,
     permissionPolicy: scenario.permissionPolicy,
     platform: process.platform,
@@ -496,6 +508,7 @@ function subjectConfiguration(context, fixtureSnapshot) {
   configuration.environmentDigest = digest({
     provider: configuration.provider,
     model: configuration.model,
+    reasoningEffort: configuration.reasoningEffort,
     surface: configuration.surface,
     permissionPolicy: configuration.permissionPolicy,
     platform: configuration.platform,
@@ -727,7 +740,9 @@ function invalidateAttempt(attempt, detail) {
 }
 
 async function prepareAttemptExecution(context, deps, lifecycle) {
-  const { scenario, manifestDir, subject, secrets, frozenRunPolicy } = context;
+  const {
+    scenario, manifestDir, subject, secrets, credentialDocument, frozenRunPolicy
+  } = context;
   const { attemptArtifactDir, sandboxRoot } = lifecycle;
   const controllerDir = path.join(sandboxRoot, "controller");
   const stateHome = path.join(sandboxRoot, "state");
@@ -738,6 +753,15 @@ async function prepareAttemptExecution(context, deps, lifecycle) {
     mkdir(attemptArtifactDir, { recursive: true }), mkdir(controllerDir, { recursive: true }),
     mkdir(stateHome, { recursive: true }), mkdir(homeDir, { recursive: true }), mkdir(tempDir, { recursive: true })
   ]);
+  if (credentialDocument) {
+    const credentialDirectory = path.join(homeDir, ".sigma");
+    await mkdir(credentialDirectory, { recursive: true, mode: 0o700 });
+    await writeFile(
+      path.join(credentialDirectory, "auth.json"),
+      `${JSON.stringify(credentialDocument)}\n`,
+      { encoding: "utf8", mode: 0o600 }
+    );
+  }
   const fixtureDirectory = path.resolve(manifestDir, scenario.fixture.workspace);
   const workspace = await seedWorkspace({
     attemptRoot: sandboxRoot,
@@ -783,7 +807,7 @@ async function prepareAttemptExecution(context, deps, lifecycle) {
 }
 
 async function executeAttemptSubject(context, lifecycle, prepared) {
-  const { scenario, subject, redactor } = context;
+  const { scenario, subject, redactor, provider, model, reasoningEffort } = context;
   const { attemptArtifactDir, startedAt } = lifecycle;
   const { runSubject, workspace, stateHome, promptPath, env, controllerDir, driverSpec } = prepared;
   lifecycle.phase = "subject";
@@ -798,7 +822,10 @@ async function executeAttemptSubject(context, lifecycle, prepared) {
       artifactDir: attemptArtifactDir,
       controllerDir,
       redactor,
-      subject
+      subject,
+      provider,
+      model,
+      reasoningEffort
     };
     const result = await runSubject(launcherInput);
     lifecycle.subjectResult = result;
@@ -1227,9 +1254,32 @@ async function scanAttemptSecrets(context, lifecycle, attempt, secretValues) {
 
 async function finalizeAttempt(context, lifecycle, result, secretValues) {
   const { redactor } = context;
+  await persistEvaluationCredential(context, lifecycle);
   await scanAttemptSecrets(context, lifecycle, result.attempt, secretValues);
   await writeJson(path.join(lifecycle.attemptArtifactDir, "attempt.json"), result.attempt, redactor);
   if (result.stateRoot) await appendExternalReport(result.stateRoot, result.attempt);
+}
+
+async function persistEvaluationCredential(context, lifecycle) {
+  if (!context.credentialSourcePath || !context.credentialDocument) return;
+  const isolatedPath = path.join(lifecycle.sandboxRoot, "home", ".sigma", "auth.json");
+  try {
+    const credentialModule = new URL(
+      "../../packages/agent-pi/dist/index.js",
+      import.meta.url
+    ).href;
+    const { FileCredentialStore } = await import(credentialModule);
+    const isolated = new FileCredentialStore({ filePath: isolatedPath });
+    const replacement = await isolated.read(context.provider);
+    if (!replacement) {
+      throw new Error(`Isolated evaluation credential for '${context.provider}' disappeared.`);
+    }
+    const host = new FileCredentialStore({ filePath: context.credentialSourcePath });
+    await host.modify(context.provider, async (current) =>
+      JSON.stringify(current) === JSON.stringify(replacement) ? undefined : replacement);
+  } finally {
+    await rm(isolatedPath, { force: true });
+  }
 }
 
 async function cleanupAttempt(context, lifecycle, attempt) {
@@ -1275,7 +1325,7 @@ async function runAttempt(context, deps = {}) {
 }
 
 async function resolveEvaluationInput(options) {
-  const { suite, subjectKind } = validateEvaluationOptions(options);
+  const { suite, subjectKind, provider, model, reasoningEffort } = validateEvaluationOptions(options);
   const manifestPath = path.resolve(options.manifestPath ?? DEFAULT_MANIFEST);
   const manifestDir = path.dirname(manifestPath);
   const manifest = await loadEvalManifest(manifestPath);
@@ -1287,7 +1337,8 @@ async function resolveEvaluationInput(options) {
   const destination = evaluationDestination(options, runId);
   const runDir = await prepareRunDirectory(destination.destination);
   return {
-    suite, subjectKind, manifestDir, scenarios, repeat, frozenRunPolicy: structuredClone(frozenRunPolicy), runId,
+    suite, subjectKind, provider, model, reasoningEffort,
+    manifestDir, scenarios, repeat, frozenRunPolicy: structuredClone(frozenRunPolicy), runId,
     effectiveEvalRoot: destination.root, runDir
   };
 }
@@ -1302,7 +1353,27 @@ function validateEvaluationOptions(options) {
   if (options.skipPackage && subjectKind !== "package") {
     throw new Error("--skip-package is valid only with --subject package.");
   }
-  return { suite, subjectKind };
+  return { suite, subjectKind, ...evaluationModelSelection(options) };
+}
+
+function evaluationModelSelection(options) {
+  const provider = options.provider ?? sigmaManifest.evaluation.provider;
+  const model = options.model ?? sigmaManifest.evaluation.model;
+  const reasoningEffort = options.reasoningEffort ?? "provider_default";
+  if (typeof provider !== "string" || provider.trim().length === 0
+    || typeof model !== "string" || model.trim().length === 0) {
+    throw new Error("Evaluation provider and model must be non-empty strings.");
+  }
+  if (![
+    "provider_default", "none", "low", "medium", "high", "xhigh", "max"
+  ].includes(reasoningEffort)) {
+    throw new Error("Evaluation reasoning effort is unsupported.");
+  }
+  return {
+    provider: provider.trim(),
+    model: model.trim(),
+    reasoningEffort
+  };
 }
 
 function selectEvaluationScenarios(manifest, suite, requested) {
@@ -1341,16 +1412,29 @@ function evaluationDestination(options, runId) {
 }
 
 async function prepareEvaluationContext(input, options, deps) {
-  const { suite, repeat, scenarios, runDir, manifestDir, frozenRunPolicy } = input;
-  const secrets = deps.secrets ?? loadEvalSecrets(options.envPath);
-  const artifactSecretValues = deps.artifactSecretValues ?? collectArtifactSecretValues(secrets);
+  const {
+    suite, repeat, scenarios, runDir, manifestDir, frozenRunPolicy, provider, model
+  } = input;
+  const providerAccess = deps.providerAccess ?? (deps.secrets
+    ? {
+        environmentSecrets: deps.secrets,
+        credentialDocument: null,
+        credentialSourcePath: null,
+        secretValues: collectArtifactSecretValues(deps.secrets)
+      }
+    : loadEvalProviderAccess(provider, { envPath: options.envPath }));
+  const secrets = providerAccess.environmentSecrets;
+  const artifactSecretValues = deps.artifactSecretValues ?? [...new Set([
+    ...collectArtifactSecretValues(secrets),
+    ...(providerAccess.secretValues ?? [])
+  ])];
   const redactor = createRedactor(artifactSecretValues);
   const sourceGitSha = await gitSha(path.resolve(options.subjectWorkspace ?? rootDir));
   const evaluatorDigest = await evaluatorSourceDigest();
   const verifierDigest = await verifierSourceDigest(manifestDir, scenarios);
   const toolchainMeasurement = deps.measureToolchain
     ? await deps.measureToolchain(options)
-    : await measureEvaluationToolchain();
+    : await measureEvaluationToolchain({ provider, model });
   const schedule = [];
   for (let repetition = 1; repetition <= repeat; repetition += 1) {
     const ordered = [...scenarios].sort((left, right) => digest({ seed: frozenRunPolicy.seed, repetition, id: left.id })
@@ -1374,7 +1458,11 @@ async function prepareEvaluationContext(input, options, deps) {
     attempts: scheduleProjection
   }, redactor);
   return {
-    ...input, secrets, artifactSecretValues, redactor, sourceGitSha, evaluatorDigest, verifierDigest,
+    ...input,
+    secrets,
+    credentialDocument: providerAccess.credentialDocument ?? null,
+    credentialSourcePath: providerAccess.credentialSourcePath ?? null,
+    artifactSecretValues, redactor, sourceGitSha, evaluatorDigest, verifierDigest,
     toolchainMeasurement, schedule, scheduleDigest,
     startedAt: new Date().toISOString()
   };
@@ -1441,12 +1529,16 @@ async function preparationFailureAttempt(context, item, error) {
     manifestDir: context.manifestDir,
     subject: { subjectKind: "unavailable" },
     secrets: context.secrets,
+    credentialDocument: context.credentialDocument,
     artifactSecretValues: context.artifactSecretValues,
     redactor: context.redactor,
     sourceGitSha: context.sourceGitSha,
     evaluatorDigest: context.evaluatorDigest,
     verifierDigest: context.verifierDigest,
     toolchainMeasurement: context.toolchainMeasurement,
+    provider: context.provider,
+    model: context.model,
+    reasoningEffort: context.reasoningEffort,
     frozenRunPolicy: context.frozenRunPolicy
   }, lifecycle, error);
   await writeJson(path.join(lifecycle.attemptArtifactDir, "attempt.json"), attempt, context.redactor);
@@ -1465,8 +1557,11 @@ async function executeEvaluationSchedule(context, preparation, deps, infrastruct
     }
     return attempts;
   }
-  const { schedule, runId, runDir, manifestDir, secrets, artifactSecretValues, redactor,
-    sourceGitSha, evaluatorDigest, verifierDigest, frozenRunPolicy, toolchainMeasurement } = context;
+  const {
+    schedule, runId, runDir, manifestDir, secrets, credentialDocument, credentialSourcePath,
+    artifactSecretValues, redactor, sourceGitSha, evaluatorDigest, verifierDigest,
+    frozenRunPolicy, toolchainMeasurement, provider, model, reasoningEffort
+  } = context;
   if (subject) {
     for (const item of schedule) {
       deps.onProgress?.({ type: "attempt.started", scenarioId: item.scenario.id, repetition: item.repetition });
@@ -1480,13 +1575,18 @@ async function executeEvaluationSchedule(context, preparation, deps, infrastruct
           subject,
           verifierRuntime,
           secrets,
+          credentialDocument,
+          credentialSourcePath,
           artifactSecretValues,
           redactor,
           sourceGitSha,
           evaluatorDigest,
           verifierDigest,
           toolchainMeasurement,
-          frozenRunPolicy
+          frozenRunPolicy,
+          provider,
+          model,
+          reasoningEffort
         }, deps);
         attempts.push(attempt);
         infrastructureErrors.push(...attemptInfrastructureErrors(attempt, item));
@@ -1507,7 +1607,8 @@ async function executeEvaluationSchedule(context, preparation, deps, infrastruct
 
 function rawEvaluationRun(context, subject, verifierRuntime, attempts, infrastructureErrors) {
   const { runId, suite, repeat, startedAt, sourceGitSha, evaluatorDigest, verifierDigest,
-    scenarios, frozenRunPolicy, scheduleDigest, toolchainMeasurement } = context;
+    scenarios, frozenRunPolicy, scheduleDigest, toolchainMeasurement,
+    provider, model, reasoningEffort } = context;
   const firstEnvironmentDigest = attempts[0]?.subject?.environmentDigest ?? null;
   return {
     schemaVersion: 1,
@@ -1521,7 +1622,7 @@ function rawEvaluationRun(context, subject, verifierRuntime, attempts, infrastru
     finishedAt: new Date().toISOString(),
     subject: rawRunSubject(
       subject, verifierRuntime, sourceGitSha, evaluatorDigest, verifierDigest,
-      firstEnvironmentDigest, toolchainMeasurement
+      firstEnvironmentDigest, toolchainMeasurement, provider, model, reasoningEffort
     ),
     scenarios: scenarios.map((scenario) => ({ scenarioId: scenario.id, scenarioDigest: digest(scenario) })),
     attempts,
@@ -1534,10 +1635,19 @@ function subjectValue(subject, key) {
 }
 
 function rawRunSubject(
-  subject, verifierRuntime, sourceGitSha, evaluatorDigest, verifierDigest, environmentDigest, toolchainMeasurement
+  subject,
+  verifierRuntime,
+  sourceGitSha,
+  evaluatorDigest,
+  verifierDigest,
+  environmentDigest,
+  toolchainMeasurement,
+  provider,
+  model,
+  reasoningEffort
 ) {
   return {
-    provider: "deepseek", model: sigmaManifest.evaluation.model,
+    provider, model, reasoningEffort,
     platform: process.platform, arch: process.arch, gitSha: sourceGitSha,
     subjectKind: subjectValue(subject, "subjectKind") ?? "unavailable", surface: "mixed",
     evaluatorDigest, verifierDigest,

--- a/scripts/eval/runner.mjs
+++ b/scripts/eval/runner.mjs
@@ -4,8 +4,8 @@ import { access, copyFile, cp, lstat, mkdir, readFile, readdir, realpath, rm, wr
 import os from "node:os";
 import path from "node:path";
 import {
-  artifactSecretValues as collectArtifactSecretValues, createRedactor, digest, evalRootDir, fixtureRootDir,
-  loadEvalProviderAccess,
+  artifactSecretValues as collectArtifactSecretValues, canonicalJson, createRedactor,
+  credentialSecretValues, digest, evalRootDir, fixtureRootDir, loadEvalProviderAccess,
   makeRunId, relativeArtifact, rootDir, subjectEnvironment, writeJson
 } from "./common.mjs";
 import { listSessions, readSession, resolveWorkspaceStateRoot } from "./event-store.mjs";
@@ -1252,31 +1252,72 @@ async function scanAttemptSecrets(context, lifecycle, attempt, secretValues) {
   for (const file of exposures) addSafetyViolation(attempt, { code: "secret_in_artifact", file });
 }
 
-async function finalizeAttempt(context, lifecycle, result, secretValues) {
+async function finalizeAttempt(context, lifecycle, result, secretValues, deps) {
   const { redactor } = context;
-  await persistEvaluationCredential(context, lifecycle);
+  let credentialFailure;
+  try {
+    await persistEvaluationCredential(context, lifecycle, deps);
+  } catch (error) {
+    credentialFailure = error;
+  }
   await scanAttemptSecrets(context, lifecycle, result.attempt, secretValues);
+  if (credentialFailure) throw credentialFailure;
   await writeJson(path.join(lifecycle.attemptArtifactDir, "attempt.json"), result.attempt, redactor);
   if (result.stateRoot) await appendExternalReport(result.stateRoot, result.attempt);
 }
 
-async function persistEvaluationCredential(context, lifecycle) {
+function credentialsEqual(left, right) {
+  return left !== undefined && right !== undefined
+    && canonicalJson(left) === canonicalJson(right);
+}
+
+function selectedCredentialDocument(provider, credential) {
+  return { version: 1, credentials: { [provider]: structuredClone(credential) } };
+}
+
+function registerCredentialSecrets(context, credential) {
+  for (const value of credentialSecretValues(credential)) {
+    if (!context.artifactSecretValues.includes(value)) context.artifactSecretValues.push(value);
+  }
+}
+
+async function credentialStoreFactory(deps) {
+  if (deps.credentialStoreFactory) return deps.credentialStoreFactory;
+  const credentialModule = new URL(
+    "../../packages/agent-pi/dist/index.js",
+    import.meta.url
+  ).href;
+  const { FileCredentialStore } = await import(credentialModule);
+  return (filePath) => new FileCredentialStore({ filePath });
+}
+
+async function persistEvaluationCredential(context, lifecycle, deps) {
   if (!context.credentialSourcePath || !context.credentialDocument) return;
   const isolatedPath = path.join(lifecycle.sandboxRoot, "home", ".sigma", "auth.json");
   try {
-    const credentialModule = new URL(
-      "../../packages/agent-pi/dist/index.js",
-      import.meta.url
-    ).href;
-    const { FileCredentialStore } = await import(credentialModule);
-    const isolated = new FileCredentialStore({ filePath: isolatedPath });
+    const createCredentialStore = await credentialStoreFactory(deps);
+    const isolated = createCredentialStore(isolatedPath);
     const replacement = await isolated.read(context.provider);
     if (!replacement) {
       throw new Error(`Isolated evaluation credential for '${context.provider}' disappeared.`);
     }
-    const host = new FileCredentialStore({ filePath: context.credentialSourcePath });
-    await host.modify(context.provider, async (current) =>
-      JSON.stringify(current) === JSON.stringify(replacement) ? undefined : replacement);
+    registerCredentialSecrets(context, replacement);
+    const seeded = context.credentialDocument.credentials?.[context.provider];
+    if (!seeded) {
+      throw new Error(`Evaluation credential seed for '${context.provider}' is unavailable.`);
+    }
+    const host = createCredentialStore(context.credentialSourcePath);
+    const accepted = await host.modify(context.provider, async (current) => {
+      if (!credentialsEqual(current, seeded)) return undefined;
+      return credentialsEqual(replacement, seeded) ? undefined : replacement;
+    });
+    if (!accepted) {
+      throw new Error(`Host evaluation credential for '${context.provider}' disappeared.`);
+    }
+    registerCredentialSecrets(context, accepted);
+    if (context.credentialState) {
+      context.credentialState.document = selectedCredentialDocument(context.provider, accepted);
+    }
   } finally {
     await rm(isolatedPath, { force: true });
   }
@@ -1311,7 +1352,7 @@ async function runAttempt(context, deps = {}) {
   try {
     const result = await executeAttemptCoreSafely(context, deps, lifecycle);
     let finalizationError;
-    try { await finalizeAttempt(context, lifecycle, result, secretValues); } catch (error) { finalizationError = error; }
+    try { await finalizeAttempt(context, lifecycle, result, secretValues, deps); } catch (error) { finalizationError = error; }
     cleanupManaged = true;
     const cleanupFailed = await cleanupAttempt(context, lifecycle, result.attempt);
     if (cleanupFailed && !finalizationError) {
@@ -1428,7 +1469,7 @@ async function prepareEvaluationContext(input, options, deps) {
     ...collectArtifactSecretValues(secrets),
     ...(providerAccess.secretValues ?? [])
   ])];
-  const redactor = createRedactor(artifactSecretValues);
+  const redactor = (value) => createRedactor(artifactSecretValues)(value);
   const sourceGitSha = await gitSha(path.resolve(options.subjectWorkspace ?? rootDir));
   const evaluatorDigest = await evaluatorSourceDigest();
   const verifierDigest = await verifierSourceDigest(manifestDir, scenarios);
@@ -1462,6 +1503,9 @@ async function prepareEvaluationContext(input, options, deps) {
     secrets,
     credentialDocument: providerAccess.credentialDocument ?? null,
     credentialSourcePath: providerAccess.credentialSourcePath ?? null,
+    credentialState: providerAccess.credentialDocument
+      ? { document: structuredClone(providerAccess.credentialDocument) }
+      : null,
     artifactSecretValues, redactor, sourceGitSha, evaluatorDigest, verifierDigest,
     toolchainMeasurement, schedule, scheduleDigest,
     startedAt: new Date().toISOString()
@@ -1559,6 +1603,7 @@ async function executeEvaluationSchedule(context, preparation, deps, infrastruct
   }
   const {
     schedule, runId, runDir, manifestDir, secrets, credentialDocument, credentialSourcePath,
+    credentialState,
     artifactSecretValues, redactor, sourceGitSha, evaluatorDigest, verifierDigest,
     frozenRunPolicy, toolchainMeasurement, provider, model, reasoningEffort
   } = context;
@@ -1575,8 +1620,9 @@ async function executeEvaluationSchedule(context, preparation, deps, infrastruct
           subject,
           verifierRuntime,
           secrets,
-          credentialDocument,
+          credentialDocument: credentialState?.document ?? credentialDocument,
           credentialSourcePath,
+          credentialState,
           artifactSecretValues,
           redactor,
           sourceGitSha,

--- a/scripts/eval/subject-cli.mjs
+++ b/scripts/eval/subject-cli.mjs
@@ -136,27 +136,50 @@ function spawnCapture(command, args, options = {}) {
   return { child, exited, getOutput: () => ({ stdout, stderr }) };
 }
 
-async function cancelSession({ sessionId, workspace, env, reason, subject }) {
+async function cancelSession({
+  sessionId,
+  workspace,
+  env,
+  reason,
+  subject,
+  provider = sigmaManifest.evaluation.provider,
+  model = sigmaManifest.evaluation.model,
+  reasoningEffort = "provider_default"
+}) {
   if (!sessionId) return { exitCode: 1, stderr: "Session id was not observed before cancellation." };
   const launch = subjectNodeLaunch(subject);
   const operation = spawnCapture(launch.executablePath, nodeCliArgs([
     "session", "cancel", sessionId,
     "--workspace", workspace,
-    "--provider", "deepseek",
-    "--model", sigmaManifest.evaluation.model,
+    "--provider", provider,
+    "--model", model,
+    ...(reasoningEffort === "provider_default"
+      ? [] : ["--reasoning-effort", reasoningEffort]),
     "--reason", reason
   ], subject), { cwd: workspace, env, timeoutMs: CANCEL_GRACE_MS });
   return await operation.exited;
 }
 
-function startCliSubject({ workspace, stateHome, promptPath, runMode, env, subject }) {
+function startCliSubject({
+  workspace,
+  stateHome,
+  promptPath,
+  runMode,
+  env,
+  subject,
+  provider = sigmaManifest.evaluation.provider,
+  model = sigmaManifest.evaluation.model,
+  reasoningEffort = "provider_default"
+}) {
   const command = runMode === "analyze" ? "inspect" : "run";
   const args = nodeCliArgs([
     command,
     "--workspace", workspace,
     "--prompt-file", promptPath,
-    "--provider", "deepseek",
-    "--model", sigmaManifest.evaluation.model,
+    "--provider", provider,
+    "--model", model,
+    ...(reasoningEffort === "provider_default"
+      ? [] : ["--reasoning-effort", reasoningEffort]),
     "--permission-mode", "auto",
     "--output-format", "stream-json"
   ], subject);
@@ -180,10 +203,16 @@ function startCliSubject({ workspace, stateHome, promptPath, runMode, env, subje
 export async function runCliSubject(options) {
   const {
     workspace, stateHome, promptPath, runMode, env, budget, artifactDir, redactor,
-    onEvent = () => undefined, subject = {}
+    onEvent = () => undefined, subject = {},
+    provider = sigmaManifest.evaluation.provider,
+    model = sigmaManifest.evaluation.model,
+    reasoningEffort = "provider_default"
   } = options;
   await mkdir(artifactDir, { recursive: true });
-  const { child, startedAt } = startCliSubject({ workspace, stateHome, promptPath, runMode, env, subject });
+  const { child, startedAt } = startCliSubject({
+    workspace, stateHome, promptPath, runMode, env, subject,
+    provider, model, reasoningEffort
+  });
   const events = [];
   let result;
   let stdout = "";
@@ -231,7 +260,10 @@ export async function runCliSubject(options) {
       // neutral external-stop request without thresholds, dimensions, scores,
       // or any other evaluation state.
       reason: "External controller requested stop.",
-      subject
+      subject,
+      provider,
+      model,
+      reasoningEffort
     }).then((cancelResult) => {
       cancellation.cancelExitCode = cancelResult.exitCode;
       if (cancelResult.exitCode !== 0 && !treeTerminationPromise) {

--- a/scripts/eval/subject-tui.mjs
+++ b/scripts/eval/subject-tui.mjs
@@ -131,7 +131,11 @@ function tuiRunResult(result, summary, startedAt) {
 export async function runTuiSubject(options) {
   const {
     workspace, stateHome, initialMessage, interactions, permissionPolicy, budget,
-    artifactDir, controllerDir = artifactDir, env, redactor, subject, eventStreamTimeoutMs = 10_000
+    artifactDir, controllerDir = artifactDir, env, redactor, subject,
+    provider = sigmaManifest.evaluation.provider,
+    model = sigmaManifest.evaluation.model,
+    reasoningEffort = "provider_default",
+    eventStreamTimeoutMs = 10_000
   } = options;
   await Promise.all([mkdir(artifactDir, { recursive: true }), mkdir(controllerDir, { recursive: true })]);
   const transcriptPath = path.join(controllerDir, "terminal.transcript.log");
@@ -143,8 +147,10 @@ export async function runTuiSubject(options) {
     command: tuiSubjectCommand(subject, [
       "tui",
       "--workspace", workspace,
-      "--provider", "deepseek",
-      "--model", sigmaManifest.evaluation.model,
+      "--provider", provider,
+      "--model", model,
+      ...(reasoningEffort === "provider_default"
+        ? [] : ["--reasoning-effort", reasoningEffort]),
       "--permission-mode", permissionPolicy === "auto" ? "auto" : "ask"
     ]),
     workspace,

--- a/test-fixtures/agent-evals/manifest.json
+++ b/test-fixtures/agent-evals/manifest.json
@@ -27,6 +27,19 @@
       "schedule": "seeded_round_robin",
       "abOrder": "interleaved_baseline_first"
     },
+    "harness-development": {
+      "schemaVersion": 1,
+      "seed": 20260807,
+      "repeat": 3,
+      "budget": {
+        "wallTimeSec": 600,
+        "modelTurns": 40,
+        "toolCalls": 120,
+        "costUsd": 0.8
+      },
+      "schedule": "seeded_round_robin",
+      "abOrder": "interleaved_baseline_first"
+    },
     "repo-scale": {
       "schemaVersion": 1,
       "seed": 20260714,
@@ -48,7 +61,8 @@
       "title": "Scoped source line count without workspace mutation",
       "suites": [
         "quick",
-        "experience"
+        "experience",
+        "harness-development"
       ],
       "fixture": {
         "workspace": "scenarios/line-count-readonly/workspace",
@@ -212,7 +226,8 @@
       "title": "Diagnose and fix an existing failing test",
       "suites": [
         "quick",
-        "experience"
+        "experience",
+        "harness-development"
       ],
       "fixture": {
         "workspace": "scenarios/fix-failing-test/workspace"
@@ -281,7 +296,8 @@
       "title": "Ask one focused question for a material ambiguity",
       "suites": [
         "quick",
-        "experience"
+        "experience",
+        "harness-development"
       ],
       "fixture": {
         "workspace": "scenarios/ambiguity-one-question/workspace"
@@ -424,7 +440,8 @@
       "id": "multi-file-change",
       "title": "Coordinated implementation and documentation update",
       "suites": [
-        "experience"
+        "experience",
+        "harness-development"
       ],
       "fixture": {
         "workspace": "scenarios/multi-file-change/workspace"
@@ -493,7 +510,8 @@
       "id": "already-satisfied-noop",
       "title": "Recognize an already satisfied request without churn",
       "suites": [
-        "experience"
+        "experience",
+        "harness-development"
       ],
       "fixture": {
         "workspace": "scenarios/already-satisfied-noop/workspace"
@@ -546,7 +564,8 @@
       "id": "tool-failure-recovery",
       "title": "Recover from an unavailable preferred input",
       "suites": [
-        "experience"
+        "experience",
+        "harness-development"
       ],
       "fixture": {
         "workspace": "scenarios/tool-failure-recovery/workspace"
@@ -604,7 +623,8 @@
       "id": "dirty-worktree-preservation",
       "title": "Preserve a user's pre-existing dirty worktree",
       "suites": [
-        "experience"
+        "experience",
+        "harness-development"
       ],
       "fixture": {
         "workspace": "scenarios/dirty-worktree-preservation/workspace",
@@ -670,7 +690,8 @@
       "id": "nested-instructions-unicode",
       "title": "Respect nested instructions and Unicode paths",
       "suites": [
-        "experience"
+        "experience",
+        "harness-development"
       ],
       "fixture": {
         "workspace": "scenarios/nested-instructions-unicode/workspace"
@@ -728,7 +749,8 @@
       "id": "large-context-lookup",
       "title": "Find one fact in a large file without repeated full reads",
       "suites": [
-        "experience"
+        "experience",
+        "harness-development"
       ],
       "fixture": {
         "workspace": "scenarios/large-context-lookup/workspace"
@@ -786,7 +808,8 @@
       "id": "validation-failure-honesty",
       "title": "Report a validation failure without claiming success",
       "suites": [
-        "experience"
+        "experience",
+        "harness-development"
       ],
       "fixture": {
         "workspace": "scenarios/validation-failure-honesty/workspace"
@@ -863,7 +886,8 @@
     {
       "schemaVersion": 1,
       "suites": [
-        "repo-scale"
+        "repo-scale",
+        "harness-development"
       ],
       "fixture": {
         "workspace": "scenarios/repo-scale-aggregate/workspace",

--- a/tests/agent-cli.commands.coverage.test.ts
+++ b/tests/agent-cli.commands.coverage.test.ts
@@ -17,6 +17,7 @@ import type {
 } from "../packages/agent-protocol/src/index.js";
 import { runAgentCommand } from "../packages/agent-cli/src/index.js";
 import { runInitCommand } from "../packages/agent-cli/src/commands/init.js";
+import { runHarnessCommand } from "../packages/agent-cli/src/commands/harness.js";
 import { runReplayCommand } from "../packages/agent-cli/src/commands/replay.js";
 import { runSessionCommand, runSessionsCommand } from "../packages/agent-cli/src/commands/session.js";
 import type { ConfiguredRuntime } from "../packages/agent-runtime/src/index.js";
@@ -112,6 +113,7 @@ function configuredComposition(
     workspace: root,
     storeRootDir: root,
     execution: {} as ConfiguredRuntime["execution"],
+    inspectHarness: () => { throw new Error("Harness inspection was not configured."); },
     close
   };
 }
@@ -122,6 +124,69 @@ afterEach(() => {
 });
 
 describe("CLI init and replay branches", () => {
+  it("inspects a frozen Harness identity without creating or running a session", async () => {
+    const root = await workspace("sigma-harness-inspect-");
+    const stdout = new Capture();
+    const close = vi.fn(async () => undefined);
+    const build = {
+      schemaVersion: 1,
+      compilerVersion: "identity-1.0.0",
+      policyPackIds: ["sigma.runtime-default.identity.v1"],
+      activation: "inspection_only",
+      modifiesRuntime: false,
+      subject: {
+        provider: "fixture",
+        model: "fixture-model",
+        reasoningEffort: "max",
+        modelRole: "orchestrator",
+        runMode: "change",
+        modelCapabilitiesDigest: "a".repeat(64),
+        profileId: "standard",
+        profileDigest: "b".repeat(64)
+      },
+      promptPolicy: {
+        mode: "runtime_default",
+        modifiesPrompt: false,
+        systemBehaviorDigest: "c".repeat(64)
+      },
+      toolPolicy: {
+        mode: "runtime_default",
+        modifiesToolSurface: false,
+        initialTools: ["read"],
+        initialToolDefinitionsDigest: "d".repeat(64)
+      },
+      contextPolicy: { mode: "runtime_default", modifiesContext: false },
+      observationPolicy: { mode: "runtime_default", modifiesObservations: false },
+      runtimeCapabilities: {
+        executionMode: "sandboxed",
+        writeScope: "workspace",
+        managedEnvironment: false,
+        network: "full",
+        interactiveApprovals: false
+      },
+      policyDigest: "e".repeat(64),
+      canonicalJson: "{}",
+      digest: "f".repeat(64)
+    } as const;
+    const createRuntime = vi.fn(async () => ({
+      inspectHarness: vi.fn(() => build),
+      close
+    }));
+
+    await expect(runHarnessCommand([
+      "inspect", "--json", "--workspace", root,
+      "--provider", "fixture", "--model", "fixture-model",
+      "--reasoning-effort", "max"
+    ], {
+      stdout,
+      createRuntime: createRuntime as never
+    })).resolves.toBe(0);
+
+    expect(JSON.parse(stdout.text())).toEqual(build);
+    expect(createRuntime).toHaveBeenCalledOnce();
+    expect(close).toHaveBeenCalledOnce();
+  });
+
   it("prints init help and handles profiles, JSON, force, and existing files", async () => {
     const root = await workspace("sigma-init-coverage-");
     const help = new Capture();
@@ -469,6 +534,7 @@ describe("CLI command registry dispatch", () => {
     await expect(runAgentCommand(["cancel", "--help"])).resolves.toBe(0);
     await expect(runAgentCommand(["replay", "--help"])).resolves.toBe(0);
     await expect(runAgentCommand(["doctor", "--help"])).resolves.toBe(0);
+    await expect(runAgentCommand(["harness", "--help"])).resolves.toBe(0);
     await expect(runAgentCommand(["init", "--help"])).resolves.toBe(0);
     await expect(runAgentCommand(["version"])).resolves.toBe(0);
     expect(stdout).toHaveBeenCalled();

--- a/tests/agent-cli.commands.coverage.test.ts
+++ b/tests/agent-cli.commands.coverage.test.ts
@@ -147,7 +147,8 @@ describe("CLI init and replay branches", () => {
       promptPolicy: {
         mode: "runtime_default",
         modifiesPrompt: false,
-        systemBehaviorDigest: "c".repeat(64)
+        systemBehaviorDigest: "c".repeat(64),
+        runtimeEnvironmentDigest: "e".repeat(64)
       },
       toolPolicy: {
         mode: "runtime_default",
@@ -162,7 +163,19 @@ describe("CLI init and replay branches", () => {
         writeScope: "workspace",
         managedEnvironment: false,
         network: "full",
-        interactiveApprovals: false
+        interactiveApprovals: false,
+        environment: {
+          platform: "linux",
+          arch: "x64",
+          defaultShell: "bash",
+          availableShells: ["bash"],
+          availableRuntimeCommands: [],
+          executionCapabilitiesVerified: true,
+          directExecutableResolution: true,
+          executionMode: "sandboxed",
+          writeScope: "workspace",
+          pathSeparator: "/"
+        }
       },
       policyDigest: "e".repeat(64),
       canonicalJson: "{}",

--- a/tests/agent-eval-runner.test.ts
+++ b/tests/agent-eval-runner.test.ts
@@ -42,6 +42,29 @@ function successfulEvents(): Record<string, unknown>[] {
   ];
 }
 
+function jsonCredentialStore(filePath: string) {
+  return {
+    read: async (provider: string) => {
+      const document = JSON.parse(await readFile(filePath, "utf8"));
+      return document.credentials?.[provider];
+    },
+    modify: async (
+      provider: string,
+      update: (current: Record<string, unknown> | undefined) => Promise<Record<string, unknown> | undefined>
+    ) => {
+      const document = JSON.parse(await readFile(filePath, "utf8"));
+      const current = document.credentials?.[provider];
+      const replacement = await update(current);
+      if (replacement !== undefined) {
+        document.credentials[provider] = replacement;
+        await writeFile(filePath, `${JSON.stringify(document)}\n`, "utf8");
+        return replacement;
+      }
+      return current;
+    }
+  };
+}
+
 async function manifest(options: {
   verifierPass?: boolean;
   verifierCrash?: boolean;
@@ -262,6 +285,89 @@ describe("agent experience evaluation runner", () => {
       reasoningEffort: "max"
     });
     expect(await readFile(result.runPath, "utf8")).not.toContain("test-secret-value-12345");
+  });
+
+  it("CAS-persists credential refreshes, preserves concurrent logins, and advances later attempts", async () => {
+    const fixture = await manifest({ repeat: 3 });
+    const runDir = path.join(fixture.root, "credential-artifacts");
+    const hostPath = path.join(fixture.root, "host-auth.json");
+    const provider = "openai-codex";
+    const seed = {
+      type: "oauth", access: "seed-access-credential", refresh: "seed-refresh-credential", expires: 1
+    };
+    const acceptedRefresh = {
+      type: "oauth", access: "accepted-access-credential", refresh: "accepted-refresh-credential", expires: 2
+    };
+    const supersededRefresh = {
+      type: "oauth", access: "superseded-access-credential", refresh: "superseded-refresh-credential", expires: 3
+    };
+    const concurrentLogin = {
+      type: "oauth", access: "concurrent-access-credential", refresh: "concurrent-refresh-credential", expires: 4
+    };
+    await writeFile(hostPath, `${JSON.stringify({
+      version: 1,
+      credentials: { [provider]: seed, unrelated: { type: "api_key", key: "keep-unrelated" } }
+    })}\n`, "utf8");
+    const observed: Array<Record<string, unknown>> = [];
+
+    const result = await runEvaluation({
+      suite: "quick",
+      repeat: 3,
+      manifestPath: fixture.manifestPath,
+      runDir,
+      provider,
+      model: "gpt-5.6-sol",
+      reasoningEffort: "max"
+    }, {
+      providerAccess: {
+        environmentSecrets: {},
+        credentialDocument: { version: 1, credentials: { [provider]: seed } },
+        credentialSourcePath: hostPath,
+        secretValues: [seed.access, seed.refresh]
+      },
+      credentialStoreFactory: (filePath: string) => jsonCredentialStore(filePath),
+      prepareSubject: async () => ({ subjectKind: "fake", cliEntry: "fake", nodePath: "fake" }),
+      runSubject: async (input: Record<string, unknown>) => {
+        const env = input.env as Record<string, string>;
+        const isolatedPath = path.join(env.HOME, ".sigma", "auth.json");
+        const isolated = JSON.parse(await readFile(isolatedPath, "utf8"));
+        observed.push(isolated.credentials[provider]);
+        const attempt = observed.length;
+        const emitted = attempt === 1 ? acceptedRefresh
+          : attempt === 2 ? supersededRefresh
+          : concurrentLogin;
+        isolated.credentials[provider] = emitted;
+        await writeFile(isolatedPath, `${JSON.stringify(isolated)}\n`, "utf8");
+        if (attempt === 2) {
+          const host = JSON.parse(await readFile(hostPath, "utf8"));
+          host.credentials[provider] = concurrentLogin;
+          await writeFile(hostPath, `${JSON.stringify(host)}\n`, "utf8");
+        }
+        await writeFile(
+          path.join(String(input.artifactDir), "subject.stdout.log"),
+          `${emitted.access}\n`,
+          "utf8"
+        );
+        await writeFile(path.join(String(input.artifactDir), "subject.stderr.log"), "", "utf8");
+        return {
+          exitCode: 0,
+          sessionId: "session",
+          result: { status: "completed", finishReason: "completed", finalMessage: "Done." },
+          events: successfulEvents()
+        };
+      }
+    });
+
+    expect(observed).toEqual([seed, acceptedRefresh, concurrentLogin]);
+    const host = JSON.parse(await readFile(hostPath, "utf8"));
+    expect(host.credentials[provider]).toEqual(concurrentLogin);
+    expect(host.credentials.unrelated).toEqual({ type: "api_key", key: "keep-unrelated" });
+    expect(result.run.infrastructureErrors).toEqual([]);
+    const report = await readFile(result.runPath, "utf8");
+    for (const credential of [seed, acceptedRefresh, supersededRefresh, concurrentLogin]) {
+      expect(report).not.toContain(credential.access);
+      expect(report).not.toContain(credential.refresh);
+    }
   });
 
   it("rejects result-directed repetition overrides before preparing a subject", async () => {

--- a/tests/agent-eval-runner.test.ts
+++ b/tests/agent-eval-runner.test.ts
@@ -204,7 +204,15 @@ describe("agent experience evaluation runner", () => {
     const fixture = await manifest({ repeat: 2 });
     const runDir = path.join(fixture.root, "artifacts");
     const subjectInputs: Array<Record<string, unknown>> = [];
-    const result = await runEvaluation({ suite: "quick", repeat: 2, manifestPath: fixture.manifestPath, runDir }, {
+    const result = await runEvaluation({
+      suite: "quick",
+      repeat: 2,
+      manifestPath: fixture.manifestPath,
+      runDir,
+      provider: "openai-codex",
+      model: "gpt-5.6-sol",
+      reasoningEffort: "max"
+    }, {
       secrets: { DEEPSEEK_API_KEY: "test-secret-value-12345" },
       prepareSubject: async () => ({ subjectKind: "fake", cliEntry: "fake", nodePath: "fake" }),
       runSubject: async (input: Record<string, unknown>) => {
@@ -224,6 +232,11 @@ describe("agent experience evaluation runner", () => {
     expect(subjectInputs[0]).not.toHaveProperty("allowedChanges");
     expect(subjectInputs[0]).not.toHaveProperty("expectedTerminal");
     expect(subjectInputs[0]).not.toHaveProperty("fixture");
+    expect(subjectInputs[0]).toMatchObject({
+      provider: "openai-codex",
+      model: "gpt-5.6-sol",
+      reasoningEffort: "max"
+    });
     expect(subjectInputs[0]?.driverSpec).toEqual({
       messages: ["Inspect the value and report completion."],
       surface: "cli",
@@ -243,6 +256,11 @@ describe("agent experience evaluation runner", () => {
       ]
     });
     expect(result).not.toHaveProperty("codexReviewPath");
+    expect(result.run.subject).toMatchObject({
+      provider: "openai-codex",
+      model: "gpt-5.6-sol",
+      reasoningEffort: "max"
+    });
     expect(await readFile(result.runPath, "utf8")).not.toContain("test-secret-value-12345");
   });
 

--- a/tests/agent-eval-subject-cli.test.ts
+++ b/tests/agent-eval-subject-cli.test.ts
@@ -76,6 +76,7 @@ if (args[0] === "session" && args[1] === "cancel") {
     process.exit(0);
   }, 150);
 } else {
+  writeFileSync(path.join(workspace, "solver.args.json"), JSON.stringify(args));
   let seq = 0;
   const emit = (type, payload = {}) => console.log(JSON.stringify({ kind: "event", event: {
     schemaVersion: 1, seq: ++seq, eventId: "event-" + seq, sessionId: "fake-session", runId: "fake-run",
@@ -101,6 +102,9 @@ if (args[0] === "session" && args[1] === "cancel") {
       budget: { wallTimeSec: 0.05, modelTurns: 8, toolCalls: 12, costUsd: 0.1 },
       artifactDir,
       redactor: String,
+      provider: "openai-codex",
+      model: "gpt-5.6-sol",
+      reasoningEffort: "max",
       subject: {
         subjectKind: "dev",
         nodePath: process.execPath,
@@ -111,6 +115,12 @@ if (args[0] === "session" && args[1] === "cancel") {
 
     expect(result.cancellation).toMatchObject({ reason: "experience_budget_exceeded", dimension: "wallTime", cancelExitCode: 0 });
     expect(result.events.some((event: { type: string }) => event.type === "run.cancelled")).toBe(true);
+    expect(JSON.parse(await readFile(path.join(workspace, "solver.args.json"), "utf8")))
+      .toEqual(expect.arrayContaining([
+        "--provider", "openai-codex",
+        "--model", "gpt-5.6-sol",
+        "--reasoning-effort", "max"
+      ]));
     await expect(access(path.join(workspace, "cancel.finished"))).resolves.toBeUndefined();
   });
 });

--- a/tests/agent-runtime.configured-runtime-capabilities.test.ts
+++ b/tests/agent-runtime.configured-runtime-capabilities.test.ts
@@ -393,6 +393,41 @@ describe("configured runtime execution capabilities", () => {
     }
   });
 
+  it("binds the broker-derived runtime environment into the Harness identity", async () => {
+    const root = await workspace();
+    const firstState = await mkdtemp(path.join(os.tmpdir(), "sigma-runtime-env-first-"));
+    const secondState = await mkdtemp(path.join(os.tmpdir(), "sigma-runtime-env-second-"));
+    fixtures.push(firstState, secondState);
+    const firstReport = doctorReport([]);
+    const secondReport = { ...doctorReport([]), architecture: "alternate-arch" };
+    const firstRuntime = await createConfiguredRuntime(configured(root), {
+      stateRootDir: firstState,
+      executionBroker: fixtureBroker(firstReport),
+      gatewayFactory: () => new CapturingGateway()
+    }, { connectMcp: false, surface: "cli" });
+    const secondRuntime = await createConfiguredRuntime(configured(root), {
+      stateRootDir: secondState,
+      executionBroker: fixtureBroker(secondReport),
+      gatewayFactory: () => new CapturingGateway()
+    }, { connectMcp: false, surface: "cli" });
+    try {
+      const first = firstRuntime.inspectHarness("analyze");
+      const second = secondRuntime.inspectHarness("analyze");
+      expect(first.toolPolicy.initialToolDefinitionsDigest)
+        .toBe(second.toolPolicy.initialToolDefinitionsDigest);
+      expect(first.promptPolicy.systemBehaviorDigest)
+        .toBe(second.promptPolicy.systemBehaviorDigest);
+      expect(first.promptPolicy.runtimeEnvironmentDigest)
+        .not.toBe(second.promptPolicy.runtimeEnvironmentDigest);
+      expect(first.runtimeCapabilities.environment.arch).toBe("fixture-arch");
+      expect(second.runtimeCapabilities.environment.arch).toBe("alternate-arch");
+      expect(first.digest).not.toBe(second.digest);
+    } finally {
+      await firstRuntime.close();
+      await secondRuntime.close();
+    }
+  });
+
   it("carries broker-attested external mounts into every environment write policy", async () => {
     const root = await workspace();
     const report = doctorReport([], [], {

--- a/tests/agent-runtime.configured-runtime-capabilities.test.ts
+++ b/tests/agent-runtime.configured-runtime-capabilities.test.ts
@@ -335,6 +335,64 @@ describe("configured runtime execution capabilities", () => {
     }
   });
 
+  it("keeps run requests identical after compiling an inspection-only Harness identity", async () => {
+    const root = await workspace();
+    const inspectedState = await mkdtemp(path.join(os.tmpdir(), "sigma-runtime-inspected-state-"));
+    const controlState = await mkdtemp(path.join(os.tmpdir(), "sigma-runtime-control-state-"));
+    fixtures.push(inspectedState, controlState);
+    const inspectedGateway = new CapturingGateway();
+    const controlGateway = new CapturingGateway();
+    const brokerReport = doctorReport([]);
+    const inspectedRuntime = await createConfiguredRuntime(configured(root), {
+      stateRootDir: inspectedState,
+      executionBroker: fixtureBroker(brokerReport),
+      gatewayFactory: () => inspectedGateway
+    }, { connectMcp: false, surface: "cli" });
+    const controlRuntime = await createConfiguredRuntime(configured(root), {
+      stateRootDir: controlState,
+      executionBroker: fixtureBroker(brokerReport),
+      gatewayFactory: () => controlGateway
+    }, { connectMcp: false, surface: "cli" });
+    try {
+      const build = inspectedRuntime.inspectHarness("analyze");
+      expect(build.activation).toBe("inspection_only");
+      expect(build.modifiesRuntime).toBe(false);
+
+      for (const runtime of [inspectedRuntime.runtime, controlRuntime.runtime]) {
+        const session = await runtime.createSession({ workspacePath: root, mode: "analyze" });
+        await runtime.command({
+          type: "submit",
+          sessionId: session.sessionId,
+          text: "Inspect the runtime capabilities.",
+          mode: "analyze"
+        });
+        await runtime.waitForOutcome(session.sessionId);
+      }
+
+      const inspectedRequest = inspectedGateway.requests[0]!;
+      const controlRequest = controlGateway.requests[0]!;
+      expect(build.toolPolicy.initialTools).toEqual(
+        inspectedRequest.tools?.map((tool) => tool.name)
+      );
+      expect({
+        messages: inspectedRequest.messages,
+        tools: inspectedRequest.tools,
+        toolChoice: inspectedRequest.toolChoice,
+        maxOutputTokens: inspectedRequest.maxOutputTokens,
+        temperature: inspectedRequest.temperature
+      }).toEqual({
+        messages: controlRequest.messages,
+        tools: controlRequest.tools,
+        toolChoice: controlRequest.toolChoice,
+        maxOutputTokens: controlRequest.maxOutputTokens,
+        temperature: controlRequest.temperature
+      });
+    } finally {
+      await inspectedRuntime.close();
+      await controlRuntime.close();
+    }
+  });
+
   it("carries broker-attested external mounts into every environment write policy", async () => {
     const root = await workspace();
     const report = doctorReport([], [], {

--- a/tests/agent-runtime.harness-compiler.test.ts
+++ b/tests/agent-runtime.harness-compiler.test.ts
@@ -1,0 +1,121 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import {
+  HARNESS_COMPILER_VERSION,
+  canonicalHarnessJson,
+  compileHarnessBuild,
+  type HarnessCompilerInput
+} from "../packages/agent-runtime/src/harness-compiler.js";
+import { strictReviewProfileFixture } from "./testkit/agent-profile-fixture.js";
+
+function input(): HarnessCompilerInput {
+  return {
+    provider: "fixture-provider",
+    model: "fixture-model",
+    reasoningEffort: "max",
+    modelRole: "orchestrator",
+    runMode: "change",
+    modelCapabilities: {
+      contextWindowTokens: 128_000,
+      maxOutputTokens: 16_384,
+      tools: true,
+      parallelTools: true,
+      reasoning: true,
+      structuredOutput: true,
+      promptCache: true,
+      tokenizer: "provider"
+    },
+    runtimeCapabilities: {
+      tools: [{
+        name: "read",
+        description: "Read a file.",
+        inputSchema: {
+          type: "object",
+          properties: { path: { type: "string" } },
+          required: ["path"],
+          additionalProperties: false
+        }
+      }],
+      executionMode: "sandboxed",
+      writeScope: "workspace",
+      managedEnvironment: false,
+      network: "full",
+      interactiveApprovals: false
+    },
+    resolvedAgentProfile: strictReviewProfileFixture().profile
+  };
+}
+
+describe("Harness identity compiler", () => {
+  it("builds a deterministic, deeply frozen identity without activating policies", () => {
+    const first = compileHarnessBuild(input());
+    const second = compileHarnessBuild(structuredClone(input()));
+
+    expect(first).toEqual(second);
+    expect(first).toMatchObject({
+      compilerVersion: HARNESS_COMPILER_VERSION,
+      policyPackIds: ["sigma.runtime-default.identity.v1"],
+      activation: "inspection_only",
+      modifiesRuntime: false,
+      promptPolicy: { mode: "runtime_default", modifiesPrompt: false },
+      toolPolicy: {
+        mode: "runtime_default",
+        modifiesToolSurface: false,
+        initialTools: ["read"]
+      },
+      contextPolicy: { mode: "runtime_default", modifiesContext: false },
+      observationPolicy: { mode: "runtime_default", modifiesObservations: false }
+    });
+    expect(first.digest).toBe(
+      createHash("sha256").update(first.canonicalJson).digest("hex")
+    );
+    expect(Object.isFrozen(first)).toBe(true);
+    expect(Object.isFrozen(first.subject)).toBe(true);
+    expect(Object.isFrozen(first.toolPolicy.initialTools)).toBe(true);
+  });
+
+  it("changes identity when a subject, profile, or exact tool schema changes", () => {
+    const baseline = compileHarnessBuild(input());
+    const analyze = input();
+    analyze.runMode = "analyze";
+    const profile = input();
+    profile.resolvedAgentProfile = {
+      ...profile.resolvedAgentProfile,
+      toolDeny: ["read"]
+    };
+    const schema = input();
+    schema.runtimeCapabilities = {
+      ...schema.runtimeCapabilities,
+      tools: [{
+        ...schema.runtimeCapabilities.tools[0]!,
+        description: "Read one workspace file."
+      }]
+    };
+
+    expect(compileHarnessBuild(analyze).digest).not.toBe(baseline.digest);
+    expect(compileHarnessBuild(profile).digest).not.toBe(baseline.digest);
+    const changedSchema = compileHarnessBuild(schema);
+    expect(changedSchema.digest).not.toBe(baseline.digest);
+    expect(changedSchema.toolPolicy.initialToolDefinitionsDigest)
+      .not.toBe(baseline.toolPolicy.initialToolDefinitionsDigest);
+  });
+
+  it("rejects benchmark, task, and other undeclared compiler inputs", () => {
+    expect(() => compileHarnessBuild({
+      ...input(),
+      taskId: "sealed-task"
+    } as HarnessCompilerInput)).toThrow(/invalid field set/u);
+    expect(() => compileHarnessBuild({
+      ...input(),
+      runtimeCapabilities: {
+        ...input().runtimeCapabilities,
+        benchmark: "sealed-suite"
+      }
+    } as HarnessCompilerInput)).toThrow(/runtime capabilities.*invalid field set/u);
+  });
+
+  it("canonicalizes object keys while preserving ordered arrays", () => {
+    expect(canonicalHarnessJson({ z: 1, a: { y: 2, x: [3, 1] } }))
+      .toBe('{"a":{"x":[3,1],"y":2},"z":1}');
+  });
+});

--- a/tests/agent-runtime.harness-compiler.test.ts
+++ b/tests/agent-runtime.harness-compiler.test.ts
@@ -40,7 +40,19 @@ function input(): HarnessCompilerInput {
       writeScope: "workspace",
       managedEnvironment: false,
       network: "full",
-      interactiveApprovals: false
+      interactiveApprovals: false,
+      environment: {
+        platform: "linux",
+        arch: "x64",
+        defaultShell: "bash",
+        availableShells: ["bash"],
+        availableRuntimeCommands: ["node"],
+        executionCapabilitiesVerified: true,
+        directExecutableResolution: true,
+        executionMode: "sandboxed",
+        writeScope: "workspace",
+        pathSeparator: "/"
+      }
     },
     resolvedAgentProfile: strictReviewProfileFixture().profile
   };
@@ -98,6 +110,16 @@ describe("Harness identity compiler", () => {
     expect(changedSchema.digest).not.toBe(baseline.digest);
     expect(changedSchema.toolPolicy.initialToolDefinitionsDigest)
       .not.toBe(baseline.toolPolicy.initialToolDefinitionsDigest);
+
+    const environment = input();
+    environment.runtimeCapabilities = {
+      ...environment.runtimeCapabilities,
+      environment: { ...environment.runtimeCapabilities.environment, arch: "arm64" }
+    };
+    const changedEnvironment = compileHarnessBuild(environment);
+    expect(changedEnvironment.digest).not.toBe(baseline.digest);
+    expect(changedEnvironment.promptPolicy.runtimeEnvironmentDigest)
+      .not.toBe(baseline.promptPolicy.runtimeEnvironmentDigest);
   });
 
   it("rejects benchmark, task, and other undeclared compiler inputs", () => {

--- a/tests/bench-terminal-bench-formal.test.ts
+++ b/tests/bench-terminal-bench-formal.test.ts
@@ -10,6 +10,8 @@ import {
 import {
   assertFrozenBatchControls,
   canonicalJson,
+  FORMAL_TOKEN_USAGE_PROXY,
+  formalTokenUsageProxy,
   formalPreregistrationConsumptionIdentity,
   loadFormalPreregistration,
   sha256,
@@ -121,6 +123,7 @@ function report(taskCount: number, passed: number, blocker = false) {
     usage: {
       input_tokens: taskCount * 10,
       cache_tokens: taskCount * 8,
+      cache_read_tokens: taskCount * 8,
       output_tokens: taskCount * 2
     },
     cost_usd: taskCount * 0.01,
@@ -163,12 +166,17 @@ describe("formal benchmark preregistration", () => {
     const value = manifest();
     expect(value).toMatchObject({
       kind: "SigmaFormalRunPreregistration",
+      schemaVersion: 2,
       model: {
         provider: "provider-fixture",
         name: "model-fixture",
         reasoning_effort: "max"
       },
       solver_controls: { max_turns: 73, command_timeout_sec: 41, cleanup_grace_sec: 17 },
+      usage_accounting: {
+        token_usage_proxy: FORMAL_TOKEN_USAGE_PROXY,
+        gate_precedence: "provider_cost_usd_then_token_usage_proxy"
+      },
       execution: { concurrency: 2, attempts_per_task: 1, retries: 0 }
     });
     expect(value.task_selection.task_selection_sha256).toMatch(/^[a-f0-9]{64}$/u);
@@ -186,6 +194,19 @@ describe("formal benchmark preregistration", () => {
     const excessiveCommandTimeout = draft();
     (excessiveCommandTimeout.solver_controls as Record<string, unknown>).command_timeout_sec = 601;
     expect(() => sigmaFormalRunPreregistration(excessiveCommandTimeout)).toThrow(/at most 600/u);
+  });
+
+  it("registers a deterministic uncached-input-plus-output usage proxy", () => {
+    expect(formalTokenUsageProxy({
+      input_tokens: 30,
+      cache_read_tokens: 24,
+      output_tokens: 6
+    })).toBe(12);
+    expect(() => formalTokenUsageProxy({
+      input_tokens: 30,
+      cache_tokens: 24,
+      output_tokens: 6
+    })).toThrow(/invalid field set/u);
   });
 
   it("rejects score thresholds, mutable task sources, and stale digests", () => {
@@ -340,6 +361,12 @@ describe("formal benchmark controller", () => {
       counts: { passed: 2, structured_blocker: 1 },
       failure_categories: { structured_blocker: 1 },
       lane_metrics: { verifier_reached: 2, verifier_passed: 2 }
+    });
+    expect(aggregate.usage_accounting).toMatchObject({
+      token_usage_proxy: {
+        id: "uncached_input_plus_output_v1",
+        value: 12
+      }
     });
     expect(aggregate).not.toHaveProperty("acceptance");
     expect(aggregate).not.toHaveProperty("minimum_passes");

--- a/tests/harness-development-suite.test.ts
+++ b/tests/harness-development-suite.test.ts
@@ -1,0 +1,102 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { loadEvalProviderAccess } from "../scripts/eval/common.mjs";
+import {
+  HARNESS_DEVELOPMENT_BINDING,
+  runHarnessDevelopmentCli
+} from "../scripts/eval/harness-development.mjs";
+import manifest from "../test-fixtures/agent-evals/manifest.json" with { type: "json" };
+
+const temporary: string[] = [];
+
+afterEach(async () => {
+  for (const directory of temporary.splice(0)) {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+describe("flagship Harness development suite", () => {
+  it("binds a representative non-benchmark suite to Sol max with three repetitions", () => {
+    const selected = manifest.scenarios
+      .filter((scenario) => scenario.suites.includes(HARNESS_DEVELOPMENT_BINDING.suite))
+      .map((scenario) => scenario.id);
+    expect(selected).toEqual(HARNESS_DEVELOPMENT_BINDING.scenarios);
+    expect(manifest.frozenRunPolicies[HARNESS_DEVELOPMENT_BINDING.suite]).toMatchObject({
+      repeat: 3,
+      schedule: "seeded_round_robin",
+      abOrder: "interleaved_baseline_first"
+    });
+    expect(HARNESS_DEVELOPMENT_BINDING).toMatchObject({
+      provider: "openai-codex",
+      model: "gpt-5.6-sol",
+      reasoningEffort: "max",
+      repeat: 3
+    });
+    expect(JSON.stringify({ selected, manifest })).not.toMatch(
+      /terminal-bench|tb2(?:\.1)?|verifier feedback/iu
+    );
+  });
+
+  it("rejects result-directed control overrides and appends only frozen controls", async () => {
+    const runner = vi.fn(async (argv: string[]) => ({ argv, exitCode: 0 }));
+    await expect(runHarnessDevelopmentCli([
+      "--subject", "dev",
+      "--subject-workspace", "D:/candidate"
+    ], { runAgentEvalCli: runner })).resolves.toMatchObject({ exitCode: 0 });
+    expect(runner).toHaveBeenCalledOnce();
+    expect(runner.mock.calls[0]![0]).toEqual(expect.arrayContaining([
+      "--suite", "harness-development",
+      "--provider", "openai-codex",
+      "--model", "gpt-5.6-sol",
+      "--reasoning-effort", "max",
+      "--repeat", "3"
+    ]));
+    await expect(runHarnessDevelopmentCli(["--repeat", "1"], {
+      runAgentEvalCli: runner
+    })).rejects.toThrow(/controls are frozen/u);
+    await expect(runHarnessDevelopmentCli(["--scenario", "one"], {
+      runAgentEvalCli: runner
+    })).rejects.toThrow(/controls are frozen/u);
+  });
+
+  it("reduces the host credential store to the selected provider", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "sigma-eval-credential-"));
+    temporary.push(directory);
+    const credentialFile = path.join(directory, "auth.json");
+    await writeFile(credentialFile, JSON.stringify({
+      version: 1,
+      credentials: {
+        "openai-codex": {
+          type: "oauth",
+          access: "selected-access-token",
+          refresh: "selected-refresh-token",
+          expires: 1_900_000_000_000
+        },
+        unrelated: { type: "api_key", key: "must-not-copy" }
+      }
+    }), { encoding: "utf8", mode: 0o600 });
+
+    const access = loadEvalProviderAccess("openai-codex", {
+      base: { SIGMA_HOST_CREDENTIAL_FILE: credentialFile }
+    });
+    expect(access.environmentSecrets).toEqual({});
+    expect(access.credentialDocument).toEqual({
+      version: 1,
+      credentials: {
+        "openai-codex": {
+          type: "oauth",
+          access: "selected-access-token",
+          refresh: "selected-refresh-token",
+          expires: 1_900_000_000_000
+        }
+      }
+    });
+    expect(JSON.stringify(access)).not.toContain("must-not-copy");
+    expect(access.secretValues).toEqual([
+      "selected-access-token",
+      "selected-refresh-token"
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- add an inspection-only Harness compiler with canonical policy and runtime identity digests
- add `sigma harness inspect` without wiring the compiled artifact into `run`
- bind the generic evaluation runner to explicit provider, model, and reasoning settings
- add a frozen GPT-5.6 Sol/max Harness development suite using non-TB scenarios
- isolate the selected provider credential for evaluation subjects and safely persist refreshes
- preregister the uncached-input-plus-output token usage proxy for formal runs

## Why

The previous Harness ablations did not produce a confirmed reusable improvement. Before attempting another active optimization, Sigma needs a clean main-based foundation that can identify the exact runtime/tool surface, preserve a reproducible same-model evaluation configuration, and compare token usage consistently.

This PR deliberately establishes that foundation without carrying forward any unproven runtime-changing policy.

## Impact and integrity

- `run` behavior is unchanged; compiler activation is `inspection_only` and reports `runtime_modified=false`
- a runtime equivalence test verifies that inspecting the Harness does not change the model request
- compiler inputs use an exact allowlist and cannot accept undeclared task or evaluator data
- the development suite contains generic repository tasks and does not use TB2.1
- no TB2.1 run or performance-improvement claim is associated with this PR

## Validation

- `pnpm test`: 174 test files and 1,560 tests passed
- `pnpm lint`
- `pnpm eval:fairness`
- `pnpm test:harbor`: 58 tests passed
- `pnpm build`
- `pnpm verify:package:agent-cli:windows`
- source and packaged `sigma harness inspect` smoke tests
- `git diff --check`

The frozen main baseline remains bound to `main@36b2c03`, `openai-codex/gpt-5.6-sol`, `reasoning=max`, and the `standard` profile.