### PR TITLE
fix: remove hardcoded provider and model assumptions

### DIFF
--- a/native/sigma-exec/src/sandbox.rs
+++ b/native/sigma-exec/src/sandbox.rs
@@ -1212,7 +1212,17 @@ fn secret_key(key: &str) -> bool {
     parts.iter().any(|part| {
         matches!(
             *part,
-            "apikey" | "secret" | "token" | "password" | "passwd" | "credential"
+            "apikey"
+                | "authorization"
+                | "bearer"
+                | "cookie"
+                | "credential"
+                | "jwt"
+                | "password"
+                | "passwd"
+                | "pat"
+                | "secret"
+                | "token"
         )
     }) || parts
         .windows(2)
@@ -2559,6 +2569,10 @@ mod tests {
     fn recognizes_secret_environment_names() {
         assert!(secret_key("DEEPSEEK_API_KEY"));
         assert!(secret_key("accessToken"));
+        assert!(secret_key("GITHUB_PAT"));
+        assert!(secret_key("HTTP_AUTHORIZATION"));
+        assert!(secret_key("SESSION_COOKIE"));
+        assert!(secret_key("OIDC_JWT"));
         assert!(!secret_key("PATH"));
         assert!(!secret_key("TOKENIZERS_PARALLELISM"));
     }

--- a/packages/agent-cli/src/acp/sigma-acp-session-registry.ts
+++ b/packages/agent-cli/src/acp/sigma-acp-session-registry.ts
@@ -3,6 +3,7 @@ import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type * as acp from "@agentclientprotocol/sdk";
 import type { ModelReasoningEffort } from "agent-model";
+import { MODEL_REASONING_EFFORTS } from "agent-protocol";
 import type {
   PersistedAcpSession,
   ResolvedSession,
@@ -13,7 +14,7 @@ import { reasoningEffortForModel } from "./sigma-acp-shared.js";
 
 const SESSION_INDEX_FILE = "acp-sessions.json";
 const INDEX_VERSION = 1;
-const REASONING_EFFORTS = new Set(["none", "low", "medium", "high", "xhigh", "max"]);
+const REASONING_EFFORTS = new Set<string>(MODEL_REASONING_EFFORTS);
 
 interface PersistedAcpIndex {
   version: typeof INDEX_VERSION;

--- a/packages/agent-cli/src/commands/doctor.ts
+++ b/packages/agent-cli/src/commands/doctor.ts
@@ -121,16 +121,6 @@ function nodeCheck(): DoctorCheck {
 
 async function apiCheck(provider: string, model: string, enabled: boolean): Promise<DoctorCheck> {
   if (!enabled) return { name: "api", status: "skipped", message: "Pass --check-api to verify the provider." };
-  if (provider !== "deepseek" && provider !== "glm") {
-    const auth = await piAuthStatus(provider);
-    return auth.status === "authenticated"
-      ? {
-          name: "api",
-          status: "ok",
-          message: `${provider} credentials are configured; no billable model request was sent.`
-        }
-      : { name: "api", status: "error", message: `${provider} authentication is required.` };
-  }
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(new Error("API check timed out.")), 15_000);
   try {

--- a/packages/agent-cli/src/config.ts
+++ b/packages/agent-cli/src/config.ts
@@ -15,6 +15,7 @@ import {
 import { parse as parseToml } from "smol-toml";
 import { resolveWorkspaceMcpTrust } from "./workspace-mcp-trust.js";
 import { resolveWorkspaceCustomizationTrust } from "./workspace-customization-trust.js";
+import type { ModelReasoningEffort } from "agent-protocol";
 
 export interface ParsedArgs {
   flags: Record<string, unknown>;
@@ -25,7 +26,7 @@ export interface CliConfig {
   workspace: string;
   provider: string;
   model: string;
-  reasoningEffort?: "none" | "low" | "medium" | "high" | "xhigh" | "max";
+  reasoningEffort?: ModelReasoningEffort;
   agentProfile: string;
   permissionMode: "workspace-auto" | "ask" | "auto" | "deny";
   sandboxMode: "required";

--- a/packages/agent-config/src/schema.ts
+++ b/packages/agent-config/src/schema.ts
@@ -1,7 +1,7 @@
 import {
   modelRoutesValue, modelSpecsValue, type ModelRouteConfigValue, type ModelSpecConfigValue
 } from "./model-catalog.js";
-import { assertMcpPersistentEffectsAllowed } from "agent-protocol";
+import { assertMcpPersistentEffectsAllowed, MODEL_REASONING_EFFORTS } from "agent-protocol";
 export type ConfigScalar = string | number | boolean;
 export type ConfigToolEffect =
   | "filesystem.read" | "filesystem.read.external" | "filesystem.write"
@@ -149,7 +149,7 @@ export const SIGMA_CONFIG_SCHEMA: readonly ConfigField[] = [
   }, hidden: true },
   { key: "provider", flag: "provider", env: "SIGMA_PROVIDER", toml: "model.provider", description: "Model provider", defaultValue: "openai-codex", parse: (raw) => stringValue(raw, "provider") },
   { key: "model", flag: "model", env: "SIGMA_MODEL", toml: "model.name", description: "Model name (auto selects provider default)", defaultValue: "auto", parse: (raw) => stringValue(raw, "model") },
-  { key: "reasoningEffort", flag: "reasoning-effort", env: "SIGMA_REASONING_EFFORT", toml: "model.reasoning_effort", description: "Model reasoning effort (auto uses the provider/model default)", defaultValue: "auto", parse: (raw) => enumValue(raw, "reasoningEffort", ["auto", "none", "low", "medium", "high", "xhigh", "max"] as const) },
+  { key: "reasoningEffort", flag: "reasoning-effort", env: "SIGMA_REASONING_EFFORT", toml: "model.reasoning_effort", description: "Model reasoning effort (auto uses the provider/model default)", defaultValue: "auto", parse: (raw) => enumValue(raw, "reasoningEffort", ["auto", ...MODEL_REASONING_EFFORTS] as const) },
   {
     key: "modelSpecs", flag: "model-spec", kind: "repeatable", env: "SIGMA_MODEL_SPECS", toml: "model.specs",
     description: "Model catalog spec JSON (repeatable)", defaultValue: [], parse: modelSpecsValue, hidden: true

--- a/packages/agent-context/src/index.ts
+++ b/packages/agent-context/src/index.ts
@@ -12,3 +12,4 @@ export * from "./repository-safe-read.js";
 export * from "./repository-statistics.js";
 export * from "./repository-text-search.js";
 export * from "./repository-path-safety.js";
+export { repositoryLanguage } from "./repository-path-metadata.js";

--- a/packages/agent-model/src/catalog.ts
+++ b/packages/agent-model/src/catalog.ts
@@ -112,6 +112,8 @@ export interface ModelSpec {
   pricing?: ModelPricing;
   supportedReasoningEfforts?: readonly PiReasoningEffort[];
   defaultReasoningEffort?: PiReasoningEffort;
+  /** Opts this model into provider-neutral automatic fallback composition. */
+  recommended?: boolean;
 }
 
 export type ModelReasoningEffort = PiReasoningEffort;
@@ -155,6 +157,7 @@ export function modelSpecsForPiCatalog(
       billingModes: model.billingModes,
       capabilities: model.capabilities,
       tokenizer: approximateTokenizer,
+      recommended: model.recommended,
       ...(model.supportedReasoningEfforts.length > 0
         ? { supportedReasoningEfforts: model.supportedReasoningEfforts }
         : {}),
@@ -175,12 +178,3 @@ export const BUILTIN_MODEL_SPECS: readonly ModelSpec[] = modelSpecsForPiCatalog(
 export function builtinModelSpec(provider: ModelSpec["providerId"], model?: string): ModelSpec | undefined {
   return BUILTIN_MODEL_SPECS.find((spec) => spec.providerId === provider && (!model || spec.upstreamModel === model));
 }
-
-export const DEFAULT_MODEL_ROUTES: readonly ModelRoute[] = [
-  {
-    id: "default",
-    candidates: ["openai-codex/gpt-5.6-terra"],
-    fallbackOn: ["rate_limit", "capacity", "network", "server", "timeout"],
-    maxAttempts: 1
-  }
-] as const;

--- a/packages/agent-model/src/provider-health.ts
+++ b/packages/agent-model/src/provider-health.ts
@@ -1,6 +1,9 @@
 import {
   createPiModels,
   defaultPiModel,
+  getPiModel,
+  getPiProvider,
+  PiModelGateway,
   sanitizePiModelError,
   type CredentialStore,
   type Models
@@ -10,7 +13,7 @@ import { classifyModelFailure } from "./failure-policy.js";
 
 export interface ProviderHealthReport {
   ok: boolean;
-  provider: "deepseek" | "glm";
+  provider: string;
   model: string;
   endpointHost: string;
   latencyMs: number;
@@ -22,11 +25,15 @@ export interface ProviderHealthReport {
 const HEALTH_PROBE_MAX_OUTPUT_TOKENS = 32;
 const DEFAULT_HEALTH_PROBE_TIMEOUT_MS = 10_000;
 
-function endpointFor(provider: "deepseek" | "glm", baseUrl?: string): string {
-  return baseUrl ?? (provider === "deepseek"
-    ? process.env.DEEPSEEK_BASE_URL ?? "https://api.deepseek.com"
-    : process.env.GLM_BASE_URL ?? process.env.ZAI_BASE_URL ?? process.env.BIGMODEL_BASE_URL
-      ?? "https://open.bigmodel.cn/api/paas/v4");
+function endpointFor(
+  models: Models,
+  provider: string,
+  model: string,
+  baseUrl?: string
+): string {
+  const definition = getPiModel(provider, model, models)
+    ?? getPiProvider(provider, models)?.getModels()[0];
+  return baseUrl ?? definition?.baseUrl ?? getPiProvider(provider, models)?.baseUrl ?? "unknown";
 }
 
 function endpointHost(endpoint: string): string {
@@ -35,13 +42,7 @@ function endpointHost(endpoint: string): string {
 
 function safeErrorMessage(error: unknown, secrets: readonly string[] = []): string {
   let message = error instanceof Error ? error.message : String(error);
-  for (const key of [
-    ...secrets,
-    process.env.DEEPSEEK_API_KEY,
-    process.env.GLM_API_KEY,
-    process.env.ZAI_API_KEY,
-    process.env.BIGMODEL_API_KEY
-  ]) {
+  for (const key of secrets) {
     if (key) message = message.split(key).join("[redacted]");
   }
   return message.replace(/Bearer\s+[^\s]+/giu, "Bearer [redacted]").slice(0, 800);
@@ -131,11 +132,9 @@ async function executeProbe(input: {
 
 async function probeAuthentication(
   models: Models,
-  provider: "deepseek" | "glm",
-  fallbackEndpoint: string,
-  baseUrl: string | undefined
+  provider: string
 ): Promise<{
-  endpoint: string;
+  endpoint?: string;
   headers: Record<string, string>;
   secrets: string[];
 }> {
@@ -156,13 +155,75 @@ async function probeAuthentication(
     headers.authorization = `Bearer ${resolved.auth.apiKey}`;
   }
   return {
-    endpoint: baseUrl ?? resolved.auth.baseUrl ?? fallbackEndpoint,
+    ...(resolved.auth.baseUrl ? { endpoint: resolved.auth.baseUrl } : {}),
     headers,
     secrets: [
       ...(resolved.auth.apiKey ? [resolved.auth.apiKey] : []),
       ...Object.values(headers)
     ]
   };
+}
+
+async function executeGatewayProbe(input: {
+  provider: string;
+  model: string;
+  endpoint?: string;
+  signal: AbortSignal;
+  timeoutMs: number;
+  models: Models;
+}): Promise<string> {
+  const gateway = new PiModelGateway({
+    provider: input.provider,
+    model: input.model,
+    models: input.models,
+    ...(input.endpoint && input.endpoint !== "unknown" ? { baseUrl: input.endpoint } : {}),
+    requestTimeoutMs: input.timeoutMs,
+    idleTimeoutMs: input.timeoutMs,
+    activeStreamTimeoutMs: input.timeoutMs
+  });
+  const response = await gateway.complete({
+    messages: [{ role: "user", content: "Return exactly the text OK." }],
+    maxOutputTokens: HEALTH_PROBE_MAX_OUTPUT_TOKENS,
+    temperature: 0,
+    signal: input.signal
+  });
+  const text = response.message.content.trim() || response.message.reasoningContent?.trim() || "";
+  if (!text) throw new ModelGatewayError("Provider returned no textual output.", "protocol");
+  return text;
+}
+
+async function executeProviderProbe(input: {
+  provider: string;
+  model: string;
+  endpoint: string;
+  signal: AbortSignal;
+  timeoutMs: number;
+  models: Models;
+  authenticationHeaders: Record<string, string>;
+  fetchImpl?: typeof fetch;
+}): Promise<string> {
+  const definition = getPiModel(input.provider, input.model, input.models)
+    ?? getPiProvider(input.provider, input.models)?.getModels()[0];
+  // The injected fetch path keeps the low-level HTTP contract testable.
+  // Production probes always use Pi's provider transport so OAuth, ambient
+  // credentials, headers and API-specific payloads remain provider-owned.
+  if (input.fetchImpl && definition?.api === "openai-completions") {
+    return executeProbe({
+      endpoint: input.endpoint,
+      model: input.model,
+      signal: input.signal,
+      fetchImpl: input.fetchImpl,
+      headers: input.authenticationHeaders
+    });
+  }
+  return executeGatewayProbe({
+    provider: input.provider,
+    model: input.model,
+    endpoint: input.endpoint,
+    signal: input.signal,
+    timeoutMs: input.timeoutMs,
+    models: input.models
+  });
 }
 
 function failureCategory(error: unknown): ModelGatewayError["category"] {
@@ -174,7 +235,7 @@ function failureCategory(error: unknown): ModelGatewayError["category"] {
 }
 
 export async function checkProviderHealth(input: {
-  provider: "deepseek" | "glm";
+  provider: string;
   model: string;
   signal: AbortSignal;
   baseUrl?: string;
@@ -185,28 +246,29 @@ export async function checkProviderHealth(input: {
 }): Promise<ProviderHealthReport> {
   const models = input.piModels ?? createPiModels(input.credentials);
   const selectedModel = input.model === "auto"
-    ? defaultPiModel(input.provider)
+    ? defaultPiModel(input.provider, process.env, models)
     : input.model;
   const model = selectedModel;
-  let endpoint = endpointFor(input.provider, input.baseUrl);
+  let endpoint = input.baseUrl ?? "unknown";
   const startedAt = performance.now();
   let secrets: string[] = [];
-  const abort = healthProbeSignal(
-    input.signal,
-    Math.max(1, input.requestTimeoutMs ?? DEFAULT_HEALTH_PROBE_TIMEOUT_MS)
-  );
+  const timeoutMs = Math.max(1, input.requestTimeoutMs ?? DEFAULT_HEALTH_PROBE_TIMEOUT_MS);
+  const abort = healthProbeSignal(input.signal, timeoutMs);
   try {
-    const authentication = await probeAuthentication(
-      models, input.provider, endpoint, input.baseUrl
-    );
-    endpoint = authentication.endpoint;
+    const authentication = await probeAuthentication(models, input.provider);
+    endpoint = input.baseUrl
+      ?? authentication.endpoint
+      ?? endpointFor(models, input.provider, model);
     secrets = authentication.secrets;
-    const text = await executeProbe({
-      endpoint,
+    const text = await executeProviderProbe({
+      provider: input.provider,
       model,
+      endpoint,
       signal: abort.signal,
-      fetchImpl: input.fetchImpl ?? globalThis.fetch,
-      headers: authentication.headers
+      timeoutMs,
+      models,
+      authenticationHeaders: authentication.headers,
+      ...(input.fetchImpl ? { fetchImpl: input.fetchImpl } : {})
     });
     return {
       ok: true,

--- a/packages/agent-model/src/registry.ts
+++ b/packages/agent-model/src/registry.ts
@@ -4,6 +4,7 @@ import {
   listPiAuthStatuses,
   listPiModels,
   listPiProviders,
+  piProviderEnvironmentValue,
   PiModelGateway,
   type CredentialStore,
   type Models,
@@ -49,10 +50,7 @@ export function createModelGateway(options: CreateGatewayOptions): ModelGateway 
   const selectedModel = options.model ?? defaultModel(options.provider);
   const spec = builtinModelSpec(options.provider, selectedModel);
   const baseUrl = options.baseUrl
-    ?? (options.provider === "deepseek" ? process.env.DEEPSEEK_BASE_URL : undefined)
-    ?? (options.provider === "glm"
-      ? process.env.GLM_BASE_URL ?? process.env.ZAI_BASE_URL ?? process.env.BIGMODEL_BASE_URL
-      : undefined);
+    ?? piProviderEnvironmentValue(options.provider, "BASE_URL");
   return new PiModelGateway({
     ...gatewayOptions,
     model: selectedModel,
@@ -105,6 +103,7 @@ export function providerAdapter(provider: SupportedProvider): ProviderSpi {
 
 export interface PiRuntimeModelCatalog {
   specs: readonly ModelSpec[];
+  authenticatedProviders: ReadonlySet<string>;
   gatewayFactory(options: {
     provider: string;
     model: string;
@@ -135,9 +134,12 @@ export async function loadPiRuntimeModelCatalog(options: {
     );
     return method ? [[status.provider, method.billingMode] as const] : [];
   }));
+  const authenticatedProviders = new Set(statuses.flatMap((status) =>
+    status.status === "authenticated" ? [status.provider] : []));
   const specs = modelSpecsForPiCatalog(listPiModels(piModels), activeBillingModes);
   return {
     specs,
+    authenticatedProviders,
     gatewayFactory: (options) => {
       const { maxRetries: _policyRetries, ...transport } = options;
       void _policyRetries;

--- a/packages/agent-model/src/router-retry.ts
+++ b/packages/agent-model/src/router-retry.ts
@@ -11,7 +11,7 @@ function retrySameProvider(category: ModelFailureCategory, spec: ModelSpec | und
     || category === "server"
     || category === "timeout"
     || category === "protocol"
-    || (category === "capacity" && spec?.providerId === "deepseek");
+    || (category === "capacity" && spec?.billingMode === "metered");
 }
 
 export function abortableDelay(delayMs: number, signal: AbortSignal): Promise<void> {

--- a/packages/agent-pi/src/gateway-adapter.ts
+++ b/packages/agent-pi/src/gateway-adapter.ts
@@ -128,7 +128,7 @@ function lateInstructionMessage(
   model: PiModel<Api>,
   codexInstructionNonce?: string
 ): Message {
-  const mappedContent = model.provider === "openai-codex" && codexInstructionNonce
+  const mappedContent = model.api === "openai-codex-responses" && codexInstructionNonce
     ? codexInstructionSentinel(role, codexInstructionNonce, content)
     : reminderContent({ role, content });
   return { role: "user", content: mappedContent, timestamp: Date.now() };

--- a/packages/agent-pi/src/gateway.ts
+++ b/packages/agent-pi/src/gateway.ts
@@ -33,7 +33,6 @@ import {
   createPiModels,
   getPiModel,
   getPiProvider,
-  OPENAI_CODEX_PROVIDER_ID,
   piHostedToolSearchSupported,
   piBillingMode,
   type PiReasoningEffort
@@ -59,11 +58,28 @@ export interface PiModelGatewayOptions {
   hostedToolSearch?: boolean;
 }
 
-function fallbackModel(providerId: string, modelId: string): PiModel<Api> | undefined {
-  if (providerId !== "deepseek" && providerId !== "glm") return undefined;
-  const template = getPiProvider(providerId)?.getModels()[0];
+function fallbackModel(
+  providerId: string,
+  modelId: string,
+  models: Models,
+  capabilities?: ModelCapabilities
+): PiModel<Api> | undefined {
+  // A custom catalog spec supplies Sigma's capabilities, tokenizer and pricing.
+  // Reuse the selected provider's wire contract for an upstream model that is
+  // newer than the bundled Pi catalog, regardless of provider identity.
+  const template = getPiProvider(providerId, models)?.getModels()[0];
   return template
-    ? { ...template, id: modelId, name: modelId }
+    ? {
+        ...template,
+        id: modelId,
+        name: modelId,
+        ...(capabilities ? {
+          reasoning: capabilities.reasoning,
+          contextWindow: capabilities.contextWindowTokens,
+          maxTokens: capabilities.maxOutputTokens,
+          input: capabilities.imageInput ? ["text", "image"] : ["text"]
+        } : {})
+      }
     : undefined;
 }
 
@@ -76,12 +92,12 @@ function hostedToolSearchEnabled(
 }
 
 function piPayloadOptions(
-  provider: string,
+  model: PiModel<Api>,
   codexInstructionNonce: string,
   hostedToolSearch: boolean,
   request: ModelRequest
 ): { onPayload?: (payload: unknown) => unknown } {
-  if (provider === OPENAI_CODEX_PROVIDER_ID) {
+  if (model.api === "openai-codex-responses") {
     return {
       onPayload: (payload) => hostedToolSearchPayload(
         codexPayload(payload, codexInstructionNonce),
@@ -90,7 +106,9 @@ function piPayloadOptions(
       )
     };
   }
-  if (provider === "deepseek") {
+  // DeepSeek requires reasoning to be disabled for forced/disabled tool use;
+  // this is a provider wire-compatibility rule, not a model routing policy.
+  if (model.provider === "deepseek") {
     return { onPayload: (payload) => deepSeekPayload(payload, request) };
   }
   return hostedToolSearch
@@ -207,7 +225,7 @@ export class PiModelGateway implements ModelGateway {
       options.modelsStore ?? new FileModelsStore()
     );
     const piModel = getPiModel(options.provider, options.model, this.models)
-      ?? fallbackModel(options.provider, options.model);
+      ?? fallbackModel(options.provider, options.model, this.models, options.capabilities);
     if (!piModel) throw new PiModelError("protocol", "protocol");
     this.piModel = options.baseUrl
       ? { ...piModel, baseUrl: options.baseUrl.replace(/\/+$/u, "") }
@@ -269,7 +287,7 @@ export class PiModelGateway implements ModelGateway {
           toolChoice: request.toolChoice,
           maxRetries: 0,
           ...(request.sessionId ? { sessionId: request.sessionId } : {}),
-          ...(this.provider === OPENAI_CODEX_PROVIDER_ID ? { transport: "auto" as const } : {}),
+          ...(this.piModel.api === "openai-codex-responses" ? { transport: "auto" as const } : {}),
           ...piReasoningStreamOptions(
             this.piModel,
             this.reasoningEffort,
@@ -278,7 +296,7 @@ export class PiModelGateway implements ModelGateway {
           ),
           ...(this.requestTimeoutMs ? { timeoutMs: this.requestTimeoutMs } : {}),
           ...piPayloadOptions(
-            this.provider,
+            this.piModel,
             this.codexInstructionNonce,
             this.hostedToolSearch,
             request

--- a/packages/agent-pi/src/model-descriptors.ts
+++ b/packages/agent-pi/src/model-descriptors.ts
@@ -5,20 +5,16 @@ import {
   type Model,
   type Provider
 } from "@earendil-works/pi-ai";
-import type { ModelCapabilities } from "agent-protocol";
+import {
+  MODEL_REASONING_EFFORTS,
+  type ModelCapabilities,
+  type ModelReasoningEffort
+} from "agent-protocol";
 import { hasKnownPricing } from "./model-pricing.js";
 
 export type PiBillingMode = "metered" | "subscription" | "unpriced";
-export const PI_REASONING_EFFORTS = [
-  "none",
-  "minimal",
-  "low",
-  "medium",
-  "high",
-  "xhigh",
-  "max"
-] as const;
-export type PiReasoningEffort = (typeof PI_REASONING_EFFORTS)[number];
+export const PI_REASONING_EFFORTS = MODEL_REASONING_EFFORTS;
+export type PiReasoningEffort = ModelReasoningEffort;
 export const DEFAULT_PI_REASONING_EFFORT: PiReasoningEffort = "medium";
 
 export interface PiAuthMethodDescriptor {

--- a/packages/agent-pi/src/models.ts
+++ b/packages/agent-pi/src/models.ts
@@ -55,12 +55,32 @@ const catalogEffectiveAt = generatedAt === undefined
   ? "2026-07-30"
   : new Date(generatedAt).toISOString().slice(0, 10);
 
-const recommendedModels = new Set<string>([
+const recommendedModelOrder = [
   "openai-codex/gpt-5.6-terra",
   "openai-codex/gpt-5.6-sol",
   "deepseek/deepseek-v4-pro",
   "glm/glm-5.2"
-]);
+] as const;
+const recommendedModels = new Set<string>(recommendedModelOrder);
+const providerEnvironmentAliases: Readonly<Record<string, Readonly<Record<string, readonly string[]>>>> = {
+  [GLM_PROVIDER_ID]: {
+    BASE_URL: ["ZAI_BASE_URL", "BIGMODEL_BASE_URL"]
+  }
+};
+
+export function piProviderEnvironmentValue(
+  providerId: string,
+  suffix: string,
+  env: NodeJS.ProcessEnv = process.env
+): string | undefined {
+  const prefix = providerId.replace(/[^a-z0-9]+/giu, "_").toUpperCase();
+  const keys = [`${prefix}_${suffix}`, ...(providerEnvironmentAliases[providerId]?.[suffix] ?? [])];
+  for (const key of keys) {
+    const value = env[key]?.trim();
+    if (value) return value;
+  }
+  return undefined;
+}
 
 const glmModel: Model<"openai-completions"> = {
   id: GLM_DEFAULT_MODEL,
@@ -126,11 +146,16 @@ function capabilities(model: Model<Api>): ModelCapabilities {
   return {
     contextWindowTokens: model.contextWindow,
     maxOutputTokens: model.maxTokens,
+    // Pi's model catalog contains chat transports whose uniform Context
+    // contract serializes function tools and multiple tool calls. Per-model
+    // custom specs can still narrow either capability at Sigma's route layer.
     tools: true,
     parallelTools: true,
     reasoning: model.reasoning,
     structuredOutput: model.api === "openai-responses"
       || model.api === "openai-codex-responses",
+    // This denotes Sigma's stable-prefix prompt layout. Individual Pi
+    // providers independently omit unsupported wire-level cache controls.
     promptCache: true,
     tokenizer: "approximate",
     imageInput: model.input.includes("image"),
@@ -286,11 +311,18 @@ export function getPiProvider(
   return models.getProvider(providerId);
 }
 
-export function defaultPiModel(providerId: string, env: NodeJS.ProcessEnv = process.env): string {
-  if (providerId === OPENAI_CODEX_PROVIDER_ID) return OPENAI_CODEX_DEFAULT_MODEL;
-  if (providerId === "deepseek") return env.DEEPSEEK_MODEL ?? "deepseek-v4-pro";
-  if (providerId === GLM_PROVIDER_ID) return env.GLM_MODEL ?? GLM_DEFAULT_MODEL;
-  const provider = getPiProvider(providerId);
+export function defaultPiModel(
+  providerId: string,
+  env: NodeJS.ProcessEnv = process.env,
+  models: Models = createPiModels()
+): string {
+  const configured = piProviderEnvironmentValue(providerId, "MODEL", env);
+  if (configured) return configured;
+  const provider = getPiProvider(providerId, models);
+  const preferredId = recommendedModelOrder.find((candidate) =>
+    candidate.startsWith(`${providerId}/`))?.slice(providerId.length + 1);
+  const preferred = preferredId ? provider?.getModels().find((model) => model.id === preferredId) : undefined;
+  if (preferred) return preferred.id;
   const first = provider?.getModels()[0];
   if (!first) throw new Error(`Provider '${providerId}' has no available models.`);
   return first.id;

--- a/packages/agent-pi/src/reasoning.ts
+++ b/packages/agent-pi/src/reasoning.ts
@@ -64,13 +64,6 @@ function anthropicReasoningOptions(
   };
 }
 
-function bedrockModelMatchCandidates(model: Model<Api>): readonly string[] {
-  return [model.id, model.name].flatMap((value) => {
-    const lower = value.toLowerCase();
-    return [lower, lower.replace(/[\s_.:]+/gu, "-")];
-  });
-}
-
 function isAnthropicBedrockModel(model: Model<Api>): boolean {
   const id = model.id.toLowerCase();
   const name = model.name.toLowerCase();
@@ -82,16 +75,8 @@ function isAnthropicBedrockModel(model: Model<Api>): boolean {
 }
 
 function supportsBedrockAdaptiveThinking(model: Model<Api>): boolean {
-  return bedrockModelMatchCandidates(model).some((candidate) =>
-    [
-      "opus-4-6",
-      "opus-4-7",
-      "opus-4-8",
-      "opus-5",
-      "sonnet-4-6",
-      "sonnet-5",
-      "fable-5"
-    ].some((marker) => candidate.includes(marker)));
+  return typeof model.thinkingLevelMap?.xhigh === "string"
+    || typeof model.thinkingLevelMap?.max === "string";
 }
 
 function bedrockReasoningOptions(
@@ -123,30 +108,10 @@ function bedrockReasoningOptions(
   };
 }
 
-function isGemini3Pro(model: Model<Api>): boolean {
-  return /gemini-3(?:\.\d+)?-pro/u.test(model.id.toLowerCase());
-}
-
-function isGemini3Flash(model: Model<Api>): boolean {
-  const id = model.id.toLowerCase();
-  return /gemini-3(?:\.\d+)?-flash/u.test(id)
-    || id === "gemini-flash-latest"
-    || id === "gemini-flash-lite-latest";
-}
-
-function isGemma4(model: Model<Api>): boolean {
-  return /gemma-?4/u.test(model.id.toLowerCase());
-}
-
 function googleThinkingLevel(model: Model<Api>, level: ThinkingLevel): string {
   const normalized = budgetLevel(level);
-  if (isGemini3Pro(model)) {
-    return normalized === "minimal" || normalized === "low" ? "LOW" : "HIGH";
-  }
-  if (isGemma4(model)) {
-    return normalized === "minimal" || normalized === "low" ? "MINIMAL" : "HIGH";
-  }
-  return normalized.toUpperCase();
+  const mapped = model.thinkingLevelMap?.[normalized];
+  return typeof mapped === "string" ? mapped : normalized.toUpperCase();
 }
 
 function googleThinkingBudget(model: Model<Api>, level: ThinkingLevel): number {
@@ -182,9 +147,7 @@ function googleReasoningOptions(
   model: Model<Api>,
   level: ThinkingLevel
 ): Readonly<Record<string, unknown>> {
-  const usesThinkingLevel = isGemini3Pro(model)
-    || isGemini3Flash(model)
-    || (model.api === "google-generative-ai" && isGemma4(model));
+  const usesThinkingLevel = model.thinkingLevelMap !== undefined;
   return usesThinkingLevel
     ? {
         thinking: {

--- a/packages/agent-protocol/src/model.ts
+++ b/packages/agent-protocol/src/model.ts
@@ -115,6 +115,18 @@ export interface ModelCapabilities {
   hostedToolSearch?: boolean;
 }
 
+/** Provider-neutral reasoning effort values accepted across every Sigma surface. */
+export const MODEL_REASONING_EFFORTS = [
+  "none",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max"
+] as const;
+export type ModelReasoningEffort = (typeof MODEL_REASONING_EFFORTS)[number];
+
 export type ModelFinishReason = "stop" | "length" | "tool_calls" | "content_filter" | "protocol_error";
 export type ModelBillingMode = "metered" | "subscription" | "unpriced";
 

--- a/packages/agent-runtime/src/assurance-engine.ts
+++ b/packages/agent-runtime/src/assurance-engine.ts
@@ -2,11 +2,15 @@ import type {
   AssuranceRequirement,
   ValidationClaimKind
 } from "agent-protocol";
+import { repositoryLanguage } from "agent-context";
 import type { RuntimeSession } from "./types.js";
 
-const HIGH_RISK_PATH = /(?:^|\/)(?:native|security|sandbox|permissions?|auth|completion|budget|release|deployment|agent-execution|agent-runtime)(?:\/|$)|(?:^|\/)(?:package-lock\.json|pnpm-lock\.yaml|yarn\.lock)$/iu;
-const SOURCE_PATH = /\.(?:[cm]?[jt]sx?|py|rs|go|java|kt|swift|c|cc|cpp|h|hpp)$/iu;
-const TEST_PATH = /(?:^|\/)(?:tests?|__tests__)(?:\/|$)|\.(?:test|spec)\.[cm]?[jt]sx?$/iu;
+const HIGH_RISK_PATH = /(?:^|\/)(?:native|security|sandbox|permissions?|auth|credentials?|secrets?|completion|budget|billing|payments?|cryptography?|migrations?|database|release|deployment|infrastructure|infra|workflows?|agent-execution|agent-runtime)(?:\/|$)|(?:^|\/)(?:dockerfile|compose\.ya?ml|cargo\.lock|gemfile\.lock|package-lock\.json|pnpm-lock\.yaml|poetry\.lock|uv\.lock|yarn\.lock)$/iu;
+const TEST_PATH = /(?:^|\/)(?:tests?|__tests__|spec)(?:\/|$)|(?:\.(?:test|spec)|_(?:test|spec))\.[^/]+$|(?:^|\/)test_[^/]+\.[^/]+$/iu;
+
+function sourcePath(value: string): boolean {
+  return repositoryLanguage(value) !== undefined;
+}
 
 function explicitAcceptanceClaims(goal: string): ValidationClaimKind[] {
   const claims: ValidationClaimKind[] = [];
@@ -30,11 +34,11 @@ export function assuranceRequirement(session: RuntimeSession): AssuranceRequirem
   const required = new Set<ValidationClaimKind>(explicitAcceptanceClaims(session.durable.state.plan.goal));
   if (changed.some((item) => TEST_PATH.test(item))) required.add("unit");
   if (changed.some((item) => /\.[cm]?tsx?$/iu.test(item))) required.add("typecheck");
-  if (changed.some((item) => SOURCE_PATH.test(item)) && required.size === 0) required.add("unit");
+  if (changed.some(sourcePath) && required.size === 0) required.add("unit");
   if (required.size === 0) required.add("acceptance");
   if (high) required.add("acceptance");
   return {
-    risk: high ? "high" : changed.some((item) => SOURCE_PATH.test(item)) ? "medium" : "low",
+    risk: high ? "high" : changed.some(sourcePath) ? "medium" : "low",
     requiredClaims: [...required],
     review: high ? "required" : "advisory"
   };
@@ -55,8 +59,8 @@ export function assurancePathsForClaim(
 ): string[] {
   if (claim === "typecheck") return paths.filter((item) => /\.[cm]?tsx?$/iu.test(item));
   if (claim === "unit" || claim === "integration") {
-    return paths.filter((item) => SOURCE_PATH.test(item) || TEST_PATH.test(item));
+    return paths.filter((item) => sourcePath(item) || TEST_PATH.test(item));
   }
-  if (claim === "lint") return paths.filter((item) => SOURCE_PATH.test(item) || /\.(?:json|ya?ml|toml)$/iu.test(item));
+  if (claim === "lint") return paths.filter((item) => sourcePath(item) || /\.(?:json|ya?ml|toml)$/iu.test(item));
   return [...paths];
 }

--- a/packages/agent-runtime/src/configured-runtime.ts
+++ b/packages/agent-runtime/src/configured-runtime.ts
@@ -153,7 +153,8 @@ export async function createConfiguredRuntime(
         ? {
             ...deps,
             gatewayFactory: piCatalog.gatewayFactory,
-            catalogSpecs: piCatalog.specs
+            catalogSpecs: piCatalog.specs,
+            authenticatedProviders: piCatalog.authenticatedProviders
           }
         : deps,
       customization

--- a/packages/agent-runtime/src/model-accounting.ts
+++ b/packages/agent-runtime/src/model-accounting.ts
@@ -63,8 +63,6 @@ function budgetAware(gateway: ModelGateway): gateway is BudgetAwareGateway {
 }
 
 function matchingSpec(gateway: ModelGateway): ModelSpec | undefined {
-  if (gateway.provider !== "deepseek" && gateway.provider !== "glm"
-    && gateway.provider !== "openai-codex") return undefined;
   return builtinModelSpec(gateway.provider, gateway.model);
 }
 

--- a/packages/agent-runtime/src/model-composition.ts
+++ b/packages/agent-runtime/src/model-composition.ts
@@ -46,6 +46,7 @@ interface ModelGatewayFactoryOptions {
 export interface ModelCompositionDeps {
   gatewayFactory?: (options: ModelGatewayFactoryOptions) => ModelGateway;
   catalogSpecs?: readonly ModelSpec[];
+  authenticatedProviders?: ReadonlySet<string>;
 }
 
 export interface ModelGateways {
@@ -62,33 +63,29 @@ const TOOL_ROLES = new Set<ModelExecutionRole>([
   "child_write"
 ]);
 
-function hasCredential(provider: ModelSpec["providerId"], env: NodeJS.ProcessEnv): boolean {
-  if (provider === "deepseek") return Boolean(env.DEEPSEEK_API_KEY?.trim());
-  if (provider === "glm") {
-    return Boolean(env.GLM_API_KEY?.trim() || env.ZAI_API_KEY?.trim() || env.BIGMODEL_API_KEY?.trim());
-  }
-  return false;
-}
-
 export function productionModelCandidates(
   config: Pick<ModelCompositionConfig, "provider" | "model" | "explicitSingleModelRoute">,
   env: NodeJS.ProcessEnv = process.env,
-  catalogSpecs: readonly ModelSpec[] = BUILTIN_MODEL_SPECS
+  catalogSpecs: readonly ModelSpec[] = BUILTIN_MODEL_SPECS,
+  authenticatedProviders: ReadonlySet<string> = new Set()
 ): ModelSpec[] {
   const model = selectedModel(config, env, catalogSpecs);
   const primary = catalogSpecs.find((spec) =>
     spec.providerId === config.provider && spec.upstreamModel === model);
   if (!primary) return [];
-  if (config.explicitSingleModelRoute || (primary.providerId !== "deepseek" && primary.providerId !== "glm")) {
+  if (config.explicitSingleModelRoute || primary.recommended !== true) {
     return [primary];
   }
-  const fallbackProvider = primary.providerId === "deepseek" ? "glm" : "deepseek";
-  const fallback = hasCredential(fallbackProvider, env)
-    ? catalogSpecs.find((spec) =>
-        spec.providerId === fallbackProvider
-        && spec.upstreamModel === defaultModel(fallbackProvider, env))
-    : undefined;
-  return fallback ? [primary, fallback] : [primary];
+  const seenProviders = new Set([primary.providerId]);
+  const fallback = catalogSpecs.filter((spec) => {
+    if (spec.recommended !== true
+      || spec.billingMode !== primary.billingMode
+      || !authenticatedProviders.has(spec.providerId)
+      || seenProviders.has(spec.providerId)) return false;
+    seenProviders.add(spec.providerId);
+    return true;
+  });
+  return [primary, ...fallback];
 }
 
 function injectedModelSpec(
@@ -100,7 +97,10 @@ function injectedModelSpec(
     id: `${provider}/${model}`,
     providerId: provider,
     upstreamModel: model,
-    billingMode: provider === "openai-codex" ? "subscription" : "unpriced",
+    // An injected gateway has no catalog-backed billing attestation. Treat it
+    // as unpriced regardless of provider name and require the normal explicit
+    // unpriced-cost opt-in whenever a monetary budget is active.
+    billingMode: "unpriced",
     capabilities: gateway.capabilities,
     tokenizer: { id: "injected/test-tokenizer", accuracy: "approximate" }
   };
@@ -159,7 +159,8 @@ function catalog(
   env: NodeJS.ProcessEnv,
   custom: readonly ModelSpec[],
   injected: ModelSpec | undefined,
-  catalogSpecs: readonly ModelSpec[]
+  catalogSpecs: readonly ModelSpec[],
+  authenticatedProviders: ReadonlySet<string>
 ): { primary: ModelSpec; specs: ModelSpec[]; routes: ModelRoute[] } {
   const model = selectedModel(config, env, catalogSpecs);
   const primary = catalogSpecs.find((spec) =>
@@ -177,12 +178,17 @@ function catalog(
   const explicitRoutes = (config.modelRoutes ?? []).map(configuredRoute);
   let routes: ModelRoute[];
   if (config.explicitSingleModelRoute
-    || (explicitRoutes.length === 0 && primary.providerId !== "deepseek" && primary.providerId !== "glm")) {
+    || (explicitRoutes.length === 0 && primary.recommended !== true)) {
     routes = [{ id: "default", candidates: [primary.id], fallbackOn: FALLBACK_ON, maxAttempts: 1 }];
   } else if (explicitRoutes.length > 0) {
     routes = explicitRoutes;
   } else {
-    const candidates = productionModelCandidates(config, env, catalogSpecs).map((spec) => spec.id);
+    const candidates = productionModelCandidates(
+      config,
+      env,
+      catalogSpecs,
+      authenticatedProviders
+    ).map((spec) => spec.id);
     if (!candidates.includes(primary.id)) candidates.unshift(primary.id);
     routes = [{ id: "default", candidates, fallbackOn: FALLBACK_ON, maxAttempts: candidates.length }];
   }
@@ -284,7 +290,14 @@ export function createRoleGateways(
   const options = gatewayOptions(config);
   const primary = primaryGateway(config.provider, model, knownPrimary, deps, options);
   const injected = knownPrimary ? undefined : injectedModelSpec(config.provider, model, primary);
-  const resolved = catalog(config, env, custom, injected, catalogSpecs);
+  const resolved = catalog(
+    config,
+    env,
+    custom,
+    injected,
+    catalogSpecs,
+    deps.authenticatedProviders ?? new Set()
+  );
   const gateways = new Map<string, ModelGateway>();
   for (const spec of resolved.specs) {
     const gateway = spec.id === resolved.primary.id

--- a/portable/harbor/sigma_harbor_agent.py
+++ b/portable/harbor/sigma_harbor_agent.py
@@ -25,19 +25,14 @@ from harbor.environments.base import BaseEnvironment
 from harbor.models.agent.context import AgentContext
 
 
-ENV_KEYS = [
-    "DEEPSEEK_API_KEY",
-    "GLM_API_KEY",
-    "ZAI_API_KEY",
-    "EXA_API_KEY",
-    "BIGMODEL_API_KEY",
-    "DEEPSEEK_BASE_URL",
-    "GLM_BASE_URL",
-    "ZAI_BASE_URL",
-]
+SHARED_ENV_KEYS = ("EXA_API_KEY",)
+PROVIDER_ENV_SUFFIXES = ("API_KEY", "BASE_URL", "MODEL")
+PROVIDER_ENV_ALIASES = {
+    "glm": ("ZAI_API_KEY", "BIGMODEL_API_KEY", "ZAI_BASE_URL", "BIGMODEL_BASE_URL"),
+}
 
 CHECKPOINT_RECOVERY_POLICIES = {"restore", "keep", "ask"}
-REASONING_EFFORTS = {"auto", "none", "low", "medium", "high", "xhigh", "max"}
+REASONING_EFFORTS = {"auto", "none", "minimal", "low", "medium", "high", "xhigh", "max"}
 MAX_EXTERNAL_RECOVERIES = 8
 RECOVERY_POLL_INTERVAL_SEC = 0.25
 MIN_CHECKPOINT_RECOVERY_TIMEOUT_SEC = 600
@@ -109,7 +104,15 @@ def _structured_blocker_code(payload: dict[str, Any]) -> str | None:
 
 
 def _default_model(provider: str) -> str:
-    return "glm-5.2" if provider == "glm" else "deepseek-v4-pro"
+    # Let Sigma's provider catalog choose the default. Keeping model selection
+    # here would require this portable adapter to mirror every provider update.
+    return "auto"
+
+
+def _provider_environment_keys(provider: str) -> tuple[str, ...]:
+    prefix = re.sub(r"[^A-Za-z0-9]+", "_", provider).strip("_").upper()
+    selected = tuple(f"{prefix}_{suffix}" for suffix in PROVIDER_ENV_SUFFIXES if prefix)
+    return (*SHARED_ENV_KEYS, *selected, *PROVIDER_ENV_ALIASES.get(provider, ()))
 
 
 def _return_code(result: Any) -> int:
@@ -1297,7 +1300,7 @@ class SigmaCliHarborAgent(BaseAgent):
         self.model = resolved_model
         if reasoning_effort not in REASONING_EFFORTS:
             raise ValueError(
-                "reasoning_effort must be one of: auto, none, low, medium, high, xhigh, max"
+                "reasoning_effort must be one of: auto, none, minimal, low, medium, high, xhigh, max"
             )
         self.reasoning_effort = reasoning_effort
         if agent_profile not in {"standard", "strict"}:
@@ -3228,7 +3231,11 @@ printf '{"status":"stopped","pid":%s,"term_status":%s,"alive_after_grace":%s}\n'
         extra_env = getattr(self, "extra_env", {})
         if isinstance(extra_env, dict):
             env_vars.update({key: str(value) for key, value in extra_env.items()})
-        env_vars.update({key: os.environ[key] for key in ENV_KEYS if os.environ.get(key)})
+        env_vars.update({
+            key: os.environ[key]
+            for key in _provider_environment_keys(self.provider)
+            if os.environ.get(key)
+        })
         return env_vars
 
     async def _download_if_present(

--- a/tests/agent-acp.contract.test.ts
+++ b/tests/agent-acp.contract.test.ts
@@ -480,6 +480,35 @@ describe("Sigma ACP v1 contract", () => {
     expect(await readFile(malformedPath, "utf8")).toBe(malformed);
   });
 
+  it("round-trips the minimal reasoning effort through the session index", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "sigma-acp-reasoning-"));
+    temporaryDirectories.push(root);
+    const options = {
+      agentVersion: "test",
+      runtimeFactory: async (): Promise<never> => {
+        throw new Error("Runtime must not start while reading the index.");
+      },
+      modelCatalog: async () => ({ currentModelId: "test/model", options: [] })
+    };
+    const now = new Date().toISOString();
+    await new SigmaAcpSessionRegistry(options).upsert(root, {
+      sessionId: "minimal-session",
+      runtimeSessionId: "runtime-session",
+      cwd: root,
+      modelId: "test/model",
+      reasoningEffort: "minimal",
+      mode: "analyze",
+      createdAt: now,
+      updatedAt: now,
+      started: false,
+      lastSeq: 0
+    });
+
+    await expect(new SigmaAcpSessionRegistry(options).index(root)).resolves.toMatchObject({
+      sessions: [expect.objectContaining({ reasoningEffort: "minimal" })]
+    });
+  });
+
   it("coalesces concurrent cold-session attachments into one runtime resume", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "sigma-acp-attach-"));
     temporaryDirectories.push(root);

--- a/tests/agent-cli.config.test.ts
+++ b/tests/agent-cli.config.test.ts
@@ -42,6 +42,7 @@ describe("Sigma config", () => {
     const options = { env: {}, cwd: root, homeDir: home };
     expect(loadCliConfig({}, options).reasoningEffort).toBeUndefined();
     expect(loadCliConfig({ "reasoning-effort": "max" }, options).reasoningEffort).toBe("max");
+    expect(loadCliConfig({ "reasoning-effort": "minimal" }, options).reasoningEffort).toBe("minimal");
     expect(loadCliConfig({}, { ...options, env: { SIGMA_REASONING_EFFORT: "high" } }).reasoningEffort)
       .toBe("high");
     await mkdir(path.join(root, ".agent"));

--- a/tests/agent-cli.doctor.coverage.test.ts
+++ b/tests/agent-cli.doctor.coverage.test.ts
@@ -11,7 +11,7 @@ vi.mock("../packages/agent-model/dist/index.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("agent-model")>();
   return {
     ...actual,
-    checkProviderHealth: async (input: { provider: "deepseek" | "glm"; model: string }) => {
+    checkProviderHealth: async (input: { provider: string; model: string }) => {
       if (api.mode === "error") throw new Error("mock API failure");
       if (api.mode === "raw_error") throw "raw API failure";
       if (api.mode === "empty") {

--- a/tests/agent-config.coverage.test.ts
+++ b/tests/agent-config.coverage.test.ts
@@ -140,6 +140,7 @@ describe("agent-config single-source schema", () => {
     expect(() => field("writeScope").parse("host")).toThrow("must be one of");
     expect(field("provider").parse("other")).toBe("other");
     expect(field("reasoningEffort").parse("max")).toBe("max");
+    expect(field("reasoningEffort").parse("minimal")).toBe("minimal");
     expect(() => field("reasoningEffort").parse("extreme")).toThrow("must be one of");
     expect(() => field("workspace").parse(1)).toThrow("string");
     expect(() => field("workspace").parse(" ")).toThrow("non-empty");

--- a/tests/agent-model.routing.test.ts
+++ b/tests/agent-model.routing.test.ts
@@ -11,8 +11,13 @@ import type { ModelSpecConfigValue } from "../packages/agent-config/src/index.js
 import {
   listPiAuthStatuses,
   listPiProviders,
+  piProviderEnvironmentValue,
+  type Api,
+  type AssistantMessage,
+  type AssistantMessageEvent,
   type Credential,
   type CredentialStore,
+  type Model as PiModel,
   type Models,
   type ModelsStore
 } from "../packages/agent-pi/src/index.js";
@@ -137,7 +142,82 @@ function credentialStore(providerId: string, credential: Credential): Credential
   };
 }
 
+function genericHealthModels(): Models {
+  const model: PiModel<Api> = {
+    id: "fixture-model",
+    name: "Fixture model",
+    api: "pi-messages",
+    provider: "fixture-provider",
+    baseUrl: "https://fixture-provider.example.test/v1",
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 8_192,
+    maxTokens: 1_024
+  };
+  const message: AssistantMessage = {
+    role: "assistant",
+    content: [{ type: "text", text: "OK" }],
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
+    usage: {
+      input: 4,
+      output: 1,
+      cacheRead: 0,
+      cacheWrite: 0,
+      reasoning: 0,
+      totalTokens: 5,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 }
+    },
+    stopReason: "stop",
+    timestamp: Date.now()
+  };
+  async function* events(): AsyncIterable<AssistantMessageEvent> {
+    yield { type: "start", partial: message };
+    yield { type: "text_delta", contentIndex: 0, delta: "OK", partial: message };
+    yield { type: "done", reason: "stop", message };
+  }
+  return {
+    getProviders: () => [],
+    getProvider: () => undefined,
+    getModels: () => [model],
+    getModel: (provider, id) => provider === model.provider && id === model.id ? model : undefined,
+    refresh: async () => ({ refreshed: [], errors: [] }) as never,
+    checkAuth: async () => ({ type: "api_key", source: "fixture" }) as never,
+    getAvailable: async () => [model],
+    getAuth: async () => ({
+      type: "api_key",
+      source: "fixture",
+      auth: { apiKey: "fixture-secret", baseUrl: model.baseUrl }
+    }) as never,
+    login: async () => { throw new Error("not interactive"); },
+    logout: async () => undefined,
+    stream: () => events() as never,
+    complete: async () => message,
+    streamSimple: () => events() as never,
+    completeSimple: async () => message
+  };
+}
+
 describe("provider health probe", () => {
+  it("executes a real gateway probe for a provider-neutral Pi transport", async () => {
+    const report = await checkProviderHealth({
+      provider: "fixture-provider",
+      model: "fixture-model",
+      signal: new AbortController().signal,
+      piModels: genericHealthModels()
+    });
+
+    expect(report).toMatchObject({
+      ok: true,
+      provider: "fixture-provider",
+      model: "fixture-model",
+      endpointHost: "fixture-provider.example.test",
+      message: "OK"
+    });
+  });
+
   it("probes the same configured default model used by runtime auto selection", async () => {
     vi.stubEnv("DEEPSEEK_MODEL", "configured-default-model");
     const fetchImpl = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
@@ -260,6 +340,14 @@ describe("provider health probe", () => {
   });
 });
 
+describe("provider environment conventions", () => {
+  it("resolves a future provider without adding a provider-specific branch", () => {
+    expect(piProviderEnvironmentValue("future-provider", "BASE_URL", {
+      FUTURE_PROVIDER_BASE_URL: "  https://future.example.test/v1  "
+    })).toBe("https://future.example.test/v1");
+  });
+});
+
 describe("capability-aware model routing", () => {
   it("classifies transport codes without treating configuration failures as retryable", () => {
     expect(classifyModelFailure(Object.assign(new Error("reset"), { code: "ECONNRESET" }))).toBe("network");
@@ -292,6 +380,16 @@ describe("capability-aware model routing", () => {
     }));
     expect(gateway).toMatchObject({ provider: "deepseek", model: "deepseek/custom" });
     expect(gateway.capabilities.contextWindowTokens).toBe(42_000);
+    const openAiGateway = createModelGatewayForSpec(spec("custom-openai", {
+      providerId: "openai",
+      upstreamModel: "future-openai-model",
+      capabilities: { ...capabilities, contextWindowTokens: 64_000 }
+    }));
+    expect(openAiGateway).toMatchObject({
+      provider: "openai",
+      model: "future-openai-model",
+      capabilities: expect.objectContaining({ contextWindowTokens: 64_000 })
+    });
   });
 
   it("hydrates Radius models from the local cache without network access", async () => {
@@ -388,20 +486,45 @@ describe("capability-aware model routing", () => {
   it("composes production fallback candidates and honors an explicit single-model route", () => {
     expect(productionModelCandidates(
       { provider: "deepseek", model: "auto" },
-      { DEEPSEEK_API_KEY: "primary", GLM_API_KEY: "fallback" }
+      { DEEPSEEK_MODEL: "deepseek-v4-pro" },
+      BUILTIN_MODEL_SPECS,
+      new Set(["deepseek", "glm"])
     ).map((item) => item.id)).toEqual(["deepseek/deepseek-v4-pro", "glm/glm-5.2"]);
     expect(productionModelCandidates(
       { provider: "glm", model: "auto", explicitSingleModelRoute: true },
-      { GLM_API_KEY: "primary", DEEPSEEK_API_KEY: "unused" }
+      {},
+      BUILTIN_MODEL_SPECS,
+      new Set(["glm", "deepseek"])
     ).map((item) => item.id)).toEqual(["glm/glm-5.2"]);
     expect(productionModelCandidates(
       { provider: "deepseek", model: "auto" },
-      { DEEPSEEK_API_KEY: "primary" }
+      {},
+      BUILTIN_MODEL_SPECS,
+      new Set(["deepseek"])
     ).map((item) => item.id)).toEqual(["deepseek/deepseek-v4-pro"]);
     expect(productionModelCandidates(
       { provider: "openai-codex", model: "gpt-5.6-terra" },
-      { OPENAI_API_KEY: "must-not-be-used", DEEPSEEK_API_KEY: "must-not-fallback" }
+      {},
+      BUILTIN_MODEL_SPECS,
+      new Set(["openai-codex", "deepseek"])
     ).map((item) => item.id)).toEqual(["openai-codex/gpt-5.6-terra"]);
+
+    const primary = spec("alpha/main", {
+      providerId: "alpha",
+      upstreamModel: "main",
+      recommended: true
+    });
+    const fallback = spec("beta/backup", {
+      providerId: "beta",
+      upstreamModel: "backup",
+      recommended: true
+    });
+    expect(productionModelCandidates(
+      { provider: "alpha", model: "main" },
+      {},
+      [primary, fallback],
+      new Set(["alpha", "beta"])
+    ).map((item) => item.id)).toEqual(["alpha/main", "beta/backup"]);
   });
 
   it("retries transient subscription failures without routing them to paid providers", async () => {
@@ -827,7 +950,7 @@ describe("capability-aware model routing", () => {
 
   it("keeps transport retries in the Sigma policy layer and reserves them", async () => {
     let calls = 0;
-    const only = spec("deepseek/a");
+    const only = spec("metered-provider/a", { providerId: "metered-provider" });
     const representative = gateway(only.id, async () => response("unused"));
     const retrying = gateway(only.id, async () => {
       calls += 1;
@@ -1446,6 +1569,32 @@ describe("normalized model usage", () => {
       costMicroUsd: null,
       billingMode: "subscription"
     });
+  });
+
+  it("matches built-in accounting metadata for providers outside the legacy trio", async () => {
+    const genericSpec = BUILTIN_MODEL_SPECS.find((item) =>
+      !["deepseek", "glm", "openai-codex"].includes(item.providerId)
+      && item.billingMode === "metered"
+      && item.pricing !== undefined);
+    expect(genericSpec).toBeDefined();
+    const genericGateway: ModelGateway = {
+      ...gateway("generic-metered", async () => response("ok")),
+      provider: genericSpec!.providerId,
+      model: genericSpec!.upstreamModel,
+      capabilities: genericSpec!.capabilities,
+      async countTokens() { return 4; }
+    };
+
+    const prepared = await prepareModelBudget(
+      genericGateway,
+      request().messages,
+      [],
+      10,
+      10_000_000
+    );
+
+    expect(prepared.spec?.id).toBe(genericSpec!.id);
+    expect(prepared.reserved.costMicroUsd).toBeGreaterThan(0);
   });
 
   it("allows null persisted cost only when usage is explicitly subscription billed", () => {

--- a/tests/agent-pi.api-families.test.ts
+++ b/tests/agent-pi.api-families.test.ts
@@ -393,7 +393,10 @@ describe.each(apiFamilies)("Pi %s API family contract", (api) => {
 
 describe("Pi Codex cache-preserving instruction projection", () => {
   it("keeps dynamic developer context at the input suffix and restores its wire role", async () => {
-    const model = contractModel("openai-codex-responses");
+    const model = {
+      ...contractModel("openai-codex-responses"),
+      provider: "codex-compatible-provider"
+    };
     const captured: CapturedCall[] = [];
     const gateway = new PiModelGateway({
       provider: model.provider,
@@ -409,6 +412,7 @@ describe("Pi Codex cache-preserving instruction projection", () => {
     await gateway.complete(modelRequest);
 
     const call = captured[0]!;
+    expect(call.options.transport).toBe("auto");
     expect(call.context.systemPrompt).not.toContain("latest durable runtime state");
     const suffix = call.context.messages.at(-1);
     expect(suffix).toMatchObject({ role: "user" });

--- a/tests/agent-runtime.evidence.test.ts
+++ b/tests/agent-runtime.evidence.test.ts
@@ -566,6 +566,42 @@ describe("assurance-coordinated mutation completion", () => {
     expect(assuranceRequirement(active)).toMatchObject({ requiredClaims: ["unit"] });
   });
 
+  it.each([
+    "src/service.cs",
+    "lib/service.rb",
+    "app/service.php",
+    "src/service.scala",
+    "lib/service.ex",
+    "scripts/check.sh",
+    "db/query.sql",
+    "ui/component.vue",
+    "src/service.zig"
+  ])("classifies repository-recognized source %s as code", (changedPath) => {
+    const active = frontierSession();
+    active.durable.state.mutationFrontier.changedPaths = [changedPath];
+
+    expect(assuranceRequirement(active)).toMatchObject({
+      risk: "medium",
+      requiredClaims: ["unit"],
+      review: "advisory"
+    });
+  });
+
+  it.each([
+    ".github/workflows/release.yml",
+    "database/migrations/001.sql",
+    "payments/checkout.ts",
+    "infrastructure/main.tf"
+  ])("requires review for security-sensitive path %s", (changedPath) => {
+    const active = frontierSession();
+    active.durable.state.mutationFrontier.changedPaths = [changedPath];
+
+    expect(assuranceRequirement(active)).toMatchObject({
+      risk: "high",
+      review: "required"
+    });
+  });
+
   it("turns recognized Node validation into current-frontier readiness", () => {
     const active = frontierSession();
     active.durable.state.mutationFrontier.changedPaths = ["src/code.mjs"];

--- a/tests/test_harbor_agent.py
+++ b/tests/test_harbor_agent.py
@@ -179,6 +179,26 @@ class HarborAgentTest(unittest.IsolatedAsyncioTestCase):
             wrapped.index("printf command-completed"),
         )
 
+    async def test_agent_environment_uses_the_selected_provider_prefix(self):
+        module = import_portable_agent_module()
+        values = {
+            "FUTURE_PROVIDER_API_KEY": "future-secret",
+            "FUTURE_PROVIDER_BASE_URL": "https://future.example.test/v1",
+            "FUTURE_PROVIDER_MODEL": "future-model",
+            "DEEPSEEK_API_KEY": "unselected-secret",
+        }
+        with patch.dict(os.environ, values, clear=False):
+            environment = module.SigmaCliHarborAgent(
+                provider="future-provider",
+                extra_env={"SAFE_SETTING": "enabled"},
+            )._agent_env()
+
+        self.assertEqual(environment["FUTURE_PROVIDER_API_KEY"], "future-secret")
+        self.assertEqual(environment["FUTURE_PROVIDER_BASE_URL"], "https://future.example.test/v1")
+        self.assertEqual(environment["FUTURE_PROVIDER_MODEL"], "future-model")
+        self.assertEqual(environment["SAFE_SETTING"], "enabled")
+        self.assertNotIn("DEEPSEEK_API_KEY", environment)
+
     async def test_private_agent_environment_rejects_unsafe_shell_names_and_nul_values(self):
         module = import_portable_agent_module()
 
@@ -529,8 +549,9 @@ class HarborAgentTest(unittest.IsolatedAsyncioTestCase):
             module.SigmaCliHarborAgent(model="explicit-model", model_name="custom-model").model,
             "explicit-model",
         )
-        self.assertEqual(module.SigmaCliHarborAgent(provider="deepseek").model, "deepseek-v4-pro")
-        self.assertEqual(module.SigmaCliHarborAgent(provider="glm").model, "glm-5.2")
+        self.assertEqual(module.SigmaCliHarborAgent(provider="deepseek").model, "auto")
+        self.assertEqual(module.SigmaCliHarborAgent(provider="glm").model, "auto")
+        self.assertEqual(module.SigmaCliHarborAgent(provider="openai-codex").model, "auto")
         with self.assertRaisesRegex(ValueError, "execution_mode"):
             module.SigmaCliHarborAgent(execution_mode="host")
         self.assertEqual(module.SigmaCliHarborAgent().network_mode, "full")
@@ -571,6 +592,10 @@ class HarborAgentTest(unittest.IsolatedAsyncioTestCase):
             module.SigmaCliHarborAgent(command_timeout_sec=601)
         with self.assertRaisesRegex(ValueError, "reasoning_effort"):
             module.SigmaCliHarborAgent(reasoning_effort="extreme")
+        self.assertEqual(
+            module.SigmaCliHarborAgent(reasoning_effort="minimal").reasoning_effort,
+            "minimal",
+        )
 
     async def test_container_execution_mode_is_forwarded_without_host_opt_in(self):
         module = import_portable_agent_module()


### PR DESCRIPTION
## Summary

- define one provider-neutral reasoning-effort contract and carry `minimal` through config, ACP persistence, CLI, and Harbor
- select defaults, custom models, base URLs, authenticated fallbacks, retry policy, health probes, and accounting from catalog/auth metadata instead of DeepSeek/GLM/OpenAI name branches
- key Codex request behavior off its API family, broaden source/risk classification, and recognize more credential-like environment names
- add provider-neutral regression coverage for future providers, custom models, health transports, billing, Harbor forwarding, and assurance paths

## Root cause

Provider and model knowledge had accumulated independently in the CLI, runtime, Pi gateway, Harbor adapter, assurance engine, and native sandbox. Those copies drifted (for example, `minimal` was supported by Pi but rejected or dropped elsewhere) and made new catalog providers require unrelated source changes.

## Impact

New catalog-backed providers and models can participate without adding routing branches. Automatic fallbacks are limited to authenticated, recommended models with the same billing mode; unknown injected gateways remain fail-closed as unpriced. Doctor API checks now exercise the selected Pi transport for every provider.

Intentional boundaries remain explicit: DeepSeek's forced-tool payload workaround is a wire-compatibility rule, and the web broker's Exa allowlist remains a security policy rather than a model-routing shortcut.

## Validation

- `pnpm lint`
- `pnpm test` — 176 files passed; 1,599 tests passed, 27 skipped
- `pnpm test:harbor` — 59 passed
- `cargo fmt --manifest-path native/sigma-exec/Cargo.toml -- --check`
- `cargo test --locked --manifest-path native/sigma-exec/Cargo.toml` — 105 passed
- `pnpm eval:fairness`