### PR TITLE
Add neutral trace attribution for harness development

### DIFF
--- a/packages/agent-kernel/src/index.ts
+++ b/packages/agent-kernel/src/index.ts
@@ -4,3 +4,4 @@ export * from "./reducer.js";
 export * from "./effects.js";
 export * from "./rehydrate.js";
 export * from "./durable-budget-reducers.js";
+export { receiptContent } from "./receipt-parsing.js";

--- a/packages/agent-protocol/src/event-payload-schemas-core.ts
+++ b/packages/agent-protocol/src/event-payload-schemas-core.ts
@@ -7,6 +7,7 @@ import {
   durableToolReceiptShape,
   modelImageSchema,
   modelMessageSchema,
+  modelPromptTraceObservationSchema,
   modelToolCallSchema,
   runModeSchema,
   sharedSchemas,
@@ -319,6 +320,7 @@ export const coreEventPayloadSchemas = {
     cacheMode: z.enum(["prefix_cache", "provider_window"]),
     promptState: runtimePromptStateSchema,
     frameMode: z.enum(["full", "delta"]),
+    traceObservation: modelPromptTraceObservationSchema.optional(),
     /** Durable record of the recovery policy actually sent to the provider. */
     toolChoice: z.enum(["auto", "required", "none"]).nullable().optional()
   }).strict(),

--- a/packages/agent-protocol/src/event-payload-schemas-foundation.ts
+++ b/packages/agent-protocol/src/event-payload-schemas-foundation.ts
@@ -131,8 +131,28 @@ export const durableToolReceiptShape = {
   evidence: z.array(evidenceRecordSchema),
   startedAt: dateTimeSchema,
   completedAt: dateTimeSchema,
+  traceObservation: z.object({
+    schemaVersion: z.literal(1),
+    rawBytes: z.number().int().nonnegative(),
+    modelVisibleBytes: z.number().int().nonnegative(),
+    fullOutputDigest: z.string().regex(/^[a-f0-9]{64}$/u)
+  }).strict().optional(),
   ...turnSchema
 };
+
+export const modelPromptTraceObservationSchema = z.object({
+  schemaVersion: z.literal(1),
+  tokenEstimator: z.literal("context_plan_approximate_tokens"),
+  tokenAccuracy: z.literal("estimated"),
+  estimatedTokens: z.object({
+    systemBaseContext: z.number().int().nonnegative(),
+    toolSchema: z.number().int().nonnegative(),
+    conversationHistory: z.number().int().nonnegative(),
+    toolResults: z.number().int().nonnegative(),
+    total: z.number().int().nonnegative()
+  }).strict(),
+  visibleToolNames: z.array(nonEmptyStringSchema)
+}).strict();
 
 export const contextItemSchema = z.object({
   id: nonEmptyStringSchema,

--- a/packages/agent-runtime/src/model-effect-runner.ts
+++ b/packages/agent-runtime/src/model-effect-runner.ts
@@ -40,6 +40,7 @@ import { prepareModelAttempt } from "./model-turn-preparation.js";
 import { LongHorizonCoordinator } from "./long-horizon-coordinator.js";
 import type { ReviewCoordinator } from "./review-coordinator.js";
 import { finishSolvingBudgetBoundary } from "./solving-budget-boundary.js";
+import { modelRequestTraceObservation } from "./model-request-trace-observation.js";
 
 type RequestModelEffect = Extract<KernelEffect, { type: "request_model" }>;
 
@@ -230,6 +231,7 @@ export class ModelEffectRunner {
       cacheMode: plan.cacheMode,
       promptState: turn.promptState,
       frameMode: turn.frameMode,
+      traceObservation: modelRequestTraceObservation(plan, turn),
       toolChoice: turn.toolChoice ?? null
     });
     await this.longHorizon.markRepairTurnConsumed(session);

--- a/packages/agent-runtime/src/model-request-trace-observation.ts
+++ b/packages/agent-runtime/src/model-request-trace-observation.ts
@@ -1,0 +1,27 @@
+import {
+  messageTokens,
+  type ContextPlan
+} from "agent-context";
+import type { PreparedModelTurn } from "./model-budget-convergence.js";
+
+export function modelRequestTraceObservation(plan: ContextPlan, turn: PreparedModelTurn) {
+  const toolResults = plan.messages
+    .filter((message) => message.role === "tool")
+    .reduce((total, message) => total + messageTokens(message), 0);
+  const estimatedTokens = {
+    systemBaseContext: plan.budget.systemTokens + plan.budget.dynamicTokens,
+    toolSchema: plan.budget.toolTokens,
+    conversationHistory: Math.max(0, plan.budget.historyTokens - toolResults),
+    toolResults
+  };
+  return {
+    schemaVersion: 1 as const,
+    tokenEstimator: "context_plan_approximate_tokens" as const,
+    tokenAccuracy: "estimated" as const,
+    estimatedTokens: {
+      ...estimatedTokens,
+      total: Object.values(estimatedTokens).reduce((total, value) => total + value, 0)
+    },
+    visibleToolNames: [...new Set(turn.tools.map((tool) => tool.name))].sort()
+  };
+}

--- a/packages/agent-runtime/src/tool-receipt-recorder.ts
+++ b/packages/agent-runtime/src/tool-receipt-recorder.ts
@@ -1,4 +1,6 @@
+import { createHash } from "node:crypto";
 import type { ActiveModelTurn } from "agent-kernel";
+import { receiptContent } from "agent-kernel";
 import type { ToolOutcome, ToolReceipt } from "agent-protocol";
 import { turnPayload } from "./effect-runner-helpers.js";
 import type { EffectRunnerOptions } from "./effect-runner.js";
@@ -20,6 +22,15 @@ function durableToolReceipt(receipt: ToolReceipt): DurableToolReceipt {
       output: receipt.output,
       diagnosticCodes
     }
+  };
+}
+
+function traceObservation(receipt: DurableToolReceipt) {
+  return {
+    schemaVersion: 1 as const,
+    rawBytes: Buffer.byteLength(receipt.output, "utf8"),
+    modelVisibleBytes: Buffer.byteLength(receiptContent(receipt), "utf8"),
+    fullOutputDigest: createHash("sha256").update(receipt.output, "utf8").digest("hex")
   };
 }
 
@@ -60,11 +71,12 @@ export class ToolReceiptRecorder {
     modelTurn: ActiveModelTurn,
     name: string
   ): Promise<void> {
+    const durable = durableToolReceipt(receipt);
     const emissions: RuntimeEventEmission[] = [{
       type: receipt.ok ? "tool.completed" : "tool.failed",
       authority: "tool",
       payload: {
-        ...durableToolReceipt(receipt), name, ...turnPayload(modelTurn)
+        ...durable, name, traceObservation: traceObservation(durable), ...turnPayload(modelTurn)
       }
     } as RuntimeEventEmission];
     for (const evidence of receipt.evidence ?? []) {

--- a/scripts/eval/agent-eval.mjs
+++ b/scripts/eval/agent-eval.mjs
@@ -27,6 +27,9 @@ function evaluationOptions(flags) {
     model: typeof flags.model === "string" ? flags.model : undefined,
     reasoningEffort: typeof flags["reasoning-effort"] === "string"
       ? flags["reasoning-effort"] : undefined,
+    agentProfile: typeof flags["agent-profile"] === "string"
+      ? flags["agent-profile"] : undefined,
+    traceAttribution: flags["trace-attribution"] === true,
     ...(repeat === undefined ? {} : { repeat }),
     scenarios: typeof flags.scenario === "string"
       ? flags.scenario.split(",").map((item) => item.trim()).filter(Boolean) : [],
@@ -48,6 +51,7 @@ export async function runAgentEvalCli(argv = process.argv.slice(2), deps = {}) {
   });
   process.stdout.write(`Evaluation run: ${result.runDir}\n`);
   process.stdout.write(`Report: ${result.reportPath}\n`);
+  if (result.traceReportPath) process.stdout.write(`Trace attribution: ${result.traceReportPath}\n`);
   return { ...result, exitCode: result.run.status === "stable" ? 0 : 1 };
 }
 

--- a/scripts/eval/harness-development.mjs
+++ b/scripts/eval/harness-development.mjs
@@ -9,6 +9,7 @@ export const HARNESS_DEVELOPMENT_BINDING = Object.freeze({
   provider: "openai-codex",
   model: "gpt-5.6-sol",
   reasoningEffort: "max",
+  profile: "standard",
   repeat: 3,
   scenarios: Object.freeze([
     "line-count-readonly",
@@ -55,6 +56,8 @@ export async function runHarnessDevelopmentCli(
     "--provider", binding.provider,
     "--model", binding.model,
     "--reasoning-effort", binding.reasoningEffort,
+    "--agent-profile", binding.profile,
+    "--trace-attribution",
     "--repeat", String(binding.repeat),
     "--scenario", binding.scenarios.join(",")
   ], evaluationDeps);

--- a/scripts/eval/runner.mjs
+++ b/scripts/eval/runner.mjs
@@ -20,6 +20,7 @@ import { runTuiSubject } from "./subject-tui.mjs";
 import {
   buildAggregateTraceAttribution,
   buildTraceAttribution,
+  markTraceAttributionInfrastructureFailure,
   writeAggregateTraceAttribution,
   writeAttemptTraceAttribution
 } from "./trace-attribution.mjs";
@@ -1328,6 +1329,23 @@ async function scanAttemptSecrets(context, lifecycle, attempt, secretValues) {
   for (const file of exposures) addSafetyViolation(attempt, { code: "secret_in_artifact", file });
 }
 
+async function reconcileAttemptTraceAttribution(context, lifecycle, attempt) {
+  if (!lifecycle.traceAttribution || attempt.validity === "valid") return false;
+  const previous = lifecycle.traceAttribution;
+  const reconciled = markTraceAttributionInfrastructureFailure(previous);
+  lifecycle.traceAttribution = reconciled;
+  attempt.traceAttribution = {
+    schemaVersion: 1,
+    reportDigest: reconciled.report.reportDigest,
+    summary: reconciled.summary
+  };
+  if (reconciled === previous) return false;
+  await writeAttemptTraceAttribution(
+    lifecycle.attemptArtifactDir, reconciled.report, context.redactor
+  );
+  return true;
+}
+
 async function finalizeAttempt(context, lifecycle, result, secretValues, deps) {
   const { redactor } = context;
   let credentialFailure;
@@ -1337,6 +1355,7 @@ async function finalizeAttempt(context, lifecycle, result, secretValues, deps) {
     credentialFailure = error;
   }
   await scanAttemptSecrets(context, lifecycle, result.attempt, secretValues);
+  await reconcileAttemptTraceAttribution(context, lifecycle, result.attempt);
   if (credentialFailure) throw credentialFailure;
   await writeJson(path.join(lifecycle.attemptArtifactDir, "attempt.json"), result.attempt, redactor);
   if (result.stateRoot) await appendExternalReport(result.stateRoot, result.attempt);
@@ -1431,7 +1450,8 @@ async function runAttempt(context, deps = {}) {
     try { await finalizeAttempt(context, lifecycle, result, secretValues, deps); } catch (error) { finalizationError = error; }
     cleanupManaged = true;
     const cleanupFailed = await cleanupAttempt(context, lifecycle, result.attempt);
-    if (cleanupFailed && !finalizationError) {
+    const traceReconciled = await reconcileAttemptTraceAttribution(context, lifecycle, result.attempt);
+    if ((cleanupFailed || traceReconciled) && !finalizationError) {
       await writeJson(path.join(lifecycle.attemptArtifactDir, "attempt.json"), result.attempt, context.redactor);
     }
     if (finalizationError) throw finalizationError;
@@ -1771,28 +1791,36 @@ function rawEvaluationRun(context, subject, verifierRuntime, attempts, infrastru
 }
 
 function traceSummaries(attempts) {
-  return attempts.map((attempt) => attempt.traceAttribution?.summary ?? {
-    attemptId: attempt.attemptId,
-    scenarioId: attempt.scenarioId,
-    repetition: attempt.repetition,
-    successful: false,
-    finalStatus: "attribution_unavailable",
-    timeout: false,
-    infrastructureFailure: true,
-    totals: {
-      modelTurns: 0, toolCalls: 0, repeatedToolCalls: 0,
-      repeatedObservations: 0, repeatedReads: 0, repeatedValidations: 0,
-      turnCategories: {}, uncachedTokenProxy: { value: 0 },
-      providerCacheReadTokens: { value: 0 }, toolOutputRawBytes: { value: 0 },
-      toolOutputModelVisibleBytes: { value: 0 }, estimatedRequestComposition: {},
-      proxyCostAttribution: {}
-    },
-    timing: {
-      totalLatencyMs: null, timeToFirstActionMs: null,
-      timeToFirstMutationMs: null, completionTailMs: null
-    },
-    completionTailTurns: 0,
-    reportDigest: null
+  return attempts.map((attempt) => {
+    const observed = attempt.traceAttribution?.summary;
+    if (observed) return attempt.validity === "valid" ? observed : {
+      ...observed,
+      successful: false,
+      infrastructureFailure: true
+    };
+    return {
+      attemptId: attempt.attemptId,
+      scenarioId: attempt.scenarioId,
+      repetition: attempt.repetition,
+      successful: false,
+      finalStatus: "attribution_unavailable",
+      timeout: false,
+      infrastructureFailure: true,
+      totals: {
+        modelTurns: 0, toolCalls: 0, repeatedToolCalls: 0,
+        repeatedObservations: 0, repeatedReads: 0, repeatedValidations: 0,
+        turnCategories: {}, uncachedTokenProxy: { value: 0 },
+        providerCacheReadTokens: { value: 0 }, toolOutputRawBytes: { value: 0 },
+        toolOutputModelVisibleBytes: { value: 0 }, estimatedRequestComposition: {},
+        proxyCostAttribution: {}
+      },
+      timing: {
+        totalLatencyMs: null, timeToFirstActionMs: null,
+        timeToFirstMutationMs: null, completionTailMs: null
+      },
+      completionTailTurns: 0,
+      reportDigest: null
+    };
   });
 }
 

--- a/scripts/eval/runner.mjs
+++ b/scripts/eval/runner.mjs
@@ -17,6 +17,12 @@ import {
   applySubjectLaunchEnvironment, createDevNodeLaunch, loadPackagedSubjectLaunch
 } from "./subject-launch.mjs";
 import { runTuiSubject } from "./subject-tui.mjs";
+import {
+  buildAggregateTraceAttribution,
+  buildTraceAttribution,
+  writeAggregateTraceAttribution,
+  writeAttemptTraceAttribution
+} from "./trace-attribution.mjs";
 import { connectVerifierBroker, runPostVerifier } from "./verifier.mjs";
 import {
   copyWorkspaceEvidence, diffWorkspaceSnapshots, evaluatorLinkTargetRoot, gitDiff, seedWorkspace, snapshotWorkspace,
@@ -181,6 +187,10 @@ async function subjectIdentity({ subjectKind, cliTreeDigest, nodePath, brokerPat
   };
 }
 
+async function compilerDigest(filePath) {
+  return await readFile(filePath).then(digest);
+}
+
 async function prepareSubject(runDir, options = {}, redactor = String) {
   const host = resolveEvaluatorHost(options.platform, options.arch);
   const subjectKind = options.subjectKind ?? "package";
@@ -210,6 +220,9 @@ async function prepareSubject(runDir, options = {}, redactor = String) {
       subjectKind, cliEntry: subjectCliEntry, nodePath: process.execPath, brokerPath,
       launch: createDevNodeLaunch(process.execPath, subjectCliEntry),
       ...identity,
+      harnessCompilerDigest: await compilerDigest(
+        path.join(subjectRoot, "packages", "agent-runtime", "dist", "harness-compiler.js")
+      ),
       nativeSourceDigest: directoryDigest(await snapshotWorkspace(path.join(subjectRoot, "native", "sigma-exec", "src"))),
       nativeTarget: host.nativeTarget
     };
@@ -235,6 +248,9 @@ async function prepareSubject(runDir, options = {}, redactor = String) {
   });
   return {
     subjectKind, ...packaged, ...identity,
+    harnessCompilerDigest: await compilerDigest(
+      path.join(bundleRoot, "packages", "agent-runtime", "dist", "harness-compiler.js")
+    ),
     nativeSourceDigest: directoryDigest(await snapshotWorkspace(path.join(subjectRoot, "native", "sigma-exec", "src"))),
     nativeTarget: host.nativeTarget
   };
@@ -478,12 +494,13 @@ async function appendExternalReport(stateRoot, attempt) {
 
 function subjectConfiguration(context, fixtureSnapshot) {
   const { scenario, subject, sourceGitSha, evaluatorDigest, verifierDigest, frozenRunPolicy,
-    toolchainMeasurement, provider, model, reasoningEffort } = context;
+    toolchainMeasurement, provider, model, reasoningEffort, agentProfile } = context;
   const budget = frozenRunPolicy.budget;
   const configuration = {
     provider,
     model,
     reasoningEffort,
+    profile: agentProfile,
     surface: scenario.surface,
     permissionPolicy: scenario.permissionPolicy,
     platform: process.platform,
@@ -501,6 +518,7 @@ function subjectConfiguration(context, fixtureSnapshot) {
     cliTreeDigest: subject.cliTreeDigest ?? null,
     brokerDigest: subject.brokerDigest ?? null,
     subjectDigest: subject.subjectDigest ?? null,
+    harnessCompilerDigest: subject.harnessCompilerDigest ?? null,
     nativeSourceDigest: subject.nativeSourceDigest ?? null,
     nativeTarget: subject.nativeTarget ?? null,
     subjectKind: subject.subjectKind
@@ -509,6 +527,7 @@ function subjectConfiguration(context, fixtureSnapshot) {
     provider: configuration.provider,
     model: configuration.model,
     reasoningEffort: configuration.reasoningEffort,
+    profile: configuration.profile,
     surface: configuration.surface,
     permissionPolicy: configuration.permissionPolicy,
     platform: configuration.platform,
@@ -523,7 +542,7 @@ function subjectConfiguration(context, fixtureSnapshot) {
   return configuration;
 }
 
-function attemptArtifactPaths(runDir, attemptArtifactDir, surface, finalWorkspaceArtifact) {
+function attemptArtifactPaths(runDir, attemptArtifactDir, surface, finalWorkspaceArtifact, traceAttribution = false) {
   return {
     attempt: relativeArtifact(runDir, path.join(attemptArtifactDir, "attempt.json")),
     events: relativeArtifact(runDir, path.join(attemptArtifactDir, "events.json")),
@@ -533,6 +552,10 @@ function attemptArtifactPaths(runDir, attemptArtifactDir, surface, finalWorkspac
     diff: relativeArtifact(runDir, path.join(attemptArtifactDir, "git.diff")),
     workspaceDelta: relativeArtifact(runDir, path.join(attemptArtifactDir, "workspace-delta.json")),
     verifierWorkspaceDelta: relativeArtifact(runDir, path.join(attemptArtifactDir, "verifier-workspace-delta.json")),
+    ...(traceAttribution ? {
+      traceAttribution: relativeArtifact(runDir, path.join(attemptArtifactDir, "trace-attribution.json")),
+      traceAttributionMarkdown: relativeArtifact(runDir, path.join(attemptArtifactDir, "trace-attribution.md"))
+    } : {}),
     ...(finalWorkspaceArtifact ? { workspaceFinal: relativeArtifact(runDir, finalWorkspaceArtifact) } : {}),
     ...(surface === "tui" ? { tuiTranscript: relativeArtifact(runDir, path.join(attemptArtifactDir, "tui.transcript.log")) } : {})
   };
@@ -714,7 +737,16 @@ function infrastructureAttemptReport(context, lifecycle, evidence) {
     },
     failureChain: { primary: cause, contributing: [], terminal: cause },
     metrics,
-    artifacts: attemptArtifactPaths(runDir, attemptArtifactDir, scenario.surface)
+    artifacts: attemptArtifactPaths(
+      runDir, attemptArtifactDir, scenario.surface, undefined, Boolean(lifecycle.traceAttribution)
+    ),
+    ...(lifecycle.traceAttribution ? {
+      traceAttribution: {
+        schemaVersion: 1,
+        reportDigest: lifecycle.traceAttribution.report.reportDigest,
+        summary: lifecycle.traceAttribution.summary
+      }
+    } : {})
   };
 }
 
@@ -807,7 +839,7 @@ async function prepareAttemptExecution(context, deps, lifecycle) {
 }
 
 async function executeAttemptSubject(context, lifecycle, prepared) {
-  const { scenario, subject, redactor, provider, model, reasoningEffort } = context;
+  const { scenario, subject, redactor, provider, model, reasoningEffort, agentProfile } = context;
   const { attemptArtifactDir, startedAt } = lifecycle;
   const { runSubject, workspace, stateHome, promptPath, env, controllerDir, driverSpec } = prepared;
   lifecycle.phase = "subject";
@@ -825,7 +857,8 @@ async function executeAttemptSubject(context, lifecycle, prepared) {
       subject,
       provider,
       model,
-      reasoningEffort
+      reasoningEffort,
+      agentProfile
     };
     const result = await runSubject(launcherInput);
     lifecycle.subjectResult = result;
@@ -885,6 +918,39 @@ async function collectAttemptEvidence(context, lifecycle, prepared, subjectResul
   await writeFile(path.join(attemptArtifactDir, "git.diff"), redactor(git.diff), "utf8");
   await writeFile(path.join(attemptArtifactDir, "git.status.txt"), redactor(git.status), "utf8");
   return { stored, events, rawMetrics, metrics, delta, git };
+}
+
+function subjectTimedOut(subjectResult) {
+  return subjectResult.timedOut === true
+    || subjectResult.cancellation?.metric === "wallTimeSec"
+    || subjectResult.cancellation?.reason === "timeout";
+}
+
+async function collectTraceAttribution(context, lifecycle, _prepared, subjectResult, collected) {
+  if (!context.traceAttribution) return null;
+  lifecycle.phase = "trace_attribution";
+  const { report, summary } = buildTraceAttribution(collected.events, {
+    attemptId: lifecycle.attemptId,
+    sessionId: collected.stored.sessionId,
+    scenarioId: context.scenario.id,
+    repetition: context.repetition,
+    provider: context.provider,
+    model: context.model,
+    reasoningEffort: context.reasoningEffort,
+    profile: context.agentProfile,
+    runMode: "change",
+    harnessDigest: context.subject.subjectDigest ?? null,
+    compilerDigest: context.subject.harnessCompilerDigest ?? null,
+    startedAt: lifecycle.startedAt,
+    durationMs: subjectResult.durationMs,
+    finalStatus: subjectResult.result?.status,
+    timeout: subjectTimedOut(subjectResult),
+    infrastructureFailure: false,
+    redactor: context.redactor
+  });
+  await writeAttemptTraceAttribution(lifecycle.attemptArtifactDir, report, context.redactor);
+  lifecycle.traceAttribution = { report, summary };
+  return lifecycle.traceAttribution;
 }
 
 async function runVerifierWitness(context, lifecycle, prepared, subjectResult, collected, witness) {
@@ -1180,7 +1246,16 @@ function buildAttemptReport(context, lifecycle, collected, verified, evidence) {
       rawMetrics, safetyViolations, reliabilitySignals, subjectResult, expectedActual, validityCause
     ),
     metrics,
-    artifacts: attemptArtifactPaths(runDir, attemptArtifactDir, scenario.surface, finalWorkspaceArtifact),
+    artifacts: attemptArtifactPaths(
+      runDir, attemptArtifactDir, scenario.surface, finalWorkspaceArtifact, Boolean(lifecycle.traceAttribution)
+    ),
+    ...(lifecycle.traceAttribution ? {
+      traceAttribution: {
+        schemaVersion: 1,
+        reportDigest: lifecycle.traceAttribution.report.reportDigest,
+        summary: lifecycle.traceAttribution.summary
+      }
+    } : {}),
     ...(subjectResult.cancellation ? { cancellation: subjectResult.cancellation } : {})
   };
 }
@@ -1195,6 +1270,7 @@ async function runAttemptCore(context, deps, lifecycle) {
     )}`);
   }
   const collected = await collectAttemptEvidence(context, lifecycle, prepared, subjectResult, deps);
+  await collectTraceAttribution(context, lifecycle, prepared, subjectResult, collected);
   const verified = await verifyAttempt(context, lifecycle, prepared, subjectResult, collected);
   const safetyViolations = safetyViolationsFromEvidence(
     scenario, collected.delta, collected.rawMetrics, collected.events
@@ -1366,7 +1442,7 @@ async function runAttempt(context, deps = {}) {
 }
 
 async function resolveEvaluationInput(options) {
-  const { suite, subjectKind, provider, model, reasoningEffort } = validateEvaluationOptions(options);
+  const { suite, subjectKind, provider, model, reasoningEffort, agentProfile } = validateEvaluationOptions(options);
   const manifestPath = path.resolve(options.manifestPath ?? DEFAULT_MANIFEST);
   const manifestDir = path.dirname(manifestPath);
   const manifest = await loadEvalManifest(manifestPath);
@@ -1378,7 +1454,8 @@ async function resolveEvaluationInput(options) {
   const destination = evaluationDestination(options, runId);
   const runDir = await prepareRunDirectory(destination.destination);
   return {
-    suite, subjectKind, provider, model, reasoningEffort,
+    suite, subjectKind, provider, model, reasoningEffort, agentProfile,
+    traceAttribution: options.traceAttribution === true,
     manifestDir, scenarios, repeat, frozenRunPolicy: structuredClone(frozenRunPolicy), runId,
     effectiveEvalRoot: destination.root, runDir
   };
@@ -1401,6 +1478,7 @@ function evaluationModelSelection(options) {
   const provider = options.provider ?? sigmaManifest.evaluation.provider;
   const model = options.model ?? sigmaManifest.evaluation.model;
   const reasoningEffort = options.reasoningEffort ?? "provider_default";
+  const agentProfile = options.agentProfile ?? "standard";
   if (typeof provider !== "string" || provider.trim().length === 0
     || typeof model !== "string" || model.trim().length === 0) {
     throw new Error("Evaluation provider and model must be non-empty strings.");
@@ -1410,10 +1488,14 @@ function evaluationModelSelection(options) {
   ].includes(reasoningEffort)) {
     throw new Error("Evaluation reasoning effort is unsupported.");
   }
+  if (typeof agentProfile !== "string" || agentProfile.trim().length === 0) {
+    throw new Error("Evaluation Agent Profile must be a non-empty string.");
+  }
   return {
     provider: provider.trim(),
     model: model.trim(),
-    reasoningEffort
+    reasoningEffort,
+    agentProfile: agentProfile.trim()
   };
 }
 
@@ -1583,6 +1665,8 @@ async function preparationFailureAttempt(context, item, error) {
     provider: context.provider,
     model: context.model,
     reasoningEffort: context.reasoningEffort,
+    agentProfile: context.agentProfile,
+    traceAttribution: context.traceAttribution,
     frozenRunPolicy: context.frozenRunPolicy
   }, lifecycle, error);
   await writeJson(path.join(lifecycle.attemptArtifactDir, "attempt.json"), attempt, context.redactor);
@@ -1605,7 +1689,8 @@ async function executeEvaluationSchedule(context, preparation, deps, infrastruct
     schedule, runId, runDir, manifestDir, secrets, credentialDocument, credentialSourcePath,
     credentialState,
     artifactSecretValues, redactor, sourceGitSha, evaluatorDigest, verifierDigest,
-    frozenRunPolicy, toolchainMeasurement, provider, model, reasoningEffort
+    frozenRunPolicy, toolchainMeasurement, provider, model, reasoningEffort,
+    agentProfile, traceAttribution
   } = context;
   if (subject) {
     for (const item of schedule) {
@@ -1632,7 +1717,9 @@ async function executeEvaluationSchedule(context, preparation, deps, infrastruct
           frozenRunPolicy,
           provider,
           model,
-          reasoningEffort
+          reasoningEffort,
+          agentProfile,
+          traceAttribution
         }, deps);
         attempts.push(attempt);
         infrastructureErrors.push(...attemptInfrastructureErrors(attempt, item));
@@ -1651,10 +1738,10 @@ async function executeEvaluationSchedule(context, preparation, deps, infrastruct
   return attempts;
 }
 
-function rawEvaluationRun(context, subject, verifierRuntime, attempts, infrastructureErrors) {
+function rawEvaluationRun(context, subject, verifierRuntime, attempts, infrastructureErrors, traceAggregate) {
   const { runId, suite, repeat, startedAt, sourceGitSha, evaluatorDigest, verifierDigest,
     scenarios, frozenRunPolicy, scheduleDigest, toolchainMeasurement,
-    provider, model, reasoningEffort } = context;
+    provider, model, reasoningEffort, agentProfile, traceAttribution } = context;
   const firstEnvironmentDigest = attempts[0]?.subject?.environmentDigest ?? null;
   return {
     schemaVersion: 1,
@@ -1668,12 +1755,68 @@ function rawEvaluationRun(context, subject, verifierRuntime, attempts, infrastru
     finishedAt: new Date().toISOString(),
     subject: rawRunSubject(
       subject, verifierRuntime, sourceGitSha, evaluatorDigest, verifierDigest,
-      firstEnvironmentDigest, toolchainMeasurement, provider, model, reasoningEffort
+      firstEnvironmentDigest, toolchainMeasurement, provider, model, reasoningEffort, agentProfile
     ),
     scenarios: scenarios.map((scenario) => ({ scenarioId: scenario.id, scenarioDigest: digest(scenario) })),
     attempts,
+    ...(traceAttribution && traceAggregate ? {
+      traceAttribution: {
+        schemaVersion: 1,
+        report: "trace-attribution.json",
+        markdown: "trace-attribution.md"
+      }
+    } : {}),
     infrastructureErrors
   };
+}
+
+function traceSummaries(attempts) {
+  return attempts.map((attempt) => attempt.traceAttribution?.summary ?? {
+    attemptId: attempt.attemptId,
+    scenarioId: attempt.scenarioId,
+    repetition: attempt.repetition,
+    successful: false,
+    finalStatus: "attribution_unavailable",
+    timeout: false,
+    infrastructureFailure: true,
+    totals: {
+      modelTurns: 0, toolCalls: 0, repeatedToolCalls: 0,
+      repeatedObservations: 0, repeatedReads: 0, repeatedValidations: 0,
+      turnCategories: {}, uncachedTokenProxy: { value: 0 },
+      providerCacheReadTokens: { value: 0 }, toolOutputRawBytes: { value: 0 },
+      toolOutputModelVisibleBytes: { value: 0 }, estimatedRequestComposition: {},
+      proxyCostAttribution: {}
+    },
+    timing: {
+      totalLatencyMs: null, timeToFirstActionMs: null,
+      timeToFirstMutationMs: null, completionTailMs: null
+    },
+    completionTailTurns: 0,
+    reportDigest: null
+  });
+}
+
+async function writeTraceAggregate(context, attempts, infrastructureErrors) {
+  if (!context.traceAttribution) return null;
+  try {
+    const report = buildAggregateTraceAttribution(traceSummaries(attempts), {
+      runId: context.runId,
+      finishedAt: attempts.map((attempt) => attempt.finishedAt).sort().at(-1) ?? context.startedAt,
+      provider: context.provider,
+      model: context.model,
+      reasoningEffort: context.reasoningEffort,
+      profile: context.agentProfile,
+      runMode: "change"
+    });
+    const paths = await writeAggregateTraceAttribution(context.runDir, report, context.redactor);
+    return { report, ...paths };
+  } catch (error) {
+    const detail = context.redactor(error instanceof Error ? error.stack ?? error.message : String(error));
+    infrastructureErrors.push({ code: "trace_attribution_write_failed", phase: "trace_attribution", detail });
+    await writeFile(path.join(context.runDir, "trace-attribution-error.log"), `${detail}\n`, "utf8")
+      .catch(() => undefined);
+    return null;
+  }
 }
 
 function subjectValue(subject, key) {
@@ -1690,10 +1833,11 @@ function rawRunSubject(
   toolchainMeasurement,
   provider,
   model,
-  reasoningEffort
+  reasoningEffort,
+  agentProfile
 ) {
   return {
-    provider, model, reasoningEffort,
+    provider, model, reasoningEffort, profile: agentProfile,
     platform: process.platform, arch: process.arch, gitSha: sourceGitSha,
     subjectKind: subjectValue(subject, "subjectKind") ?? "unavailable", surface: "mixed",
     evaluatorDigest, verifierDigest,
@@ -1742,10 +1886,12 @@ export async function runEvaluation(options = {}, deps = {}) {
   const infrastructureErrors = [];
   const preparation = await prepareEvaluationSubject(context, options, deps, infrastructureErrors);
   const attempts = await executeEvaluationSchedule(context, preparation, deps, infrastructureErrors);
+  const traceAggregate = await writeTraceAggregate(context, attempts, infrastructureErrors);
   const rawRun = rawEvaluationRun(
-    context, preparation.subject, preparation.verifierRuntime, attempts, infrastructureErrors
+    context, preparation.subject, preparation.verifierRuntime, attempts, infrastructureErrors, traceAggregate
   );
-  return await writeSafeEvaluationReport(context, rawRun, infrastructureErrors);
+  const result = await writeSafeEvaluationReport(context, rawRun, infrastructureErrors);
+  return traceAggregate ? { ...result, traceReportPath: traceAggregate.jsonPath } : result;
 }
 
 export { prepareSubject, runAttempt };

--- a/scripts/eval/subject-cli.mjs
+++ b/scripts/eval/subject-cli.mjs
@@ -144,7 +144,8 @@ async function cancelSession({
   subject,
   provider = sigmaManifest.evaluation.provider,
   model = sigmaManifest.evaluation.model,
-  reasoningEffort = "provider_default"
+  reasoningEffort = "provider_default",
+  agentProfile = "standard"
 }) {
   if (!sessionId) return { exitCode: 1, stderr: "Session id was not observed before cancellation." };
   const launch = subjectNodeLaunch(subject);
@@ -155,6 +156,7 @@ async function cancelSession({
     "--model", model,
     ...(reasoningEffort === "provider_default"
       ? [] : ["--reasoning-effort", reasoningEffort]),
+    "--agent-profile", agentProfile,
     "--reason", reason
   ], subject), { cwd: workspace, env, timeoutMs: CANCEL_GRACE_MS });
   return await operation.exited;
@@ -169,7 +171,8 @@ function startCliSubject({
   subject,
   provider = sigmaManifest.evaluation.provider,
   model = sigmaManifest.evaluation.model,
-  reasoningEffort = "provider_default"
+  reasoningEffort = "provider_default",
+  agentProfile = "standard"
 }) {
   const command = runMode === "analyze" ? "inspect" : "run";
   const args = nodeCliArgs([
@@ -180,6 +183,7 @@ function startCliSubject({
     "--model", model,
     ...(reasoningEffort === "provider_default"
       ? [] : ["--reasoning-effort", reasoningEffort]),
+    "--agent-profile", agentProfile,
     "--permission-mode", "auto",
     "--output-format", "stream-json"
   ], subject);
@@ -206,12 +210,13 @@ export async function runCliSubject(options) {
     onEvent = () => undefined, subject = {},
     provider = sigmaManifest.evaluation.provider,
     model = sigmaManifest.evaluation.model,
-    reasoningEffort = "provider_default"
+    reasoningEffort = "provider_default",
+    agentProfile = "standard"
   } = options;
   await mkdir(artifactDir, { recursive: true });
   const { child, startedAt } = startCliSubject({
     workspace, stateHome, promptPath, runMode, env, subject,
-    provider, model, reasoningEffort
+    provider, model, reasoningEffort, agentProfile
   });
   const events = [];
   let result;
@@ -263,7 +268,8 @@ export async function runCliSubject(options) {
       subject,
       provider,
       model,
-      reasoningEffort
+      reasoningEffort,
+      agentProfile
     }).then((cancelResult) => {
       cancellation.cancelExitCode = cancelResult.exitCode;
       if (cancelResult.exitCode !== 0 && !treeTerminationPromise) {

--- a/scripts/eval/subject-tui.mjs
+++ b/scripts/eval/subject-tui.mjs
@@ -135,6 +135,7 @@ export async function runTuiSubject(options) {
     provider = sigmaManifest.evaluation.provider,
     model = sigmaManifest.evaluation.model,
     reasoningEffort = "provider_default",
+    agentProfile = "standard",
     eventStreamTimeoutMs = 10_000
   } = options;
   await Promise.all([mkdir(artifactDir, { recursive: true }), mkdir(controllerDir, { recursive: true })]);
@@ -151,6 +152,7 @@ export async function runTuiSubject(options) {
       "--model", model,
       ...(reasoningEffort === "provider_default"
         ? [] : ["--reasoning-effort", reasoningEffort]),
+      "--agent-profile", agentProfile,
       "--permission-mode", permissionPolicy === "auto" ? "auto" : "ask"
     ]),
     workspace,

--- a/scripts/eval/trace-attribution-classifier.mjs
+++ b/scripts/eval/trace-attribution-classifier.mjs
@@ -1,0 +1,278 @@
+import { eventRef } from "./trace-attribution-schema.mjs";
+import { elapsedMs, mutationEvent } from "./trace-attribution-events.mjs";
+
+const FAILURE_TYPES = new Set(["model.failed", "tool.failed", "execution.failed", "process.lost"]);
+
+function failedEvent(event) {
+  return FAILURE_TYPES.has(event.type)
+    || (event.type === "process.exited" && event.payload?.exitCode !== 0);
+}
+
+function explicitRecovery(event) {
+  return event.type === "diagnostic" && (
+    String(event.payload?.kind ?? "").startsWith("recovery.")
+    || ["runtime.dependency_prepared", "runtime.dependency_reprobed"].includes(event.payload?.kind)
+  );
+}
+
+function refs(events) {
+  return events.map(eventRef).filter(Boolean);
+}
+
+function uniqueRefs(items) {
+  const seen = new Set();
+  return items.filter((item) => {
+    if (!item || seen.has(item.eventId)) return false;
+    seen.add(item.eventId);
+    return true;
+  });
+}
+
+function baseClassification(turn, prior) {
+  const mutationRefs = refs(turn.events.filter(mutationEvent));
+  const validationRefs = uniqueRefs([
+    ...turn.calls.filter((call) => call.validation).map((call) => call.requestedRef),
+    ...refs(turn.states.validationEvents)
+  ]);
+  const recoveryRefs = uniqueRefs([
+    ...refs(turn.events.filter(explicitRecovery)),
+    ...refs(prior?.events.filter(failedEvent) ?? [])
+  ]);
+  const userRefs = uniqueRefs([
+    ...refs(turn.events.filter((event) => event.type === "run.suspended")),
+    ...turn.calls.filter((call) => call.effects.includes("outcome.request_input"))
+      .map((call) => call.requestedRef)
+  ]);
+  const mutation = turn.mutationFrontierRevision.end > turn.mutationFrontierRevision.start;
+  const validation = validationRefs.length > 0;
+  const recovery = recoveryRefs.length > 0;
+  const userInput = userRefs.length > 0;
+  const inspect = turn.calls.length > 0 && !mutation && !validation && !userInput;
+  return { mutation, mutationRefs, validation, validationRefs, recovery, recoveryRefs, userInput, userRefs, inspect };
+}
+
+function primaryCategory(state, turn) {
+  if (state.userInput) return "user_input";
+  if (state.recovery) return "recovery";
+  if (state.mutation) return "mutation";
+  if (state.validation) return "validation";
+  if (state.inspect) return "inspect";
+  if (turn.states.completion) return "completion";
+  return "other";
+}
+
+function classificationRecord(turn, prior) {
+  const state = baseClassification(turn, prior);
+  const labels = [
+    ...(state.inspect ? ["inspect"] : []),
+    ...(state.mutation ? ["mutation"] : []),
+    ...(state.validation ? ["validation"] : []),
+    ...(state.recovery ? ["recovery"] : []),
+    ...(state.userInput ? ["user_input"] : [])
+  ];
+  const sourceRefs = uniqueRefs([
+    ...state.mutationRefs,
+    ...state.validationRefs,
+    ...state.recoveryRefs,
+    ...state.userRefs,
+    ...turn.calls.map((call) => call.requestedRef),
+    eventRef(turn.states.completion)
+  ]);
+  return {
+    turnOrdinal: turn.ordinal,
+    turnId: turn.turnId,
+    primary: primaryCategory(state, turn),
+    labels,
+    sourceRefs
+  };
+}
+
+function repeatRecord(kind, current, previous, extra = {}) {
+  return {
+    kind,
+    ...extra,
+    mutationFrontierRevision: current.mutationFrontierRevision,
+    previousMutationFrontierRevision: previous.mutationFrontierRevision,
+    mutationIntervened: previous.mutationFrontierRevision !== current.mutationFrontierRevision,
+    previousRef: previous.requestedRef ?? previous.eventRef,
+    currentRef: current.requestedRef ?? current.eventRef
+  };
+}
+
+function toolRepeats(turns) {
+  const seen = new Map();
+  const repeated = [];
+  for (const turn of turns) for (const call of turn.calls) {
+    const key = [call.mutationFrontierRevision, call.toolName, call.canonicalArgumentsDigest].join(":");
+    const previous = seen.get(key);
+    if (previous) repeated.push(repeatRecord("canonical_tool_call", call, previous, {
+      toolName: call.toolName,
+      canonicalArgumentsDigest: call.canonicalArgumentsDigest
+    }));
+    seen.set(key, call);
+  }
+  return repeated;
+}
+
+function readRepeats(turns) {
+  const seen = new Map();
+  const repeated = [];
+  for (const turn of turns) for (const call of turn.calls) {
+    if (!call.readScopeDigest) continue;
+    const key = [call.mutationFrontierRevision, call.toolName, call.readScopeDigest].join(":");
+    const previous = seen.get(key);
+    if (previous) repeated.push(repeatRecord("same_path_and_range", call, previous, {
+      toolName: call.toolName,
+      readScopeDigest: call.readScopeDigest
+    }));
+    seen.set(key, call);
+  }
+  return repeated;
+}
+
+function observationRecords(call) {
+  if (!call.result) return [];
+  const digests = new Map([[call.result.fullOutputDigest, "output"]]);
+  for (const artifact of call.result.fullArtifactDigests) {
+    if (!digests.has(artifact.digest)) digests.set(artifact.digest, artifact.source);
+  }
+  return [...digests].map(([observationDigest, source]) => ({
+    observationDigest,
+    source,
+    mutationFrontierRevision: call.mutationFrontierRevision,
+    eventRef: call.result.eventRef,
+    toolName: call.toolName
+  }));
+}
+
+function observationRepeats(turns) {
+  const seen = new Map();
+  const repeated = [];
+  for (const turn of turns) for (const call of turn.calls) for (const observation of observationRecords(call)) {
+    const key = observation.observationDigest;
+    const previous = seen.get(key);
+    if (previous) repeated.push(repeatRecord("same_artifact_or_output", observation, previous, {
+      toolName: observation.toolName,
+      observationDigest: observation.observationDigest,
+      observationSource: observation.source
+    }));
+    seen.set(key, observation);
+  }
+  return repeated;
+}
+
+function validationObservations(turn) {
+  const calls = turn.calls.filter((call) => call.validation).map((call) => ({
+    turnOrdinal: turn.ordinal,
+    mutationFrontierRevision: call.mutationFrontierRevision,
+    eventRef: call.requestedRef
+  }));
+  if (calls.length > 0) return calls;
+  return turn.states.validationEvents.map((event) => ({
+    turnOrdinal: turn.ordinal,
+    mutationFrontierRevision: Number.isSafeInteger(event.payload?.data?.frontierRevision)
+      ? event.payload.data.frontierRevision : turn.mutationFrontierRevision.end,
+    eventRef: eventRef(event)
+  }));
+}
+
+function validationRepeats(turns) {
+  const seen = new Map();
+  const repeats = [];
+  const effective = [];
+  for (const turn of turns) for (const current of validationObservations(turn)) {
+    const previous = seen.get(current.mutationFrontierRevision);
+    if (previous) repeats.push(repeatRecord("validation_without_new_mutation", current, previous));
+    else effective.push(current);
+    seen.set(current.mutationFrontierRevision, current);
+  }
+  return { repeats, effective, all: [...seen.values()] };
+}
+
+function turnForEvent(turns, event) {
+  return event ? turns.find((turn) => turn.events.some((item) => item.eventId === event.eventId)) : null;
+}
+
+function milestone(turn, event) {
+  return turn && event ? { turnOrdinal: turn.ordinal, turnId: turn.turnId, eventRef: eventRef(event) } : null;
+}
+
+function mutationMilestones(turns) {
+  const items = turns.flatMap((turn) => turn.events.filter(mutationEvent)
+    .map((event) => ({ turn, event })));
+  return {
+    firstMutation: items[0] ? milestone(items[0].turn, items[0].event) : null,
+    lastMutation: items.at(-1) ? milestone(items.at(-1).turn, items.at(-1).event) : null
+  };
+}
+
+function completionTail(turns, classifications, mutation, validation, completion) {
+  const anchors = [mutation.lastMutation, ...validation.effective.map((item) => ({
+    turnOrdinal: item.turnOrdinal,
+    turnId: turns.find((turn) => turn.ordinal === item.turnOrdinal)?.turnId,
+    eventRef: item.eventRef
+  }))].filter(Boolean).sort((left, right) => left.eventRef.seq - right.eventRef.seq);
+  const anchor = anchors.at(-1) ?? null;
+  const completionTurn = completion?.turnOrdinal ?? null;
+  const tail = anchor && completionTurn !== null
+    ? turns.filter((turn) => turn.ordinal > anchor.turnOrdinal && turn.ordinal <= completionTurn)
+    : [];
+  for (const turn of tail) {
+    const record = classifications.find((item) => item.turnOrdinal === turn.ordinal);
+    if (record && !record.labels.includes("completion_tail")) record.labels.push("completion_tail");
+  }
+  return {
+    anchor,
+    completion,
+    count: tail.length,
+    turns: tail.map((turn) => ({
+      turnOrdinal: turn.ordinal,
+      turnId: turn.turnId,
+      sourceRefs: [turn.startRef, turn.endRef].filter(Boolean)
+    })),
+    latencyMs: anchor && completion
+      ? elapsedMs({ occurredAt: turns.find((turn) => turn.ordinal === anchor.turnOrdinal)?.events
+        .find((event) => event.eventId === anchor.eventRef.eventId)?.occurredAt },
+      { occurredAt: turns.find((turn) => turn.ordinal === completion.turnOrdinal)?.events
+        .find((event) => event.eventId === completion.eventRef.eventId)?.occurredAt }) : null
+  };
+}
+
+function categoryIndex(classifications) {
+  const names = ["inspect", "mutation", "validation", "recovery", "user_input", "completion_tail"];
+  return Object.fromEntries(names.map((name) => {
+    const turns = classifications.filter((item) => item.labels.includes(name))
+      .map((item) => ({ turnOrdinal: item.turnOrdinal, turnId: item.turnId, sourceRefs: item.sourceRefs }));
+    return [name, { count: turns.length, turns }];
+  }));
+}
+
+export function classifyTrace(indexed) {
+  const classifications = indexed.turns.map((turn, index) => classificationRecord(turn, indexed.turns[index - 1]));
+  const toolCalls = toolRepeats(indexed.turns);
+  const reads = readRepeats(indexed.turns);
+  const observations = observationRepeats(indexed.turns);
+  const validations = validationRepeats(indexed.turns);
+  const mutations = mutationMilestones(indexed.turns);
+  const firstCall = indexed.turns.flatMap((turn) => turn.calls.map((call) => ({ turn, call })))[0];
+  const completionEvent = indexed.events.findLast((event) => event.type === "run.completed") ?? null;
+  const completionTurn = turnForEvent(indexed.turns, completionEvent);
+  const finalCompletion = milestone(completionTurn, completionEvent);
+  const tail = completionTail(indexed.turns, classifications, mutations, validations, finalCompletion);
+  return {
+    classifications,
+    categories: categoryIndex(classifications),
+    repeats: { toolCalls, reads, observations, validations: validations.repeats },
+    milestones: {
+      firstToolCall: firstCall ? {
+        turnOrdinal: firstCall.turn.ordinal,
+        turnId: firstCall.turn.turnId,
+        eventRef: firstCall.call.requestedRef
+      } : null,
+      ...mutations,
+      firstValidation: validations.effective[0] ?? null,
+      finalCompletion
+    },
+    completionTail: tail
+  };
+}

--- a/scripts/eval/trace-attribution-events.mjs
+++ b/scripts/eval/trace-attribution-events.mjs
@@ -1,0 +1,216 @@
+import { digest } from "./common.mjs";
+import {
+  canonicalArgumentsDigest,
+  eventRef,
+  readScopeDigest,
+  safeLabel
+} from "./trace-attribution-schema.mjs";
+
+const MUTATION_EFFECTS = new Set([
+  "filesystem.write", "repository.write", "checkpoint.restore", "destructive"
+]);
+
+function eventTimestamp(event) {
+  const value = Date.parse(event?.occurredAt ?? "");
+  return Number.isFinite(value) ? value : null;
+}
+
+export function elapsedMs(start, end) {
+  const left = eventTimestamp(start);
+  const right = eventTimestamp(end);
+  return left === null || right === null ? null : Math.max(0, right - left);
+}
+
+function changedDelta(delta) {
+  return delta && [delta.added, delta.modified, delta.deleted]
+    .some((items) => Array.isArray(items) && items.length > 0);
+}
+
+function evidenceMutates(payload) {
+  if (payload?.kind === "repository_delta") return true;
+  if (payload?.kind === "checkpoint" && payload.data?.sourceSessionId) return true;
+  return payload?.kind === "diagnostic"
+    && payload.data?.source === "enclosing_container_mutation"
+    && Array.isArray(payload.data?.diagnostic?.declaredPaths)
+    && payload.data.diagnostic.declaredPaths.length > 0;
+}
+
+export function mutationEvent(event) {
+  if (event.type === "checkpoint.restored") return true;
+  if (event.type === "checkpoint.sealed") {
+    return event.payload?.delta === undefined || changedDelta(event.payload.delta);
+  }
+  return event.type === "evidence.recorded" && evidenceMutates(event.payload);
+}
+
+export function mutationTimeline(events) {
+  const before = new Map();
+  const after = new Map();
+  let revision = 0;
+  for (const event of events) {
+    before.set(event.eventId, revision);
+    if (mutationEvent(event)) revision += 1;
+    after.set(event.eventId, revision);
+  }
+  return { before, after, finalRevision: revision };
+}
+
+function eventWindows(events) {
+  const starts = events.map((event, index) => ({ event, index }))
+    .filter((item) => item.event.type === "model.started");
+  return starts.map((item, ordinal) => ({
+    ordinal: ordinal + 1,
+    start: item.event,
+    nextStart: starts[ordinal + 1]?.event ?? null,
+    events: events.slice(item.index, starts[ordinal + 1]?.index ?? events.length)
+  }));
+}
+
+function effectsForCall(call, windowEvents, executionPlans) {
+  const planned = executionPlans.get(call.payload.callId)?.payload?.plan?.exactEffects ?? [];
+  const receipt = windowEvents.find((event) => ["tool.completed", "tool.failed"].includes(event.type)
+    && event.payload?.callId === call.payload.callId);
+  return {
+    effects: [...new Set([
+      ...planned,
+      ...(receipt?.payload?.observedEffects ?? []),
+      ...(receipt?.payload?.actualEffects ?? [])
+    ])].sort(),
+    receipt
+  };
+}
+
+function artifactDigests(payload, outputDigest) {
+  const refs = (payload?.artifactRefs ?? [])
+    .filter((item) => typeof item?.digest === "string")
+    .map((item) => ({ digest: item.digest, source: "artifact_ref" }));
+  return refs.length > 0 ? refs : [{ digest: outputDigest, source: "durable_full_output" }];
+}
+
+function receiptObservation(payload, output) {
+  const observed = payload?.traceObservation ?? {};
+  const rawBytes = Buffer.byteLength(output, "utf8");
+  const fullOutputDigest = digest(output);
+  return {
+    rawBytes,
+    rawBytesAccuracy: "durable_exact",
+    modelVisibleBytes: Number.isSafeInteger(observed.modelVisibleBytes)
+      ? observed.modelVisibleBytes : null,
+    fullOutputDigest,
+    observationIntegrity: observed.schemaVersion === 1
+      ? observed.rawBytes === rawBytes && observed.fullOutputDigest === fullOutputDigest
+      : "unavailable",
+    modelVisibleBytesAccuracy: Number.isSafeInteger(observed.modelVisibleBytes)
+      ? "runtime_exact" : "unavailable"
+  };
+}
+
+function toolResult(receipt, redactor) {
+  if (!receipt) return null;
+  const output = typeof receipt.payload?.output === "string" ? receipt.payload.output : "";
+  const observation = receiptObservation(receipt.payload, output);
+  return {
+    status: receipt.type === "tool.completed" ? "completed" : "failed",
+    ...observation,
+    fullArtifactDigests: artifactDigests(receipt.payload, observation.fullOutputDigest)
+      .map((item) => ({ ...item, digest: safeLabel(item.digest, redactor) })),
+    durationMs: elapsedMs(
+      { occurredAt: receipt.payload?.startedAt },
+      { occurredAt: receipt.payload?.completedAt }
+    ),
+    eventRef: eventRef(receipt)
+  };
+}
+
+function toolCallRecord(call, windowEvents, executionPlans, timeline, redactor) {
+  const { effects, receipt } = effectsForCall(call, windowEvents, executionPlans);
+  const name = safeLabel(call.payload?.name, redactor);
+  const argumentsValue = call.payload?.arguments ?? {};
+  const revision = timeline.before.get(call.eventId) ?? 0;
+  const validation = effects.includes("validation") || name === "validate";
+  return {
+    callId: safeLabel(call.payload?.callId, redactor),
+    toolName: name,
+    canonicalArgumentsDigest: canonicalArgumentsDigest(argumentsValue, redactor),
+    readScopeDigest: effects.some((effect) => effect.startsWith("filesystem.read"))
+      ? readScopeDigest(argumentsValue, redactor) : null,
+    mutationFrontierRevision: revision,
+    effects,
+    mutationPlannedOrObserved: effects.some((effect) => MUTATION_EFFECTS.has(effect)),
+    validation,
+    requestedRef: eventRef(call),
+    result: toolResult(receipt, redactor)
+  };
+}
+
+function windowStates(windowEvents) {
+  const validationEvents = windowEvents.filter((event) => event.type === "evidence.recorded"
+    && event.payload?.kind === "validation");
+  const checkpointEvents = windowEvents.filter((event) => event.type.startsWith("checkpoint."));
+  const completion = windowEvents.find((event) => event.type === "run.completed");
+  const suspended = windowEvents.find((event) => event.type === "run.suspended");
+  return {
+    validationEvents,
+    checkpointEvents,
+    completion,
+    suspended
+  };
+}
+
+function modelEvents(windowEvents, turnId) {
+  const completion = windowEvents.find((event) => event.type === "model.completed"
+    && event.payload?.turnId === turnId);
+  const failure = windowEvents.find((event) => event.type === "model.failed"
+    && event.payload?.turnId === turnId);
+  const prompt = windowEvents.find((event) => event.type === "model.prompt_materialized"
+    && event.payload?.turnId === turnId);
+  const usage = completion?.payload?.usage ?? windowEvents.find((event) => event.type === "usage.recorded"
+    && String(event.payload?.requestId ?? "").endsWith(`:${turnId}`))?.payload;
+  return { completion, failure, prompt, usage };
+}
+
+function windowEndEvent(windowEvents) {
+  return windowEvents.findLast((event) => [
+    "run.completed", "run.cancelled", "run.failed", "run.suspended"
+  ].includes(event.type)) ?? windowEvents.at(-1);
+}
+
+export function traceTurns(events, redactor = String) {
+  const ordered = [...events].sort((left, right) => left.seq - right.seq);
+  const timeline = mutationTimeline(ordered);
+  const executionPlans = new Map(ordered.filter((event) => event.type === "execution.planned")
+    .map((event) => [event.payload?.toolCallId, event]));
+  const turns = eventWindows(ordered).map((window) => {
+    const turnId = window.start.payload?.turnId;
+    const calls = window.events.filter((event) => event.type === "tool.requested")
+      .map((call) => toolCallRecord(call, window.events, executionPlans, timeline, redactor));
+    const model = modelEvents(window.events, turnId);
+    const states = windowStates(window.events);
+    const last = windowEndEvent(window.events);
+    return {
+      ordinal: window.ordinal,
+      turnId,
+      startRef: eventRef(window.start),
+      endRef: eventRef(last),
+      startEvent: window.start,
+      boundaryEvent: window.nextStart ?? last,
+      events: window.events,
+      model,
+      calls,
+      states,
+      mutationFrontierRevision: {
+        start: timeline.before.get(window.start.eventId) ?? 0,
+        end: timeline.after.get(last?.eventId) ?? timeline.finalRevision
+      }
+    };
+  });
+  return { events: ordered, turns, timeline };
+}
+
+export function firstEvent(events, predicate) {
+  return events.find(predicate) ?? null;
+}
+
+export function lastEvent(events, predicate) {
+  return events.findLast(predicate) ?? null;
+}

--- a/scripts/eval/trace-attribution-events.mjs
+++ b/scripts/eval/trace-attribution-events.mjs
@@ -26,9 +26,14 @@ function changedDelta(delta) {
     .some((items) => Array.isArray(items) && items.length > 0);
 }
 
+function successfulRestoration(payload) {
+  return payload?.kind === "restoration" && payload.status === "passed";
+}
+
 function evidenceMutates(payload) {
   if (payload?.kind === "repository_delta") return true;
   if (payload?.kind === "checkpoint" && payload.data?.sourceSessionId) return true;
+  if (successfulRestoration(payload)) return true;
   return payload?.kind === "diagnostic"
     && payload.data?.source === "enclosing_container_mutation"
     && Array.isArray(payload.data?.diagnostic?.declaredPaths)

--- a/scripts/eval/trace-attribution-schema.mjs
+++ b/scripts/eval/trace-attribution-schema.mjs
@@ -1,0 +1,132 @@
+import { canonicalJson, digest } from "./common.mjs";
+
+export const TRACE_ATTRIBUTION_SCHEMA_VERSION = 1;
+export const TRACE_ATTRIBUTION_SCHEMA_ID = "https://sigmacode.biz/schemas/trace-attribution/v1";
+export const TRACE_ATTRIBUTION_VERSION = "trace-attribution-1.0.0";
+export const TOKEN_ESTIMATOR = "context_plan_approximate_tokens";
+export const TOKEN_PROXY = "uncached_input_plus_output_v1";
+
+const PATH_KEY = /(?:^|_)(?:path|paths|file|files|directory|directories|root|cwd)$/iu;
+const RANGE_KEY = /(?:^|_)(?:start|end|line|lines|offset|limit|range)$/iu;
+
+export function eventRef(event) {
+  return event ? { eventId: event.eventId, seq: event.seq, type: event.type } : null;
+}
+
+export function safeLabel(value, redactor = String) {
+  return redactor(typeof value === "string" ? value : String(value ?? "unknown"));
+}
+
+function normalizeValue(value, key = "") {
+  if (Array.isArray(value)) return value.map((item) => normalizeValue(item, key));
+  if (value && typeof value === "object") {
+    return Object.fromEntries(Object.entries(value)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([childKey, item]) => [childKey, normalizeValue(item, childKey)]));
+  }
+  if (typeof value === "string" && PATH_KEY.test(key)) return value.replace(/\\/gu, "/");
+  return value;
+}
+
+export function canonicalArgumentsDigest(value, redactor = String) {
+  return digest(redactor(canonicalJson(normalizeValue(value ?? {}))));
+}
+
+function scopeEntries(value, prefix = []) {
+  if (Array.isArray(value)) return value.flatMap((item, index) => scopeEntries(item, [...prefix, index]));
+  if (!value || typeof value !== "object") return [];
+  return Object.entries(value).sort(([left], [right]) => left.localeCompare(right)).flatMap(([key, item]) => {
+    const nested = scopeEntries(item, [...prefix, key]);
+    return PATH_KEY.test(key) || RANGE_KEY.test(key)
+      ? [{ key: [...prefix, key].join("."), value: normalizeValue(item, key) }, ...nested]
+      : nested;
+  });
+}
+
+export function readScopeDigest(value, redactor = String) {
+  const entries = scopeEntries(value ?? {});
+  return entries.length > 0 ? digest(redactor(canonicalJson(entries))) : null;
+}
+
+function finiteToken(value) {
+  return Number.isFinite(value) && value >= 0 ? Math.trunc(value) : null;
+}
+
+function nativeUsageAvailable(usage) {
+  if (usage?.providerReported !== true) return false;
+  const input = finiteToken(usage.inputTokens);
+  const output = finiteToken(usage.outputTokens);
+  return input !== null && output !== null && input + output > 0;
+}
+
+function providerUsage(usage) {
+  const available = nativeUsageAvailable(usage);
+  const cache = finiteToken(usage?.cacheReadTokens);
+  return {
+    accuracy: available ? "provider_native" : "unavailable",
+    inputTokens: available ? finiteToken(usage.inputTokens) : null,
+    outputTokens: available ? finiteToken(usage.outputTokens) : null,
+    cacheReadTokens: available && cache !== null ? cache : null,
+    cacheReadAccuracy: !available || cache === null
+      ? "unavailable"
+      : cache > 0 ? "provider_native" : "provider_or_adapter_default_zero"
+  };
+}
+
+function accountedUsage(usage, native) {
+  const inputTokens = finiteToken(usage?.inputTokens);
+  const outputTokens = finiteToken(usage?.outputTokens);
+  const cacheReadTokens = finiteToken(usage?.cacheReadTokens);
+  return {
+    accuracy: native.accuracy === "provider_native" ? "provider_native" : "runtime_estimated_or_defaulted",
+    inputTokens,
+    outputTokens,
+    cacheReadTokens
+  };
+}
+
+export function tokenUsageAttribution(usage) {
+  const providerReported = providerUsage(usage);
+  const accounted = accountedUsage(usage, providerReported);
+  const complete = [accounted.inputTokens, accounted.outputTokens, accounted.cacheReadTokens]
+    .every((value) => value !== null);
+  const value = complete
+    ? Math.max(0, accounted.inputTokens - accounted.cacheReadTokens) + accounted.outputTokens
+    : null;
+  return {
+    providerReported,
+    accounted,
+    uncachedInputPlusOutputV1: {
+      name: TOKEN_PROXY,
+      formula: "max(0,input_tokens-cache_read_tokens)+output_tokens",
+      value,
+      accuracy: providerReported.accuracy === "provider_native"
+        && providerReported.cacheReadAccuracy === "provider_native"
+        ? "provider_native" : value === null ? "unavailable" : "mixed_or_estimated"
+    }
+  };
+}
+
+export function reportWithDigest(report) {
+  const reportDigest = digest(report);
+  return { ...report, reportDigest };
+}
+
+function percentile(sorted, fraction) {
+  if (sorted.length === 0) return null;
+  return sorted[Math.min(sorted.length - 1, Math.ceil(sorted.length * fraction) - 1)];
+}
+
+export function distribution(values) {
+  const sorted = values.filter(Number.isFinite).sort((left, right) => left - right);
+  if (sorted.length === 0) return { count: 0, min: null, p50: null, p90: null, p95: null, max: null, mean: null };
+  return {
+    count: sorted.length,
+    min: sorted[0],
+    p50: percentile(sorted, 0.5),
+    p90: percentile(sorted, 0.9),
+    p95: percentile(sorted, 0.95),
+    max: sorted.at(-1),
+    mean: Math.round(sorted.reduce((total, value) => total + value, 0) / sorted.length)
+  };
+}

--- a/scripts/eval/trace-attribution.mjs
+++ b/scripts/eval/trace-attribution.mjs
@@ -1,0 +1,475 @@
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+import { digest, writeJson } from "./common.mjs";
+import { classifyTrace } from "./trace-attribution-classifier.mjs";
+import { elapsedMs, firstEvent, lastEvent, traceTurns } from "./trace-attribution-events.mjs";
+import {
+  distribution,
+  eventRef,
+  reportWithDigest,
+  safeLabel,
+  TOKEN_ESTIMATOR,
+  TRACE_ATTRIBUTION_SCHEMA_ID,
+  TRACE_ATTRIBUTION_SCHEMA_VERSION,
+  TRACE_ATTRIBUTION_VERSION,
+  tokenUsageAttribution
+} from "./trace-attribution-schema.mjs";
+
+function requestComposition(prompt) {
+  const observation = prompt?.payload?.traceObservation;
+  const tokens = observation?.estimatedTokens;
+  if (!tokens) return {
+    accuracy: "unavailable",
+    estimator: TOKEN_ESTIMATOR,
+    systemBaseContext: null,
+    toolSchema: null,
+    conversationHistory: null,
+    toolResults: null,
+    total: null
+  };
+  return {
+    accuracy: "estimated",
+    estimator: observation.tokenEstimator,
+    systemBaseContext: tokens.systemBaseContext,
+    toolSchema: tokens.toolSchema,
+    conversationHistory: tokens.conversationHistory,
+    toolResults: tokens.toolResults,
+    total: tokens.total
+  };
+}
+
+function allocateInteger(total, weights) {
+  const entries = Object.entries(weights);
+  const denominator = entries.reduce((sum, [, value]) => sum + value, 0);
+  if (!Number.isFinite(total) || denominator <= 0) return null;
+  let remaining = total;
+  return Object.fromEntries(entries.map(([key, value], index) => {
+    const allocation = index === entries.length - 1
+      ? remaining : Math.floor(total * value / denominator);
+    remaining -= allocation;
+    return [key, allocation];
+  }));
+}
+
+function proxyAttribution(usage, composition) {
+  const accounted = usage.accounted;
+  if ([accounted.inputTokens, accounted.outputTokens, accounted.cacheReadTokens, composition.total]
+    .some((value) => value === null)) return { accuracy: "unavailable", components: null };
+  const uncachedInput = Math.max(0, accounted.inputTokens - accounted.cacheReadTokens);
+  const input = allocateInteger(uncachedInput, {
+    systemBaseContext: composition.systemBaseContext,
+    toolSchema: composition.toolSchema,
+    conversationHistory: composition.conversationHistory,
+    toolResults: composition.toolResults
+  });
+  if (!input) return { accuracy: "unavailable", components: null };
+  return {
+    accuracy: usage.providerReported.accuracy === "provider_native"
+      ? "estimated_allocation_over_provider_or_adapter_usage" : "estimated_allocation",
+    components: { ...input, modelOutput: accounted.outputTokens }
+  };
+}
+
+function modelLatency(turn) {
+  const terminal = turn.model.completion ?? turn.model.failure;
+  const usageLatency = turn.model.usage?.latencyMs;
+  const toolDurations = turn.calls.map((call) => call.result?.durationMs).filter(Number.isFinite);
+  const completeToolTiming = toolDurations.length === turn.calls.length;
+  return {
+    modelCallMs: Number.isFinite(usageLatency) ? Math.max(0, Math.round(usageLatency)) : elapsedMs(turn.startEvent, terminal),
+    modelCallSource: Number.isFinite(usageLatency) ? "runtime_usage_record" : "event_lifecycle",
+    toolExecutionMs: completeToolTiming
+      ? toolDurations.reduce((total, value) => total + value, 0) : null,
+    toolExecutionObservedCount: toolDurations.length,
+    toolExecutionAccuracy: completeToolTiming ? "runtime_exact" : "unavailable_or_partial",
+    totalTurnMs: elapsedMs(turn.startEvent, turn.boundaryEvent)
+  };
+}
+
+function validationState(turn, classified) {
+  const repeatedRefs = new Set(classified.repeats.validations.map((item) => item.currentRef?.eventId));
+  const refs = [
+    ...turn.calls.filter((call) => call.validation).map((call) => call.requestedRef),
+    ...turn.states.validationEvents.map(eventRef)
+  ].filter(Boolean);
+  return {
+    observed: refs.length > 0,
+    statuses: [...new Set(turn.states.validationEvents.map((event) => event.payload?.status ?? "observed"))],
+    repeatedWithoutMutation: refs.some((ref) => repeatedRefs.has(ref.eventId)),
+    sourceRefs: refs
+  };
+}
+
+function callToolResults(turn) {
+  return turn.calls.filter((call) => call.result).map((call) => ({
+    toolName: call.toolName,
+    callRef: call.requestedRef,
+    ...call.result
+  }));
+}
+
+function callConfiguration(turn, metadata, redactor) {
+  const started = turn.startEvent.payload ?? {};
+  const completed = turn.model.completion?.payload ?? {};
+  const usage = turn.model.usage ?? {};
+  return {
+    provider: safeLabel(usage.providerId ?? started.provider ?? metadata.provider, redactor),
+    resolvedModel: safeLabel(usage.modelId ?? completed.model ?? started.model ?? metadata.model, redactor),
+    reasoningEffort: safeLabel(metadata.reasoningEffort, redactor),
+    profile: safeLabel(metadata.profile, redactor),
+    runMode: safeLabel(metadata.runMode, redactor),
+    harnessDigest: metadata.harnessDigest ?? null,
+    compilerDigest: metadata.compilerDigest ?? null,
+    compilerActivation: "inspection_only"
+  };
+}
+
+function callRequest(turn, composition, redactor) {
+  const prompt = turn.model.prompt?.payload;
+  const observation = prompt?.traceObservation;
+  return {
+    requestDigest: prompt?.requestDigest ?? null,
+    toolSchemaDigest: prompt?.toolSchemaDigest ?? null,
+    visibleToolNames: (observation?.visibleToolNames ?? []).map((name) => safeLabel(name, redactor)),
+    visibleToolNamesAccuracy: observation ? "runtime_exact" : "unavailable",
+    estimatedTokens: composition
+  };
+}
+
+function callState(turn, classified) {
+  const terminal = turn.states.completion ?? turn.states.suspended;
+  let status = "not_terminal";
+  if (turn.states.completion) status = "completed";
+  else if (turn.states.suspended) status = "needs_input";
+  return {
+    validation: validationState(turn, classified),
+    checkpoint: {
+      events: turn.states.checkpointEvents.map(eventRef),
+      observed: turn.states.checkpointEvents.length > 0
+    },
+    completion: { status, sourceRef: eventRef(terminal) }
+  };
+}
+
+function modelCall(turn, classified, metadata, redactor) {
+  const classification = classified.classifications.find((item) => item.turnOrdinal === turn.ordinal);
+  const usage = tokenUsageAttribution(turn.model.usage);
+  const composition = requestComposition(turn.model.prompt);
+  return {
+    callId: `model-turn-${turn.ordinal}`,
+    ordinal: turn.ordinal,
+    modelTurnId: turn.turnId,
+    startRef: turn.startRef,
+    completionRef: eventRef(turn.model.completion ?? turn.model.failure),
+    configuration: callConfiguration(turn, metadata, redactor),
+    request: callRequest(turn, composition, redactor),
+    usage,
+    uncachedProxyAttribution: proxyAttribution(usage, composition),
+    toolCallCount: turn.calls.length,
+    toolResults: callToolResults(turn),
+    latency: modelLatency(turn),
+    mutationFrontierRevision: turn.mutationFrontierRevision,
+    state: callState(turn, classified),
+    classification
+  };
+}
+
+function terminalState(indexed, metadata) {
+  const terminal = lastEvent(indexed.events, (event) => [
+    "run.completed", "run.suspended", "run.cancelled", "run.failed"
+  ].includes(event.type));
+  const timeout = Boolean(metadata.timeout) || indexed.events.some((event) =>
+    event.type === "model.failed" && event.payload?.diagnostics?.category === "timeout");
+  const statuses = {
+    "run.completed": "completed",
+    "run.suspended": "needs_input",
+    "run.cancelled": "cancelled",
+    "run.failed": "failed"
+  };
+  const finalStatus = statuses[terminal?.type] ?? safeLabel(metadata.finalStatus ?? "incomplete", metadata.redactor);
+  const infrastructureFailure = Boolean(metadata.infrastructureFailure);
+  return {
+    finalStatus,
+    timeout,
+    infrastructureFailure,
+    successful: finalStatus === "completed" && !timeout && !infrastructureFailure,
+    successDefinition: "product_terminal_completed_without_timeout_or_infrastructure_failure",
+    terminalRef: eventRef(terminal)
+  };
+}
+
+function sumKnown(values) {
+  const known = values.filter(Number.isFinite);
+  return { value: known.reduce((total, value) => total + value, 0), observedCount: known.length };
+}
+
+function sumComponents(calls, selector) {
+  const names = ["systemBaseContext", "toolSchema", "conversationHistory", "toolResults", "modelOutput"];
+  return Object.fromEntries(names.map((name) => [name, sumKnown(calls.map((call) => selector(call)?.[name]))]));
+}
+
+function primaryTurnTotals(calls) {
+  const names = [...new Set(calls.map((call) => call.classification.primary))].sort();
+  return Object.fromEntries(names.map((name) => {
+    const selected = calls.filter((call) => call.classification.primary === name);
+    return [name, {
+      turns: selected.length,
+      uncachedTokenProxy: sumKnown(selected.map((call) => call.usage.uncachedInputPlusOutputV1.value))
+    }];
+  }));
+}
+
+function attemptTotals(calls, classified) {
+  const results = calls.flatMap((call) => call.toolResults);
+  return {
+    modelTurns: calls.length,
+    turnCategories: Object.fromEntries(Object.entries(classified.categories)
+      .map(([name, value]) => [name, value.count])),
+    toolCalls: calls.reduce((total, call) => total + call.toolCallCount, 0),
+    repeatedToolCalls: classified.repeats.toolCalls.length,
+    repeatedObservations: classified.repeats.observations.length,
+    repeatedReads: classified.repeats.reads.length,
+    repeatedValidations: classified.repeats.validations.length,
+    uncachedTokenProxy: sumKnown(calls.map((call) => call.usage.uncachedInputPlusOutputV1.value)),
+    providerCacheReadTokens: sumKnown(calls.map((call) => call.usage.providerReported.cacheReadTokens)),
+    toolOutputRawBytes: sumKnown(results.map((result) => result.rawBytes)),
+    toolOutputModelVisibleBytes: sumKnown(results.map((result) => result.modelVisibleBytes)),
+    estimatedRequestComposition: sumComponents(calls, (call) => call.request.estimatedTokens),
+    proxyCostAttribution: sumComponents(calls, (call) => call.uncachedProxyAttribution.components),
+    primaryTurnAttribution: primaryTurnTotals(calls)
+  };
+}
+
+function eventByRef(indexed, ref) {
+  return ref ? indexed.events.find((event) => event.eventId === ref.eventId) : null;
+}
+
+function attemptTiming(indexed, classified, metadata) {
+  const started = firstEvent(indexed.events, (event) => event.type === "run.started")
+    ?? indexed.events[0];
+  const firstAction = eventByRef(indexed, classified.milestones.firstToolCall?.eventRef);
+  const firstMutation = eventByRef(indexed, classified.milestones.firstMutation?.eventRef);
+  return {
+    totalLatencyMs: Number.isFinite(metadata.durationMs)
+      ? Math.max(0, Math.round(metadata.durationMs))
+      : elapsedMs(started, indexed.events.at(-1)),
+    timeToFirstActionMs: elapsedMs(started, firstAction),
+    timeToFirstMutationMs: elapsedMs(started, firstMutation),
+    completionTailMs: classified.completionTail.latencyMs
+  };
+}
+
+function attemptSummary(report, metadata) {
+  return {
+    attemptId: report.attemptId,
+    scenarioId: metadata.scenarioId,
+    repetition: metadata.repetition,
+    successful: report.terminal.successful,
+    finalStatus: report.terminal.finalStatus,
+    timeout: report.terminal.timeout,
+    infrastructureFailure: report.terminal.infrastructureFailure,
+    totals: report.totals,
+    timing: report.timing,
+    completionTailTurns: report.derived.completionTail.count,
+    reportDigest: report.reportDigest
+  };
+}
+
+function traceSource(indexed, metadata) {
+  return {
+    eventStreamDigest: digest(indexed.events),
+    firstEventRef: eventRef(indexed.events[0]),
+    lastEventRef: eventRef(indexed.events.at(-1)),
+    harnessDigest: metadata.harnessDigest ?? null,
+    compilerDigest: metadata.compilerDigest ?? null,
+    compilerActivation: "inspection_only"
+  };
+}
+
+function traceIdentity(indexed, metadata, redactor) {
+  return {
+    generatedAt: indexed.events.at(-1)?.occurredAt ?? metadata.finishedAt ?? metadata.startedAt ?? null,
+    attemptId: safeLabel(metadata.attemptId ?? "unknown", redactor),
+    sessionId: safeLabel(metadata.sessionId ?? indexed.events[0]?.sessionId ?? "unknown", redactor)
+  };
+}
+
+export function buildTraceAttribution(events, metadata = {}) {
+  const redactor = metadata.redactor ?? String;
+  const indexed = traceTurns(events, redactor);
+  const classified = classifyTrace(indexed);
+  const created = firstEvent(indexed.events, (event) => event.type === "session.created");
+  const runtimeMode = created?.payload?.mode ?? metadata.runMode ?? "change";
+  const normalized = { ...metadata, runMode: runtimeMode, redactor };
+  const calls = indexed.turns.map((turn) => modelCall(turn, classified, normalized, redactor));
+  const base = {
+    $schema: TRACE_ATTRIBUTION_SCHEMA_ID,
+    schemaVersion: TRACE_ATTRIBUTION_SCHEMA_VERSION,
+    kind: "trace_attribution_attempt",
+    attributionVersion: TRACE_ATTRIBUTION_VERSION,
+    ...traceIdentity(indexed, metadata, redactor),
+    source: traceSource(indexed, metadata),
+    modelCalls: calls,
+    derived: classified,
+    totals: attemptTotals(calls, classified),
+    timing: attemptTiming(indexed, classified, metadata),
+    terminal: terminalState(indexed, normalized)
+  };
+  const report = reportWithDigest(base);
+  return { report, summary: attemptSummary(report, metadata) };
+}
+
+function aggregateTotals(summaries) {
+  const numberAt = (summary, path) => path.reduce((value, key) => value?.[key], summary);
+  const sum = (path) => summaries.reduce((total, summary) => total + (numberAt(summary, path) ?? 0), 0);
+  const categories = ["inspect", "mutation", "validation", "recovery", "user_input", "completion_tail"];
+  const finalStatuses = [...new Set(summaries.map((item) => item.finalStatus))].sort();
+  return {
+    attempts: summaries.length,
+    successfulAttempts: summaries.filter((item) => item.successful).length,
+    modelTurns: sum(["totals", "modelTurns"]),
+    toolCalls: sum(["totals", "toolCalls"]),
+    repeatedToolCalls: sum(["totals", "repeatedToolCalls"]),
+    repeatedObservations: sum(["totals", "repeatedObservations"]),
+    repeatedReads: sum(["totals", "repeatedReads"]),
+    repeatedValidations: sum(["totals", "repeatedValidations"]),
+    turnCategories: Object.fromEntries(categories.map((name) => [name, sum(["totals", "turnCategories", name])])),
+    uncachedTokenProxy: sum(["totals", "uncachedTokenProxy", "value"]),
+    providerCacheReadTokens: sum(["totals", "providerCacheReadTokens", "value"]),
+    toolOutputRawBytes: sum(["totals", "toolOutputRawBytes", "value"]),
+    toolOutputModelVisibleBytes: sum(["totals", "toolOutputModelVisibleBytes", "value"]),
+    completionTailTurns: sum(["completionTailTurns"]),
+    timeouts: summaries.filter((item) => item.timeout).length,
+    infrastructureFailures: summaries.filter((item) => item.infrastructureFailure).length,
+    finalStatuses: Object.fromEntries(finalStatuses.map((status) => [
+      status, summaries.filter((item) => item.finalStatus === status).length
+    ]))
+  };
+}
+
+function successfulDistributions(summaries) {
+  const successful = summaries.filter((item) => item.successful);
+  return {
+    uncachedTokenProxy: distribution(successful.map((item) => item.totals.uncachedTokenProxy.value)),
+    modelTurns: distribution(successful.map((item) => item.totals.modelTurns)),
+    totalLatencyMs: distribution(successful.map((item) => item.timing.totalLatencyMs))
+  };
+}
+
+function timingDistributions(summaries) {
+  return {
+    timeToFirstActionMs: distribution(summaries.map((item) => item.timing.timeToFirstActionMs)),
+    timeToFirstMutationMs: distribution(summaries.map((item) => item.timing.timeToFirstMutationMs)),
+    completionTailMs: distribution(summaries.map((item) => item.timing.completionTailMs))
+  };
+}
+
+function aggregateComponents(summaries, key) {
+  const names = ["systemBaseContext", "toolSchema", "conversationHistory", "toolResults", "modelOutput"];
+  return Object.fromEntries(names.map((name) => [name, summaries.reduce((total, summary) =>
+    total + (summary.totals[key]?.[name]?.value ?? 0), 0)]));
+}
+
+function scenarioAggregates(summaries) {
+  const ids = [...new Set(summaries.map((item) => item.scenarioId))].sort();
+  return ids.map((scenarioId) => {
+    const selected = summaries.filter((item) => item.scenarioId === scenarioId);
+    return {
+      scenarioId,
+      totals: aggregateTotals(selected),
+      successfulDistributions: successfulDistributions(selected),
+      timingDistributions: timingDistributions(selected)
+    };
+  });
+}
+
+export function buildAggregateTraceAttribution(summaries, metadata = {}) {
+  const ordered = [...summaries].sort((left, right) =>
+    String(left.scenarioId).localeCompare(String(right.scenarioId)) || left.repetition - right.repetition);
+  return reportWithDigest({
+    $schema: TRACE_ATTRIBUTION_SCHEMA_ID,
+    schemaVersion: TRACE_ATTRIBUTION_SCHEMA_VERSION,
+    kind: "trace_attribution_aggregate",
+    attributionVersion: TRACE_ATTRIBUTION_VERSION,
+    runId: metadata.runId ?? null,
+    generatedAt: metadata.finishedAt ?? null,
+    configuration: {
+      provider: metadata.provider ?? null,
+      model: metadata.model ?? null,
+      reasoningEffort: metadata.reasoningEffort ?? null,
+      profile: metadata.profile ?? null,
+      runMode: metadata.runMode ?? "change"
+    },
+    totals: aggregateTotals(ordered),
+    tokenCostAttribution: aggregateComponents(ordered, "proxyCostAttribution"),
+    estimatedRequestComposition: aggregateComponents(ordered, "estimatedRequestComposition"),
+    successfulAttemptDistributions: successfulDistributions(ordered),
+    timingDistributions: timingDistributions(ordered),
+    scenarios: scenarioAggregates(ordered),
+    attempts: ordered
+  });
+}
+
+function markdownTable(rows) {
+  return rows.map((row) => `| ${row.join(" | ")} |`).join("\n");
+}
+
+export function renderAttemptTraceMarkdown(report) {
+  const categoryRows = Object.entries(report.totals.turnCategories)
+    .map(([name, count]) => [name, String(count)]);
+  return [
+    "# Trace attribution",
+    "",
+    `- Attempt: \`${report.attemptId}\``,
+    `- Final status: ${report.terminal.finalStatus}`,
+    `- Model turns: ${report.totals.modelTurns}`,
+    `- Tool calls / repeated: ${report.totals.toolCalls} / ${report.totals.repeatedToolCalls}`,
+    `- Uncached token proxy: ${report.totals.uncachedTokenProxy.value}`,
+    `- Completion tail turns: ${report.derived.completionTail.count}`,
+    "",
+    "| Turn class | Count |",
+    "| --- | ---: |",
+    markdownTable(categoryRows),
+    "",
+    `Authoritative JSON digest: \`${report.reportDigest}\``,
+    ""
+  ].join("\n");
+}
+
+export function renderAggregateTraceMarkdown(report) {
+  const componentRows = Object.entries(report.tokenCostAttribution)
+    .sort(([, left], [, right]) => right - left)
+    .map(([name, value]) => [name, String(value)]);
+  return [
+    "# Aggregate trace attribution",
+    "",
+    `- Attempts / successful product terminals: ${report.totals.attempts} / ${report.totals.successfulAttempts}`,
+    `- Model turns: ${report.totals.modelTurns}`,
+    `- Tool calls / repeated: ${report.totals.toolCalls} / ${report.totals.repeatedToolCalls}`,
+    `- Uncached token proxy: ${report.totals.uncachedTokenProxy}`,
+    `- Completion tail turns: ${report.totals.completionTailTurns}`,
+    "",
+    "| Proxy token component | Tokens |",
+    "| --- | ---: |",
+    markdownTable(componentRows),
+    "",
+    `Authoritative JSON digest: \`${report.reportDigest}\``,
+    ""
+  ].join("\n");
+}
+
+export async function writeAttemptTraceAttribution(directory, report, redactor = String) {
+  const jsonPath = path.join(directory, "trace-attribution.json");
+  const markdownPath = path.join(directory, "trace-attribution.md");
+  await writeJson(jsonPath, report, redactor);
+  await writeFile(markdownPath, redactor(renderAttemptTraceMarkdown(report)), "utf8");
+  return { jsonPath, markdownPath };
+}
+
+export async function writeAggregateTraceAttribution(runDir, report, redactor = String) {
+  const jsonPath = path.join(runDir, "trace-attribution.json");
+  const markdownPath = path.join(runDir, "trace-attribution.md");
+  await writeJson(jsonPath, report, redactor);
+  await writeFile(markdownPath, redactor(renderAggregateTraceMarkdown(report)), "utf8");
+  return { jsonPath, markdownPath };
+}

--- a/scripts/eval/trace-attribution.mjs
+++ b/scripts/eval/trace-attribution.mjs
@@ -319,6 +319,27 @@ export function buildTraceAttribution(events, metadata = {}) {
   return { report, summary: attemptSummary(report, metadata) };
 }
 
+export function markTraceAttributionInfrastructureFailure(attribution) {
+  if (attribution.report.terminal.infrastructureFailure) return attribution;
+  const base = structuredClone(attribution.report);
+  delete base.reportDigest;
+  base.terminal = {
+    ...base.terminal,
+    infrastructureFailure: true,
+    successful: false
+  };
+  const report = reportWithDigest(base);
+  return {
+    report,
+    summary: {
+      ...attribution.summary,
+      successful: false,
+      infrastructureFailure: true,
+      reportDigest: report.reportDigest
+    }
+  };
+}
+
 function aggregateTotals(summaries) {
   const numberAt = (summary, path) => path.reduce((value, key) => value?.[key], summary);
   const sum = (path) => summaries.reduce((total, summary) => total + (numberAt(summary, path) ?? 0), 0);

--- a/scripts/eval/trace-attribution.schema.json
+++ b/scripts/eval/trace-attribution.schema.json
@@ -1,0 +1,149 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sigmacode.biz/schemas/trace-attribution/v1",
+  "title": "Sigma neutral trace attribution v1",
+  "oneOf": [
+    { "$ref": "#/$defs/attempt" },
+    { "$ref": "#/$defs/aggregate" }
+  ],
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "eventRef": {
+      "type": ["object", "null"],
+      "properties": {
+        "eventId": { "type": "string", "minLength": 1 },
+        "seq": { "type": "integer", "minimum": 1 },
+        "type": { "type": "string", "minLength": 1 }
+      },
+      "required": ["eventId", "seq", "type"],
+      "additionalProperties": false
+    },
+    "tokenEstimate": {
+      "type": "object",
+      "properties": {
+        "accuracy": { "enum": ["estimated", "unavailable"] },
+        "estimator": { "const": "context_plan_approximate_tokens" },
+        "systemBaseContext": { "type": ["integer", "null"], "minimum": 0 },
+        "toolSchema": { "type": ["integer", "null"], "minimum": 0 },
+        "conversationHistory": { "type": ["integer", "null"], "minimum": 0 },
+        "toolResults": { "type": ["integer", "null"], "minimum": 0 },
+        "total": { "type": ["integer", "null"], "minimum": 0 }
+      },
+      "required": [
+        "accuracy", "estimator", "systemBaseContext", "toolSchema",
+        "conversationHistory", "toolResults", "total"
+      ],
+      "additionalProperties": false
+    },
+    "modelCall": {
+      "type": "object",
+      "properties": {
+        "callId": { "type": "string" },
+        "ordinal": { "type": "integer", "minimum": 1 },
+        "modelTurnId": { "type": "integer", "minimum": 1 },
+        "startRef": { "$ref": "#/$defs/eventRef" },
+        "completionRef": { "$ref": "#/$defs/eventRef" },
+        "configuration": {
+          "type": "object",
+          "properties": {
+            "provider": { "type": "string" },
+            "resolvedModel": { "type": "string" },
+            "reasoningEffort": { "type": "string" },
+            "profile": { "type": "string" },
+            "runMode": { "type": "string" },
+            "harnessDigest": { "type": ["string", "null"] },
+            "compilerDigest": { "type": ["string", "null"] },
+            "compilerActivation": { "const": "inspection_only" }
+          },
+          "required": [
+            "provider", "resolvedModel", "reasoningEffort", "profile", "runMode",
+            "harnessDigest", "compilerDigest", "compilerActivation"
+          ],
+          "additionalProperties": false
+        },
+        "request": {
+          "type": "object",
+          "properties": {
+            "requestDigest": { "type": ["string", "null"] },
+            "toolSchemaDigest": { "type": ["string", "null"] },
+            "visibleToolNames": { "type": "array", "items": { "type": "string" } },
+            "visibleToolNamesAccuracy": { "enum": ["runtime_exact", "unavailable"] },
+            "estimatedTokens": { "$ref": "#/$defs/tokenEstimate" }
+          },
+          "required": [
+            "requestDigest", "toolSchemaDigest", "visibleToolNames",
+            "visibleToolNamesAccuracy", "estimatedTokens"
+          ],
+          "additionalProperties": false
+        },
+        "usage": { "type": "object" },
+        "uncachedProxyAttribution": { "type": "object" },
+        "toolCallCount": { "type": "integer", "minimum": 0 },
+        "toolResults": { "type": "array", "items": { "type": "object" } },
+        "latency": { "type": "object" },
+        "mutationFrontierRevision": { "type": "object" },
+        "state": { "type": "object" },
+        "classification": { "type": "object" }
+      },
+      "required": [
+        "callId", "ordinal", "modelTurnId", "startRef", "completionRef", "configuration",
+        "request", "usage", "uncachedProxyAttribution", "toolCallCount", "toolResults",
+        "latency", "mutationFrontierRevision", "state", "classification"
+      ],
+      "additionalProperties": false
+    },
+    "attempt": {
+      "type": "object",
+      "properties": {
+        "$schema": { "const": "https://sigmacode.biz/schemas/trace-attribution/v1" },
+        "schemaVersion": { "const": 1 },
+        "kind": { "const": "trace_attribution_attempt" },
+        "attributionVersion": { "const": "trace-attribution-1.0.0" },
+        "generatedAt": { "type": ["string", "null"] },
+        "attemptId": { "type": "string" },
+        "sessionId": { "type": "string" },
+        "source": { "type": "object" },
+        "modelCalls": { "type": "array", "items": { "$ref": "#/$defs/modelCall" } },
+        "derived": { "type": "object" },
+        "totals": { "type": "object" },
+        "timing": { "type": "object" },
+        "terminal": { "type": "object" },
+        "reportDigest": { "$ref": "#/$defs/sha256" }
+      },
+      "required": [
+        "$schema", "schemaVersion", "kind", "attributionVersion", "generatedAt", "attemptId",
+        "sessionId", "source", "modelCalls", "derived", "totals", "timing", "terminal", "reportDigest"
+      ],
+      "additionalProperties": false
+    },
+    "aggregate": {
+      "type": "object",
+      "properties": {
+        "$schema": { "const": "https://sigmacode.biz/schemas/trace-attribution/v1" },
+        "schemaVersion": { "const": 1 },
+        "kind": { "const": "trace_attribution_aggregate" },
+        "attributionVersion": { "const": "trace-attribution-1.0.0" },
+        "runId": { "type": ["string", "null"] },
+        "generatedAt": { "type": ["string", "null"] },
+        "configuration": { "type": "object" },
+        "totals": { "type": "object" },
+        "tokenCostAttribution": { "type": "object" },
+        "estimatedRequestComposition": { "type": "object" },
+        "successfulAttemptDistributions": { "type": "object" },
+        "timingDistributions": { "type": "object" },
+        "scenarios": { "type": "array", "items": { "type": "object" } },
+        "attempts": { "type": "array", "items": { "type": "object" } },
+        "reportDigest": { "$ref": "#/$defs/sha256" }
+      },
+      "required": [
+        "$schema", "schemaVersion", "kind", "attributionVersion", "runId", "generatedAt",
+        "configuration", "totals", "tokenCostAttribution", "estimatedRequestComposition",
+        "successfulAttemptDistributions", "timingDistributions", "scenarios", "attempts", "reportDigest"
+      ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/tests/agent-eval-runner.test.ts
+++ b/tests/agent-eval-runner.test.ts
@@ -287,6 +287,100 @@ describe("agent experience evaluation runner", () => {
     expect(await readFile(result.runPath, "utf8")).not.toContain("test-secret-value-12345");
   });
 
+  it("writes trace attribution after the subject without forwarding evaluator identity", async () => {
+    const fixture = await manifest();
+    const runDir = path.join(fixture.root, "trace-artifacts");
+    let subjectInput: Record<string, unknown> | undefined;
+    const result = await runEvaluation({
+      suite: "quick",
+      manifestPath: fixture.manifestPath,
+      runDir,
+      provider: "openai-codex",
+      model: "gpt-5.6-sol",
+      reasoningEffort: "max",
+      agentProfile: "standard",
+      traceAttribution: true
+    }, {
+      secrets: { DEEPSEEK_API_KEY: "trace-secret-value-12345" },
+      prepareSubject: async () => ({
+        subjectKind: "fake", cliEntry: "fake", nodePath: "fake",
+        subjectDigest: "a".repeat(64), harnessCompilerDigest: "b".repeat(64)
+      }),
+      runSubject: async (input: Record<string, unknown>) => {
+        subjectInput = input;
+        await writeFile(path.join(String(input.artifactDir), "subject.stdout.log"), "fake subject\n", "utf8");
+        await writeFile(path.join(String(input.artifactDir), "subject.stderr.log"), "", "utf8");
+        return {
+          exitCode: 0,
+          sessionId: "session",
+          durationMs: 6_000,
+          result: { status: "completed", finishReason: "completed", finalMessage: "Done." },
+          events: successfulEvents()
+        };
+      }
+    });
+    expect(subjectInput).toMatchObject({
+      provider: "openai-codex", model: "gpt-5.6-sol", reasoningEffort: "max", agentProfile: "standard"
+    });
+    expect(subjectInput).not.toHaveProperty("traceAttribution");
+    expect(subjectInput).not.toHaveProperty("scenarioId");
+    expect(subjectInput).not.toHaveProperty("verifier");
+    expect(result.traceReportPath).toBe(path.join(runDir, "trace-attribution.json"));
+    const aggregate = JSON.parse(await readFile(result.traceReportPath, "utf8"));
+    expect(aggregate).toMatchObject({
+      schemaVersion: 1,
+      kind: "trace_attribution_aggregate",
+      configuration: {
+        provider: "openai-codex", model: "gpt-5.6-sol", reasoningEffort: "max", profile: "standard"
+      },
+      totals: { attempts: 1, successfulAttempts: 1, modelTurns: 1 }
+    });
+    const attempt = result.run.attempts[0];
+    expect(attempt.traceAttribution).toMatchObject({
+      schemaVersion: 1,
+      summary: { successful: true, finalStatus: "completed" }
+    });
+    const perAttempt = JSON.parse(await readFile(
+      path.join(runDir, attempt.artifacts.traceAttribution), "utf8"
+    ));
+    expect(perAttempt.source).toMatchObject({
+      harnessDigest: "a".repeat(64), compilerDigest: "b".repeat(64), compilerActivation: "inspection_only"
+    });
+    expect(JSON.stringify({ aggregate, perAttempt })).not.toContain("trace-secret-value-12345");
+  });
+
+  it("fails closed as evaluator infrastructure when trace attribution cannot be written", async () => {
+    const fixture = await manifest();
+    const runDir = path.join(fixture.root, "trace-write-failure");
+    const result = await runEvaluation({
+      suite: "quick",
+      manifestPath: fixture.manifestPath,
+      runDir,
+      traceAttribution: true
+    }, {
+      secrets: { DEEPSEEK_API_KEY: "trace-write-secret-12345" },
+      prepareSubject: async () => ({ subjectKind: "fake", cliEntry: "fake", nodePath: "fake" }),
+      runSubject: async (input: Record<string, unknown>) => {
+        await writeFile(path.join(String(input.artifactDir), "subject.stdout.log"), "fake subject\n", "utf8");
+        await writeFile(path.join(String(input.artifactDir), "subject.stderr.log"), "", "utf8");
+        await mkdir(path.join(String(input.artifactDir), "trace-attribution.json"));
+        return {
+          exitCode: 0, sessionId: "session", durationMs: 6_000,
+          result: { status: "completed", finishReason: "completed", finalMessage: "Done." },
+          events: successfulEvents()
+        };
+      }
+    });
+    expect(result.run.status).toBe("inconclusive");
+    expect(result.run.attempts[0]).toMatchObject({
+      validity: "invalid",
+      validityDetail: { owner: "evaluator", phase: "trace_attribution" }
+    });
+    expect(result.run.infrastructureErrors).toEqual(expect.arrayContaining([
+      expect.objectContaining({ phase: "trace_attribution" })
+    ]));
+  });
+
   it("CAS-persists credential refreshes, preserves concurrent logins, and advances later attempts", async () => {
     const fixture = await manifest({ repeat: 3 });
     const runDir = path.join(fixture.root, "credential-artifacts");

--- a/tests/agent-eval-runner.test.ts
+++ b/tests/agent-eval-runner.test.ts
@@ -637,7 +637,8 @@ describe("agent experience evaluation runner", () => {
   it("marks verifier infrastructure failure invalid without observing correctness", async () => {
     const fixture = await manifest({ verifierCrash: true });
     const result = await runEvaluation({
-      suite: "quick", manifestPath: fixture.manifestPath, runDir: path.join(fixture.root, "verifier-crash")
+      suite: "quick", manifestPath: fixture.manifestPath,
+      runDir: path.join(fixture.root, "verifier-crash"), traceAttribution: true
     }, {
       secrets: { DEEPSEEK_API_KEY: "test-secret-value-12345" },
       prepareSubject: async () => ({ subjectKind: "fake", cliEntry: "fake", nodePath: "fake" }),
@@ -650,8 +651,17 @@ describe("agent experience evaluation runner", () => {
     expect(result.run.attempts[0]).toMatchObject({
       validity: "invalid",
       validityDetail: { owner: "verifier", code: "verifier_infrastructure_error" },
-      dimensions: { correctness: { status: "not_observed" }, delivery: { status: "not_observed" } }
+      dimensions: { correctness: { status: "not_observed" }, delivery: { status: "not_observed" } },
+      traceAttribution: { summary: { successful: false, infrastructureFailure: true } }
     });
+    const aggregate = JSON.parse(await readFile(result.traceReportPath, "utf8"));
+    expect(aggregate.totals).toMatchObject({ successfulAttempts: 0, infrastructureFailures: 1 });
+    const attempt = result.run.attempts[0];
+    const trace = JSON.parse(await readFile(
+      path.join(result.runDir, attempt.artifacts.traceAttribution), "utf8"
+    ));
+    expect(trace.terminal).toMatchObject({ successful: false, infrastructureFailure: true });
+    expect(trace.reportDigest).toBe(attempt.traceAttribution.reportDigest);
   });
 
   it("keeps a Sigma sandbox launch fault as a valid product reliability sample", async () => {

--- a/tests/agent-eval-trace-attribution.test.ts
+++ b/tests/agent-eval-trace-attribution.test.ts
@@ -1,0 +1,291 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { digest } from "../scripts/eval/common.mjs";
+import {
+  buildAggregateTraceAttribution,
+  buildTraceAttribution
+} from "../scripts/eval/trace-attribution.mjs";
+import { rootDir } from "../scripts/eval/common.mjs";
+
+function event(seq: number, type: string, payload: Record<string, unknown> = {}) {
+  return {
+    schemaVersion: 1,
+    seq,
+    eventId: `event-${seq}`,
+    sessionId: "session",
+    runId: "run",
+    occurredAt: new Date(Date.UTC(2026, 7, 1, 0, 0, seq)).toISOString(),
+    type,
+    authority: type.startsWith("tool.") ? "tool" : "runtime",
+    payload
+  };
+}
+
+function usage(inputTokens = 100, outputTokens = 10, cacheReadTokens: number | undefined = 40) {
+  return {
+    providerId: "openai-codex",
+    modelId: "gpt-5.6-sol",
+    providerReported: true,
+    inputTokens,
+    outputTokens,
+    ...(cacheReadTokens === undefined ? {} : { cacheReadTokens }),
+    latencyMs: 1_000
+  };
+}
+
+function prompt(turnId: number) {
+  return {
+    turnId,
+    requestDigest: String(turnId).padStart(64, "a").slice(-64),
+    toolSchemaDigest: "b".repeat(64),
+    traceObservation: {
+      schemaVersion: 1,
+      tokenEstimator: "context_plan_approximate_tokens",
+      tokenAccuracy: "estimated",
+      estimatedTokens: {
+        systemBaseContext: 20,
+        toolSchema: 10,
+        conversationHistory: 50,
+        toolResults: 20,
+        total: 100
+      },
+      visibleToolNames: ["read", "validate", "write"]
+    }
+  };
+}
+
+function modelEvents(seq: number, turnId: number) {
+  return [
+    event(seq, "model.started", { turnId, provider: "openai-codex", model: "gpt-5.6-sol" }),
+    event(seq + 1, "model.prompt_materialized", prompt(turnId)),
+    event(seq + 2, "model.completed", {
+      turnId, model: "gpt-5.6-sol", usage: usage(), text: "", toolCalls: []
+    })
+  ];
+}
+
+function receipt(seq: number, turnId: number, callId: string, name: string, output: string, effects: string[]) {
+  return event(seq, "tool.completed", {
+    turnId,
+    callId,
+    name,
+    output,
+    observedEffects: effects,
+    actualEffects: effects,
+    artifactRefs: [],
+    traceObservation: {
+      schemaVersion: 1,
+      rawBytes: Buffer.byteLength(output),
+      modelVisibleBytes: Buffer.byteLength(`visible:${output}`),
+      fullOutputDigest: digest(output)
+    },
+    startedAt: new Date(Date.UTC(2026, 7, 1, 0, 0, seq - 1)).toISOString(),
+    completedAt: new Date(Date.UTC(2026, 7, 1, 0, 0, seq)).toISOString()
+  });
+}
+
+function requested(seq: number, turnId: number, callId: string, name: string, argumentsValue: object) {
+  return event(seq, "tool.requested", { turnId, callId, name, arguments: argumentsValue });
+}
+
+function syntheticTrace() {
+  return [
+    event(1, "session.created", { mode: "change" }),
+    event(2, "run.started", { mode: "change" }),
+    ...modelEvents(3, 1),
+    requested(6, 1, "read-1", "read", { path: "src/a.ts", start: 1, end: 20 }),
+    receipt(7, 1, "read-1", "read", "alpha", ["filesystem.read"]),
+    ...modelEvents(8, 2),
+    requested(11, 2, "read-2", "read", { end: 20, path: "src/a.ts", start: 1 }),
+    receipt(12, 2, "read-2", "read", "alpha", ["filesystem.read"]),
+    ...modelEvents(13, 3),
+    requested(16, 3, "write-1", "write", { path: "src/a.ts", content: "changed" }),
+    event(17, "checkpoint.sealed", {
+      checkpointId: "checkpoint", status: "sealed",
+      preManifestDigest: "c".repeat(64), postManifestDigest: "d".repeat(64),
+      delta: { added: [], modified: ["src/a.ts"], deleted: [] }
+    }),
+    receipt(18, 3, "write-1", "write", "changed", ["filesystem.write"]),
+    ...modelEvents(19, 4),
+    requested(22, 4, "read-3", "read", { path: "src/a.ts", start: 1, end: 20 }),
+    receipt(23, 4, "read-3", "read", "alpha", ["filesystem.read"]),
+    ...modelEvents(24, 5),
+    requested(27, 5, "validate-1", "validate", { command: "pnpm test" }),
+    receipt(28, 5, "validate-1", "validate", "pass", ["validation"]),
+    event(29, "evidence.recorded", {
+      evidenceId: "validation-1", kind: "validation", status: "passed",
+      data: { frontierRevision: 1 }
+    }),
+    ...modelEvents(30, 6),
+    requested(33, 6, "validate-2", "validate", { command: "pnpm test" }),
+    receipt(34, 6, "validate-2", "validate", "pass", ["validation"]),
+    ...modelEvents(35, 7),
+    event(38, "run.completed", { kind: "completed" })
+  ];
+}
+
+function metadata() {
+  return {
+    attemptId: "attempt",
+    scenarioId: "general-scenario",
+    repetition: 1,
+    provider: "openai-codex",
+    model: "gpt-5.6-sol",
+    reasoningEffort: "max",
+    profile: "standard",
+    runMode: "change",
+    harnessDigest: "e".repeat(64),
+    compilerDigest: "f".repeat(64),
+    durationMs: 38_000
+  };
+}
+
+describe("neutral trace attribution", () => {
+  it("classifies turns, preserves source refs, and applies deterministic repeat boundaries", () => {
+    const { report } = buildTraceAttribution(syntheticTrace(), metadata());
+    expect(report.totals.turnCategories).toMatchObject({
+      inspect: 3, mutation: 1, validation: 2, completion_tail: 2
+    });
+    expect(report.derived.repeats.toolCalls).toHaveLength(2);
+    expect(report.derived.repeats.reads).toHaveLength(1);
+    expect(report.derived.repeats.observations).toHaveLength(3);
+    expect(report.derived.repeats.validations).toHaveLength(1);
+    expect(report.derived.repeats.reads[0]).toMatchObject({
+      previousRef: { eventId: "event-6" },
+      currentRef: { eventId: "event-11" },
+      mutationFrontierRevision: 0
+    });
+    expect(report.derived.repeats.reads.some((item: { currentRef: { eventId: string } }) =>
+      item.currentRef.eventId === "event-22")).toBe(false);
+    expect(report.derived.repeats.observations).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        currentRef: expect.objectContaining({ eventId: "event-23" }),
+        mutationIntervened: true
+      })
+    ]));
+    expect(report.derived.milestones).toMatchObject({
+      firstToolCall: { turnOrdinal: 1 },
+      firstMutation: { turnOrdinal: 3 },
+      lastMutation: { turnOrdinal: 3 },
+      firstValidation: { turnOrdinal: 5 },
+      finalCompletion: { turnOrdinal: 7 }
+    });
+    expect(report.derived.completionTail).toMatchObject({ count: 2 });
+    expect(report.derived.completionTail.turns.map((turn: { turnOrdinal: number }) => turn.turnOrdinal))
+      .toEqual([6, 7]);
+    expect(report.derived.repeats.toolCalls.every((item: { currentRef: unknown; previousRef: unknown }) =>
+      item.currentRef && item.previousRef)).toBe(true);
+  });
+
+  it("marks recovery and user-input turns from events without interpreting task answers", () => {
+    const events = [
+      event(1, "session.created", { mode: "change" }),
+      event(2, "run.started", { mode: "change" }),
+      ...modelEvents(3, 1),
+      requested(6, 1, "failed", "read", { path: "a" }),
+      event(7, "tool.failed", {
+        turnId: 1, callId: "failed", name: "read", output: "failed",
+        actualEffects: ["filesystem.read"], observedEffects: ["filesystem.read"]
+      }),
+      ...modelEvents(8, 2),
+      event(11, "diagnostic", { kind: "recovery.retry_model", message: "retry" }),
+      requested(12, 2, "question", "request_input", {}),
+      event(13, "execution.planned", {
+        toolCallId: "question", plan: { exactEffects: ["outcome.request_input"] }
+      }),
+      event(14, "run.suspended", { kind: "needs_input" })
+    ];
+    const { report } = buildTraceAttribution(events, metadata());
+    expect(report.totals.turnCategories).toMatchObject({ recovery: 1, user_input: 1 });
+    expect(report.modelCalls[1].classification.labels).toEqual(expect.arrayContaining(["recovery", "user_input"]));
+  });
+
+  it("keeps missing provider and cache usage unavailable instead of inventing zeroes", () => {
+    const missing = [
+      event(1, "session.created", { mode: "change" }),
+      event(2, "run.started", { mode: "change" }),
+      event(3, "model.started", { turnId: 1, provider: "provider", model: "model" }),
+      event(4, "model.prompt_materialized", prompt(1)),
+      event(5, "model.completed", { turnId: 1, model: "model" })
+    ];
+    const missingUsage = buildTraceAttribution(missing, metadata()).report.modelCalls[0].usage;
+    expect(missingUsage.providerReported).toMatchObject({
+      accuracy: "unavailable", inputTokens: null, outputTokens: null, cacheReadTokens: null
+    });
+    expect(missingUsage.uncachedInputPlusOutputV1.value).toBeNull();
+
+    missing[4]!.payload = {
+      turnId: 1,
+      model: "model",
+      usage: {
+        providerId: "openai-codex", modelId: "gpt-5.6-sol",
+        providerReported: true, inputTokens: 10, outputTokens: 2, latencyMs: 1_000
+      }
+    };
+    const missingCache = buildTraceAttribution(missing, metadata()).report.modelCalls[0].usage;
+    expect(missingCache.providerReported.cacheReadTokens).toBeNull();
+    expect(missingCache.accounted.cacheReadTokens).toBeNull();
+    expect(missingCache.uncachedInputPlusOutputV1.value).toBeNull();
+  });
+
+  it("redacts labels and stores only digests for arguments and tool output", () => {
+    const secret = "credential-secret-value";
+    const events = syntheticTrace();
+    events[2]!.payload.provider = secret;
+    events[5]!.payload.name = secret;
+    events[5]!.payload.arguments = { path: secret, credential: secret };
+    events[6]!.payload.output = secret;
+    const { report } = buildTraceAttribution(events, {
+      ...metadata(), provider: secret, model: secret, profile: secret,
+      redactor: (value: unknown) => String(value).split(secret).join("[REDACTED]")
+    });
+    expect(JSON.stringify(report)).not.toContain(secret);
+    expect(JSON.stringify(report)).toContain("[REDACTED]");
+  });
+
+  it("produces deterministic JSON and self-digests against the versioned schema", async () => {
+    const first = buildTraceAttribution(syntheticTrace(), metadata()).report;
+    const second = buildTraceAttribution(syntheticTrace(), metadata()).report;
+    expect(second).toEqual(first);
+    const { reportDigest, ...unsigned } = first;
+    expect(reportDigest).toBe(digest(unsigned));
+    const schema = JSON.parse(await readFile(
+      path.join(rootDir, "scripts", "eval", "trace-attribution.schema.json"), "utf8"
+    ));
+    expect(first.$schema).toBe(schema.$id);
+    expect(schema.$defs.attempt.properties.attributionVersion.const).toBe("trace-attribution-1.0.0");
+  });
+
+  it("leaves the complete outbound model request identical when attribution is enabled", () => {
+    const request = {
+      messages: [{ role: "user", content: "neutral request" }],
+      tools: [{ name: "read", description: "read", inputSchema: { type: "object" } }],
+      toolChoice: "auto",
+      maxOutputTokens: 4096,
+      temperature: 0
+    };
+    const run = (enabled: boolean) => {
+      const outbound = structuredClone(request);
+      if (enabled) buildTraceAttribution(syntheticTrace(), metadata());
+      return outbound;
+    };
+    expect(run(true)).toEqual(run(false));
+    expect(run(true)).toEqual(request);
+  });
+
+  it("aggregates only evaluator-side scenario labels and product-terminal success distributions", () => {
+    const first = buildTraceAttribution(syntheticTrace(), metadata()).summary;
+    const second = { ...first, attemptId: "attempt-2", scenarioId: "other", repetition: 2 };
+    const report = buildAggregateTraceAttribution([second, first], {
+      runId: "run", finishedAt: "2026-08-01T00:01:00.000Z",
+      provider: "openai-codex", model: "gpt-5.6-sol", reasoningEffort: "max", profile: "standard"
+    });
+    expect(report.scenarios.map((scenario: { scenarioId: string }) => scenario.scenarioId))
+      .toEqual(["general-scenario", "other"]);
+    expect(report.successfulAttemptDistributions.modelTurns).toMatchObject({ count: 2, p50: 7 });
+    expect(report.configuration).toMatchObject({
+      provider: "openai-codex", model: "gpt-5.6-sol", reasoningEffort: "max", profile: "standard"
+    });
+  });
+});

--- a/tests/agent-eval-trace-attribution.test.ts
+++ b/tests/agent-eval-trace-attribution.test.ts
@@ -178,6 +178,48 @@ describe("neutral trace attribution", () => {
       item.currentRef && item.previousRef)).toBe(true);
   });
 
+  it("advances the repeat frontier after successful restoration evidence", () => {
+    const restorationTrace = (status: "passed" | "failed") => [
+      event(1, "session.created", { mode: "change" }),
+      event(2, "run.started", { mode: "change" }),
+      event(3, "checkpoint.sealed", {
+        checkpointId: "checkpoint", status: "sealed",
+        preManifestDigest: "a".repeat(64), postManifestDigest: "b".repeat(64),
+        delta: { added: [], modified: ["src/a.ts"], deleted: [] }
+      }),
+      ...modelEvents(4, 1),
+      requested(7, 1, "read-1", "read", { path: "src/a.ts", start: 1, end: 20 }),
+      receipt(8, 1, "read-1", "read", "alpha", ["filesystem.read"]),
+      event(9, "evidence.recorded", {
+        evidenceId: "restoration", sessionId: "session", runId: "run",
+        kind: "restoration", status, producer: { authority: "runtime" },
+        data: {
+          frontierRevision: 1,
+          frontierStateDigest: "b".repeat(64),
+          baselineManifestDigest: "a".repeat(64),
+          currentManifestDigest: "a".repeat(64),
+          repository: { status: "unchanged" }
+        }
+      }),
+      ...modelEvents(10, 2),
+      requested(13, 2, "read-2", "read", { path: "src/a.ts", start: 1, end: 20 }),
+      receipt(14, 2, "read-2", "read", "alpha", ["filesystem.read"]),
+      event(15, "run.completed", { kind: "completed" })
+    ];
+    const passed = buildTraceAttribution(restorationTrace("passed"), metadata()).report;
+    expect(passed.derived.repeats.toolCalls).toHaveLength(0);
+    expect(passed.derived.repeats.reads).toHaveLength(0);
+    expect(passed.derived.repeats.observations).toEqual(expect.arrayContaining([
+      expect.objectContaining({ mutationIntervened: true })
+    ]));
+    expect(passed.modelCalls[1].mutationFrontierRevision.start).toBe(2);
+
+    const failed = buildTraceAttribution(restorationTrace("failed"), metadata()).report;
+    expect(failed.derived.repeats.toolCalls).toHaveLength(1);
+    expect(failed.derived.repeats.reads).toHaveLength(1);
+    expect(failed.modelCalls[1].mutationFrontierRevision.start).toBe(1);
+  });
+
   it("marks recovery and user-input turns from events without interpreting task answers", () => {
     const events = [
       event(1, "session.created", { mode: "change" }),

--- a/tests/agent-runtime.measured-budget.test.ts
+++ b/tests/agent-runtime.measured-budget.test.ts
@@ -214,6 +214,38 @@ describe("provider-measured model budget settlement", () => {
     });
     expect((promptEvents[0]!.payload as { requestDigest: string }).requestDigest)
       .toMatch(/^[a-f0-9]{64}$/u);
+    const observation = (promptEvents[0]!.payload as {
+      traceObservation: {
+        tokenAccuracy: string;
+        estimatedTokens: Record<string, number>;
+        visibleToolNames: string[];
+      };
+    }).traceObservation;
+    expect(observation.tokenAccuracy).toBe("estimated");
+    expect(observation.visibleToolNames).toEqual(
+      gateway.requests[0]!.tools.map((tool) => tool.name).sort()
+    );
+    expect(observation.estimatedTokens.total).toBe(
+      observation.estimatedTokens.systemBaseContext
+      + observation.estimatedTokens.toolSchema
+      + observation.estimatedTokens.conversationHistory
+      + observation.estimatedTokens.toolResults
+    );
+    const receipt = (await storedEvents(store, session.sessionId))
+      .find((event) => event.type === "tool.completed");
+    expect(receipt?.payload).toMatchObject({
+      traceObservation: {
+        schemaVersion: 1,
+        rawBytes: expect.any(Number),
+        modelVisibleBytes: expect.any(Number),
+        fullOutputDigest: expect.stringMatching(/^[a-f0-9]{64}$/u)
+      }
+    });
+    const receiptPayload = receipt?.payload as {
+      output: string;
+      traceObservation: { rawBytes: number };
+    };
+    expect(receiptPayload.traceObservation.rawBytes).toBe(Buffer.byteLength(receiptPayload.output));
   });
 
   it("uses one clean higher-headroom retry and then stops on another length finish", async () => {

--- a/tests/harness-development-suite.test.ts
+++ b/tests/harness-development-suite.test.ts
@@ -32,6 +32,7 @@ describe("flagship Harness development suite", () => {
       provider: "openai-codex",
       model: "gpt-5.6-sol",
       reasoningEffort: "max",
+      profile: "standard",
       repeat: 3
     });
     expect(JSON.stringify({ selected, manifest })).not.toMatch(
@@ -51,12 +52,29 @@ describe("flagship Harness development suite", () => {
       "--provider", "openai-codex",
       "--model", "gpt-5.6-sol",
       "--reasoning-effort", "max",
+      "--agent-profile", "standard",
+      "--trace-attribution",
       "--repeat", "3"
     ]));
     await expect(runHarnessDevelopmentCli(["--repeat", "1"], {
       runAgentEvalCli: runner
     })).rejects.toThrow(/controls are frozen/u);
     await expect(runHarnessDevelopmentCli(["--scenario", "one"], {
+      runAgentEvalCli: runner
+    })).rejects.toThrow(/controls are frozen/u);
+    await expect(runHarnessDevelopmentCli(["--model", "different"], {
+      runAgentEvalCli: runner
+    })).rejects.toThrow(/controls are frozen/u);
+    await expect(runHarnessDevelopmentCli(["--provider", "different"], {
+      runAgentEvalCli: runner
+    })).rejects.toThrow(/controls are frozen/u);
+    await expect(runHarnessDevelopmentCli(["--reasoning-effort", "low"], {
+      runAgentEvalCli: runner
+    })).rejects.toThrow(/controls are frozen/u);
+    await expect(runHarnessDevelopmentCli(["--agent-profile", "strict"], {
+      runAgentEvalCli: runner
+    })).rejects.toThrow(/controls are frozen/u);
+    await expect(runHarnessDevelopmentCli(["--trace-attribution"], {
       runAgentEvalCli: runner
     })).rejects.toThrow(/controls are frozen/u);
   });


### PR DESCRIPTION
## Summary

- add a versioned, JSON-authoritative Trace Attribution schema
- record provider-native usage separately from estimated ContextPlan request composition
- record visible tool/schema digests, tool-result byte counts and full-output digests, latency, mutation frontier, validation, checkpoint, and completion state
- classify inspect, mutation, validation, recovery, user-input, and completion-tail turns deterministically from durable events
- detect repeated canonical calls, observations, reads, and validations while preserving source event references
- write per-attempt and aggregate JSON reports with Markdown views
- bind the generic harness-development suite to Sol/max/standard with attribution enabled

## Motivation

Previous prompt, tool-surface, context, and output-deduplication experiments did not establish a reliable improvement and often expanded tokens, turns, or timeouts. This change establishes a neutral measurement layer before testing another active optimization.

## Behavioral and fairness boundaries

- attribution observes durable runtime events and is not forwarded to the solving subject
- scenario identity remains evaluator-only
- outbound model messages, tools, toolChoice, and generation parameters are identical with attribution enabled or disabled
- trace write failure is an evaluator infrastructure failure rather than a solver behavior change
- the Harness identity compiler remains `inspection_only`
- the frozen `main@36b2c03` baseline was not regenerated or overwritten
- no active tool-description optimization is included
- TB2.1 was not run and verifier data was not used for attribution or optimization

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` — 175 files passed, 1 skipped; 1,572 tests passed, 27 skipped
- `pnpm eval:fairness`
- `pnpm test:harbor` — 58 tests passed
- `pnpm build`
- `git diff --check`

The fixed non-TB harness-development suite completed all 33 attempts and produced 33/33 per-attempt traces plus an aggregate report. Attribution collection reported no timeout or infrastructure failure.

## Neutral trace snapshot

For `openai-codex/gpt-5.6-sol`, reasoning `max`, profile `standard`:

- 125 model turns and 190 tool calls
- 404,653 `uncached_input_plus_output_v1` tokens
- 614,400 provider cache-read tokens
- 48,338 raw tool-output bytes and 105,304 model-visible bytes
- 28 completion-tail turns
- estimated proxy attribution: tool schema 63.3%, system/base context 13.4%, model output 12.4%

Input-component attribution is explicitly estimated and is not presented as provider-native segment billing.

## Trace provenance

- canonical aggregate report digest: `8da18c697dda1182aefdffd2ab16524c3dfa481bc8f6633dbc5267d5b570c5b8`
- observed Harness compiler digest: `4573269845bd4372157711feb2ca1462e93872336531c5c25365e311b8cb7c5b`
- compiler activation: `inspection_only`