### PR TITLE
Add paired harness A/B experiment infrastructure

### DIFF
--- a/PAIRED_EXPERIMENTS.md
+++ b/PAIRED_EXPERIMENTS.md
@@ -1,0 +1,43 @@
+# Paired Harness Experiments
+
+The paired benchmark path compares two immutable harness runtimes while keeping the model, reasoning effort, task identity, verifier, timeout, network policy, and outer Harbor environment frozen.
+
+It is intentionally neutral infrastructure. Task selection is an externally seeded SHA-256 ranking over a complete, Git-pinned catalog. The runner never branches on task names or verifier output, never passes benchmark identity or verifier feedback into a solving session, and never retries a consumed attempt.
+
+## Workflow
+
+1. Build the Sigma Linux runtime and obtain its SHA-256.
+2. Package an explicit Codex Linux version from the official npm platform archive:
+
+   ```powershell
+   pnpm package:codex-runtime -- --version <version> --output <archive> --metadata-output <metadata.json>
+   ```
+
+3. Create a draft with two arms, a complete pinned task catalog, the shared model controls, repetitions, concurrency, and cumulative first-repetition ramp sizes.
+4. Freeze it once:
+
+   ```powershell
+   pnpm bench:paired:preregister -- --draft <draft.json> --output <preregistration.json>
+   ```
+
+5. Run only the next unused stage. The first repetition is split by `ramp_task_counts`; later repetitions each form one stage.
+
+   ```powershell
+   pnpm bench:paired:run -- --preregistration-file <preregistration.json> --expected-preregistration-sha256 <sha256> --output <run-dir> --stage next
+   ```
+
+6. Analyze complete task×repetition pairs:
+
+   ```powershell
+   pnpm bench:paired:analyze -- --preregistration-file <preregistration.json> --expected-preregistration-sha256 <sha256> --experiment-output <run-dir> --output <analysis-dir>
+   ```
+
+## Stop-loss semantics
+
+The controller stops on control drift, incomplete reports, infrastructure-invalid attempts, credential/provider unavailability, or dirty runtime/Docker cleanup. Ordinary verifier failures, agent timeouts, and efficiency regressions are recorded outcomes and do not stop rollout.
+
+The irreversible boundary is immediately before Harbor dispatch. Once an attempt crosses it, its task×repetition×arm identity cannot be retried. A stopped stage therefore closes the experiment instead of using post-verifier information to repair or rerun attempts.
+
+## Analysis
+
+The report includes attempt pass rate with Wilson intervals, task-level pass-at-least-once, exact paired McNemar outcomes, order strata, cost/token/time summaries, joint-valid and joint-success paired ratios, and task-clustered bootstrap intervals. Sigma JSONL traces and Harbor ATIF Codex trajectories are normalized into model turns, tool calls, failures, repeated calls, validation events, tool histograms, and pairwise tool-sequence distance.

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "mutation:protocol": "stryker run stryker.protocol.conf.mjs",
     "mutation:kernel": "stryker run stryker.kernel.conf.mjs",
     "mutation": "pnpm mutation:protocol && pnpm mutation:kernel",
-    "test:harbor": "python -m unittest tests.test_harbor_agent tests.test_codex_harbor_agent",
+    "test:harbor": "python -m unittest tests.test_harbor_agent tests.test_codex_harbor_agent tests.test_harbor_probe",
     "test:all": "pnpm test && pnpm test:harbor",
     "typecheck": "tsc -b --pretty false",
     "lint:eslint": "eslint packages scripts tests *.ts *.mjs",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "verify:package:agent-cli:windows": "node scripts/release/run-stage-graph.ts verify-package-windows",
     "verify:package:agent-cli:macos": "node scripts/release/run-stage-graph.ts verify-package-macos",
     "package:harbor-runtime": "node scripts/package-harbor-runtime.mjs",
+    "package:codex-runtime": "node scripts/package-codex-runtime.mjs",
     "smoke:local": "pnpm build && node scripts/smoke-local.mjs",
     "smoke:local:fake": "pnpm smoke:product",
     "smoke:product": "pnpm build && node --experimental-ffi --disable-warning=ExperimentalWarning scripts/smoke-product.mjs",
@@ -86,7 +87,10 @@
     "bench:tb:report:all": "node scripts/bench-report.mjs --all",
     "bench:tb:formal": "node scripts/bench-terminal-bench-formal.mjs",
     "bench:tb:preregister": "node scripts/bench-terminal-bench-formal-preregistration.mjs",
-    "bench:tb:identity-archive": "node scripts/bench-task-identity-archive.mjs"
+    "bench:tb:identity-archive": "node scripts/bench-task-identity-archive.mjs",
+    "bench:paired:preregister": "node scripts/bench-paired-preregistration.mjs",
+    "bench:paired:run": "node scripts/bench-paired-experiment.mjs",
+    "bench:paired:analyze": "node scripts/bench-paired-analysis.mjs"
   },
   "devDependencies": {
     "@agentclientprotocol/sdk": "1.3.0",

--- a/portable/harbor/apt-network-retries.conf
+++ b/portable/harbor/apt-network-retries.conf
@@ -1,0 +1,4 @@
+Acquire::Retries "5";
+Acquire::http::Timeout "120";
+Acquire::https::Timeout "120";
+Acquire::http::Pipeline-Depth "0";

--- a/portable/harbor/apt-network-retry
+++ b/portable/harbor/apt-network-retry
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+# Retry only transient network failures from the same apt/apt-get invocation.
+# Package, dpkg, argument, and other deterministic failures retain the original
+# exit code without retrying.
+
+command_name=${0##*/}
+case "$command_name" in
+  apt|apt-get) ;;
+  *)
+    printf '%s\n' "Unsupported APT wrapper command: $command_name" >&2
+    exit 64
+    ;;
+esac
+
+real_bin_dir=${SIGMA_APT_REAL_BIN_DIR:-/usr/bin}
+real_command=$real_bin_dir/$command_name
+if [ ! -x "$real_command" ]; then
+  printf '%s\n' "APT executable is unavailable: $real_command" >&2
+  exit 127
+fi
+
+log_file=$(mktemp "${TMPDIR:-/tmp}/sigma-apt-network-retry.XXXXXX") || exit 70
+trap 'rm -f "$log_file"' EXIT
+trap 'exit 130' INT
+trap 'exit 143' HUP TERM
+
+attempt=1
+max_attempts=5
+while :; do
+  : >"$log_file"
+  "$real_command" "$@" >"$log_file" 2>&1
+  status=$?
+  cat "$log_file"
+  if [ "$status" -eq 0 ]; then
+    exit 0
+  fi
+
+  if [ "$attempt" -ge "$max_attempts" ] || ! grep -Eiq \
+    '502[[:space:]]+Bad Gateway|503[[:space:]]+Service Unavailable|504[[:space:]]+Gateway (Time-out|Timeout)|Temporary failure resolving|Could not resolve|Could not connect|Connection failed|Connection timed out|Connection reset by peer|Network is unreachable|TLS connection was non-properly terminated|Resource temporarily unavailable' \
+    "$log_file"; then
+    exit "$status"
+  fi
+
+  delay=$((1 << (attempt - 1)))
+  printf '%s\n' \
+    "Transient APT network failure; retrying command ($attempt/$max_attempts) in ${delay}s." >&2
+  sleep "$delay"
+  attempt=$((attempt + 1))
+done

--- a/portable/harbor/codex_harbor_agent.py
+++ b/portable/harbor/codex_harbor_agent.py
@@ -18,6 +18,24 @@ from harbor.environments.base import BaseEnvironment
 
 
 _SHA256_PATTERN = re.compile(r"^[a-f0-9]{64}$")
+_ARCHIVE_LAYOUTS = {
+    "portable-root": {
+        "strip_components": 1,
+        "binary": "/opt/codex-cli/bin/codex",
+        "rg": "/opt/codex-cli/bin/rg",
+    },
+    "npm-linux-x64": {
+        "strip_components": 0,
+        "binary": (
+            "/opt/codex-cli/package/vendor/"
+            "x86_64-unknown-linux-musl/bin/codex"
+        ),
+        "rg": (
+            "/opt/codex-cli/package/vendor/"
+            "x86_64-unknown-linux-musl/codex-path/rg"
+        ),
+    },
+}
 
 
 def _sha256_file(path: pathlib.Path) -> str:
@@ -39,6 +57,7 @@ class PortableCodex(Codex):
         *args: Any,
         codex_cli_tarball: pathlib.Path | str | None = None,
         codex_cli_sha256: str | None = None,
+        codex_cli_layout: str = "portable-root",
         **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
@@ -60,8 +79,15 @@ class PortableCodex(Codex):
                 f"expected {expected_sha256}, got {actual_sha256}"
             )
 
+        if codex_cli_layout not in _ARCHIVE_LAYOUTS:
+            raise ValueError(
+                "codex_cli_layout must be one of: "
+                + ", ".join(sorted(_ARCHIVE_LAYOUTS))
+            )
+
         self.codex_cli_tarball = runtime_path
         self.codex_cli_sha256 = expected_sha256
+        self.codex_cli_layout = codex_cli_layout
 
     async def install(self, environment: BaseEnvironment) -> None:
         # A matching version string is not a content identity. Re-check the
@@ -81,6 +107,10 @@ class PortableCodex(Codex):
         await environment.upload_file(self.codex_cli_tarball, self._REMOTE_ARCHIVE)
         remote_root = shlex.quote(self._REMOTE_ROOT)
         remote_archive = shlex.quote(self._REMOTE_ARCHIVE)
+        layout = _ARCHIVE_LAYOUTS[self.codex_cli_layout]
+        codex_binary = shlex.quote(layout["binary"])
+        rg_binary = shlex.quote(layout["rg"])
+        strip_components = int(layout["strip_components"])
         await self.exec_as_root(
             environment,
             command=(
@@ -90,13 +120,14 @@ class PortableCodex(Codex):
                 f"rm -f {remote_archive}; exit 1; fi; "
                 f"rm -rf {remote_root}; "
                 f"mkdir -p {remote_root} /usr/local/bin; "
-                f"tar -xzf {remote_archive} -C {remote_root} --strip-components=1; "
-                f"test -x {remote_root}/bin/codex; "
-                f"chmod 0755 {remote_root}/bin/codex; "
-                f"ln -sf {remote_root}/bin/codex /usr/local/bin/codex; "
-                f"if test -f {remote_root}/bin/rg; then "
-                f"chmod 0755 {remote_root}/bin/rg; "
-                f"ln -sf {remote_root}/bin/rg /usr/local/bin/rg; "
+                f"tar -xzf {remote_archive} -C {remote_root} "
+                f"--strip-components={strip_components}; "
+                f"test -x {codex_binary}; "
+                f"chmod 0755 {codex_binary}; "
+                f"ln -sf {codex_binary} /usr/local/bin/codex; "
+                f"if test -f {rg_binary}; then "
+                f"chmod 0755 {rg_binary}; "
+                f"ln -sf {rg_binary} /usr/local/bin/rg; "
                 "fi; "
                 f"rm -f {remote_archive}"
             ),

--- a/portable/harbor/curl-network-retry
+++ b/portable/harbor/curl-network-retry
@@ -21,7 +21,12 @@ trap 'exit 130' INT
 trap 'exit 143' HUP TERM
 
 attempt=1
-max_attempts=5
+# A host proxy or upstream TLS endpoint can remain unavailable for longer than
+# the original 15-second retry window when several verifier containers start at
+# once. Keep retrying only curl's transient transport failures, with a bounded
+# backoff window that still fits comfortably inside the verifier timeout.
+max_attempts=8
+max_delay=30
 while :; do
   : >"$stdout_file"
   : >"$stderr_file"
@@ -44,6 +49,9 @@ while :; do
   fi
 
   delay=$((1 << (attempt - 1)))
+  if [ "$delay" -gt "$max_delay" ]; then
+    delay=$max_delay
+  fi
   cat "$stderr_file" >&2
   printf '%s\n' \
     "Transient curl network failure (exit $status); retrying command ($attempt/$max_attempts) in ${delay}s." >&2

--- a/portable/harbor/curl-network-retry
+++ b/portable/harbor/curl-network-retry
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+# Preserve curl's stdout as an atomic response so a failed transfer in a
+# pipeline cannot feed partial content to a downstream interpreter. Retry only
+# curl exit codes that represent transient DNS, connection, TLS, or timeout
+# failures; HTTP, certificate, argument, and local I/O failures are unchanged.
+
+real_command=${SIGMA_CURL_REAL_COMMAND:-/usr/bin/curl}
+if [ ! -x "$real_command" ]; then
+  printf '%s\n' "curl executable is unavailable: $real_command" >&2
+  exit 127
+fi
+
+stdout_file=$(mktemp "${TMPDIR:-/tmp}/sigma-curl-network-retry.stdout.XXXXXX") || exit 70
+stderr_file=$(mktemp "${TMPDIR:-/tmp}/sigma-curl-network-retry.stderr.XXXXXX") || {
+  rm -f "$stdout_file"
+  exit 70
+}
+trap 'rm -f "$stdout_file" "$stderr_file"' EXIT
+trap 'exit 130' INT
+trap 'exit 143' HUP TERM
+
+attempt=1
+max_attempts=5
+while :; do
+  : >"$stdout_file"
+  : >"$stderr_file"
+  "$real_command" "$@" >"$stdout_file" 2>"$stderr_file"
+  status=$?
+  if [ "$status" -eq 0 ]; then
+    cat "$stderr_file" >&2
+    cat "$stdout_file"
+    exit 0
+  fi
+
+  case "$status" in
+    5|6|7|18|28|35|52|55|56|92) retryable=1 ;;
+    *) retryable=0 ;;
+  esac
+  if [ "$attempt" -ge "$max_attempts" ] || [ "$retryable" -ne 1 ]; then
+    cat "$stderr_file" >&2
+    cat "$stdout_file"
+    exit "$status"
+  fi
+
+  delay=$((1 << (attempt - 1)))
+  cat "$stderr_file" >&2
+  printf '%s\n' \
+    "Transient curl network failure (exit $status); retrying command ($attempt/$max_attempts) in ${delay}s." >&2
+  sleep "$delay"
+  attempt=$((attempt + 1))
+done

--- a/portable/harbor/docker-compose-sigma-proxy.yaml
+++ b/portable/harbor/docker-compose-sigma-proxy.yaml
@@ -15,3 +15,4 @@ services:
       - "${SIGMA_CONTAINER_APT_CONFIG}:/etc/apt/apt.conf.d/80sigma-network-retries:ro"
       - "${SIGMA_CONTAINER_APT_RETRY_WRAPPER}:/usr/local/bin/apt:ro"
       - "${SIGMA_CONTAINER_APT_RETRY_WRAPPER}:/usr/local/bin/apt-get:ro"
+      - "${SIGMA_CONTAINER_CURL_RETRY_WRAPPER}:/usr/local/bin/curl:ro"

--- a/portable/harbor/docker-compose-sigma-proxy.yaml
+++ b/portable/harbor/docker-compose-sigma-proxy.yaml
@@ -1,0 +1,13 @@
+services:
+  main:
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      HTTP_PROXY: "${SIGMA_CONTAINER_HTTP_PROXY}"
+      HTTPS_PROXY: "${SIGMA_CONTAINER_HTTPS_PROXY}"
+      ALL_PROXY: "${SIGMA_CONTAINER_ALL_PROXY}"
+      NO_PROXY: "${SIGMA_CONTAINER_NO_PROXY}"
+      http_proxy: "${SIGMA_CONTAINER_HTTP_PROXY}"
+      https_proxy: "${SIGMA_CONTAINER_HTTPS_PROXY}"
+      all_proxy: "${SIGMA_CONTAINER_ALL_PROXY}"
+      no_proxy: "${SIGMA_CONTAINER_NO_PROXY}"

--- a/portable/harbor/docker-compose-sigma-proxy.yaml
+++ b/portable/harbor/docker-compose-sigma-proxy.yaml
@@ -13,3 +13,5 @@ services:
       no_proxy: "${SIGMA_CONTAINER_NO_PROXY}"
     volumes:
       - "${SIGMA_CONTAINER_APT_CONFIG}:/etc/apt/apt.conf.d/80sigma-network-retries:ro"
+      - "${SIGMA_CONTAINER_APT_RETRY_WRAPPER}:/usr/local/bin/apt:ro"
+      - "${SIGMA_CONTAINER_APT_RETRY_WRAPPER}:/usr/local/bin/apt-get:ro"

--- a/portable/harbor/docker-compose-sigma-proxy.yaml
+++ b/portable/harbor/docker-compose-sigma-proxy.yaml
@@ -11,3 +11,5 @@ services:
       https_proxy: "${SIGMA_CONTAINER_HTTPS_PROXY}"
       all_proxy: "${SIGMA_CONTAINER_ALL_PROXY}"
       no_proxy: "${SIGMA_CONTAINER_NO_PROXY}"
+    volumes:
+      - "${SIGMA_CONTAINER_APT_CONFIG}:/etc/apt/apt.conf.d/80sigma-network-retries:ro"

--- a/portable/harbor/sigma_harbor_agent.py
+++ b/portable/harbor/sigma_harbor_agent.py
@@ -46,6 +46,8 @@ DECLARED_FAILURE_KINDS = FAILURE_KINDS - {"structured_blocker"}
 DOCTOR_REPORT_SCHEMA_VERSION = 1
 BROKER_PROTOCOL_VERSION = 1
 SUPPORTED_NETWORK_MODES = {"none", "full"}
+DOCTOR_API_PREFLIGHT_ATTEMPTS = 3
+RETRYABLE_DOCTOR_API_CATEGORIES = {"network", "rate_limit", "server", "timeout"}
 MAX_CONTEXT_TEXT_CHARS = 8_192
 MAX_PARTIAL_ARTIFACT_CHARS = 1_048_576
 MAX_TRACE_ARTIFACT_BYTES = 4 * 1_048_576
@@ -164,6 +166,26 @@ def _stderr_text(result: Any) -> str:
         if isinstance(value, str):
             return value
     return ""
+
+
+def _retryable_doctor_api_failure(doctor_json: Any) -> bool:
+    """Retry only a transient provider probe before any solving work starts."""
+    if not isinstance(doctor_json, dict):
+        return False
+    checks = doctor_json.get("checks")
+    if not isinstance(checks, list):
+        return False
+    blocking = [
+        check for check in checks
+        if isinstance(check, dict) and check.get("status") in {"error", "warning"}
+    ]
+    if len(blocking) != 1 or blocking[0].get("name") != "api":
+        return False
+    api_check = blocking[0]
+    return (
+        api_check.get("failure_kind") in {"api_error", "network_error"}
+        and api_check.get("error_category") in RETRYABLE_DOCTOR_API_CATEGORIES
+    )
 
 
 class _ExecResultView:
@@ -2673,35 +2695,62 @@ printf '{"status":"stopped","pid":%s,"term_status":%s,"alive_after_grace":%s}\n'
         doctor_write_scope = (
             "workspace" if self.write_scope == "auto" else self.write_scope
         )
-        doctor_check = await self._exec_with_private_env(
-            environment,
-            " ".join([
-                "/usr/local/bin/agent doctor --workspace",
-                shlex.quote(self._workspace),
-                "--json --strict",
-                "--execution-mode",
-                shlex.quote(self.execution_mode),
-                "--network",
-                shlex.quote(self.network_mode),
-                "--read-scope",
-                shlex.quote(self.effective_read_scope),
-                "--write-scope",
-                shlex.quote(doctor_write_scope),
-                "--managed-environment-mode",
-                shlex.quote(self.managed_environment_mode),
-                "--reasoning-effort",
-                shlex.quote(self.reasoning_effort),
-                "--max-model-turns",
-                str(self.max_turns),
-                "--command-timeout-sec",
-                str(self.command_timeout_sec),
-                *( ["--check-api"] if self.check_api else [] ),
-            ]),
-            self._agent_env(),
-            timeout_sec=60,
-        )
+        doctor_command = " ".join([
+            "/usr/local/bin/agent doctor --workspace",
+            shlex.quote(self._workspace),
+            "--json --strict",
+            "--provider",
+            shlex.quote(self.provider),
+            "--model",
+            shlex.quote(self.model),
+            "--execution-mode",
+            shlex.quote(self.execution_mode),
+            "--network",
+            shlex.quote(self.network_mode),
+            "--read-scope",
+            shlex.quote(self.effective_read_scope),
+            "--write-scope",
+            shlex.quote(doctor_write_scope),
+            "--managed-environment-mode",
+            shlex.quote(self.managed_environment_mode),
+            "--reasoning-effort",
+            shlex.quote(self.reasoning_effort),
+            "--max-model-turns",
+            str(self.max_turns),
+            "--command-timeout-sec",
+            str(self.command_timeout_sec),
+            *( ["--check-api"] if self.check_api else [] ),
+        ])
+        doctor_attempts: list[dict[str, Any]] = []
+        for attempt in range(1, DOCTOR_API_PREFLIGHT_ATTEMPTS + 1):
+            doctor_check = await self._exec_with_private_env(
+                environment,
+                doctor_command,
+                self._agent_env(),
+                timeout_sec=60,
+            )
+            doctor_json = self._parse_doctor_json(_stdout_text(doctor_check))
+            retryable = self.check_api and _retryable_doctor_api_failure(doctor_json)
+            api_check = next((
+                check for check in doctor_json.get("checks", [])
+                if isinstance(check, dict) and check.get("name") == "api"
+            ), None) if isinstance(doctor_json, dict) else None
+            doctor_attempts.append({
+                "attempt": attempt,
+                "exit_code": _return_code(doctor_check),
+                "retryable_api_failure": retryable,
+                "api_check": api_check,
+            })
+            if (
+                _return_code(doctor_check) == 0
+                or not retryable
+                or attempt == DOCTOR_API_PREFLIGHT_ATTEMPTS
+            ):
+                break
+            await asyncio.sleep(2 ** (attempt - 1))
         doctor_record = self._setup_check_record("strict_doctor", doctor_check)
-        doctor_record["doctor_json"] = self._parse_doctor_json(_stdout_text(doctor_check))
+        doctor_record["doctor_json"] = doctor_json
+        doctor_record["preflight_attempts"] = doctor_attempts
         checks.append(doctor_record)
         if _return_code(doctor_check) != 0:
             self._write_setup_checks(checks, "agent_setup_failed")

--- a/scripts/bench-common.mjs
+++ b/scripts/bench-common.mjs
@@ -38,6 +38,10 @@ export const harborProxyComposePath = path.join(
   harborRuntimeDir,
   "docker-compose-sigma-proxy.yaml"
 );
+export const harborAptNetworkConfigPath = path.join(
+  harborRuntimeDir,
+  "apt-network-retries.conf"
+);
 export const terminalBenchDataset = "terminal-bench/terminal-bench-2";
 export const portableAgentImportPath = "sigma_harbor_agent:SigmaCliHarborAgent";
 export const portableCodexAgentImportPath = "codex_harbor_agent:PortableCodex";
@@ -3184,7 +3188,8 @@ const containerProxyEnvironmentKeys = [
   "SIGMA_CONTAINER_HTTP_PROXY",
   "SIGMA_CONTAINER_HTTPS_PROXY",
   "SIGMA_CONTAINER_ALL_PROXY",
-  "SIGMA_CONTAINER_NO_PROXY"
+  "SIGMA_CONTAINER_NO_PROXY",
+  "SIGMA_CONTAINER_APT_CONFIG"
 ];
 
 function normalizedProxyScheme(value) {
@@ -3237,7 +3242,8 @@ function containerProxyEnvironment(env) {
     SIGMA_CONTAINER_HTTP_PROXY: http ?? https ?? all,
     SIGMA_CONTAINER_HTTPS_PROXY: https ?? http ?? all,
     SIGMA_CONTAINER_ALL_PROXY: all ?? https ?? http,
-    SIGMA_CONTAINER_NO_PROXY: firstProxyValue(env, ["NO_PROXY", "no_proxy"]) ?? ""
+    SIGMA_CONTAINER_NO_PROXY: firstProxyValue(env, ["NO_PROXY", "no_proxy"]) ?? "",
+    SIGMA_CONTAINER_APT_CONFIG: harborAptNetworkConfigPath
   };
 }
 

--- a/scripts/bench-common.mjs
+++ b/scripts/bench-common.mjs
@@ -42,6 +42,10 @@ export const harborAptNetworkConfigPath = path.join(
   harborRuntimeDir,
   "apt-network-retries.conf"
 );
+export const harborAptRetryWrapperPath = path.join(
+  harborRuntimeDir,
+  "apt-network-retry"
+);
 export const terminalBenchDataset = "terminal-bench/terminal-bench-2";
 export const portableAgentImportPath = "sigma_harbor_agent:SigmaCliHarborAgent";
 export const portableCodexAgentImportPath = "codex_harbor_agent:PortableCodex";
@@ -3189,7 +3193,8 @@ const containerProxyEnvironmentKeys = [
   "SIGMA_CONTAINER_HTTPS_PROXY",
   "SIGMA_CONTAINER_ALL_PROXY",
   "SIGMA_CONTAINER_NO_PROXY",
-  "SIGMA_CONTAINER_APT_CONFIG"
+  "SIGMA_CONTAINER_APT_CONFIG",
+  "SIGMA_CONTAINER_APT_RETRY_WRAPPER"
 ];
 
 function normalizedProxyScheme(value) {
@@ -3243,7 +3248,8 @@ function containerProxyEnvironment(env) {
     SIGMA_CONTAINER_HTTPS_PROXY: https ?? http ?? all,
     SIGMA_CONTAINER_ALL_PROXY: all ?? https ?? http,
     SIGMA_CONTAINER_NO_PROXY: firstProxyValue(env, ["NO_PROXY", "no_proxy"]) ?? "",
-    SIGMA_CONTAINER_APT_CONFIG: harborAptNetworkConfigPath
+    SIGMA_CONTAINER_APT_CONFIG: harborAptNetworkConfigPath,
+    SIGMA_CONTAINER_APT_RETRY_WRAPPER: harborAptRetryWrapperPath
   };
 }
 

--- a/scripts/bench-common.mjs
+++ b/scripts/bench-common.mjs
@@ -34,6 +34,10 @@ export const harborSandboxComposePath = path.join(
   harborRuntimeDir,
   "docker-compose-sigma-sandbox.yaml"
 );
+export const harborProxyComposePath = path.join(
+  harborRuntimeDir,
+  "docker-compose-sigma-proxy.yaml"
+);
 export const terminalBenchDataset = "terminal-bench/terminal-bench-2";
 export const portableAgentImportPath = "sigma_harbor_agent:SigmaCliHarborAgent";
 export const portableCodexAgentImportPath = "codex_harbor_agent:PortableCodex";
@@ -823,9 +827,17 @@ export function buildHarborJobConfig(options, jobsDir, timeoutPlan = null, timeo
   }
 
   if (options.mode !== "smoke") {
+    const extraDockerCompose = [
+      path.resolve(options.harborSandboxComposePath ?? harborSandboxComposePath)
+    ];
+    if (options.env?.SIGMA_CONTAINER_PROXY_ENABLED === "1") {
+      extraDockerCompose.push(
+        path.resolve(options.harborProxyComposePath ?? harborProxyComposePath)
+      );
+    }
     config.environment = {
       type: "docker",
-      extra_docker_compose: [path.resolve(options.harborSandboxComposePath ?? harborSandboxComposePath)]
+      extra_docker_compose: extraDockerCompose
     };
   }
 
@@ -1370,7 +1382,8 @@ export function classifyFailure(input = {}) {
     return declared;
   }
 
-  if (/unknown scheme for proxy url/i.test(logText) || /\bhtpp:\/\//i.test(logText)) return "host_proxy_error";
+  if (/unknown scheme for proxy url/i.test(logText) || /\bhtpp:\/\//i.test(logText)
+    || /invalid peer certificate:\s*unknownissuer/i.test(logText)) return "host_proxy_error";
   if (/unicodeencodeerror/i.test(logText) || /codec can't encode character/i.test(logText) || /illegal multibyte sequence/i.test(logText)) {
     return "host_encoding_error";
   }
@@ -3163,6 +3176,71 @@ export async function ensurePlaceholderTask(runDir, metadata) {
   });
 }
 
+const proxyEnvironmentKeys = [
+  "HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "http_proxy", "https_proxy", "all_proxy"
+];
+const containerProxyEnvironmentKeys = [
+  "SIGMA_CONTAINER_PROXY_ENABLED",
+  "SIGMA_CONTAINER_HTTP_PROXY",
+  "SIGMA_CONTAINER_HTTPS_PROXY",
+  "SIGMA_CONTAINER_ALL_PROXY",
+  "SIGMA_CONTAINER_NO_PROXY"
+];
+
+function normalizedProxyScheme(value) {
+  return typeof value === "string" && /^htpp:\/\//i.test(value)
+    ? `http://${value.slice(7)}`
+    : value;
+}
+
+function containerProxyUrl(value) {
+  const normalized = normalizedProxyScheme(value);
+  if (typeof normalized !== "string" || normalized.trim().length === 0) return null;
+  const text = normalized.trim();
+  try {
+    const parsed = new URL(text);
+    const hostname = parsed.hostname.replace(/^\[|\]$/gu, "").toLowerCase();
+    if (hostname === "localhost" || hostname === "::1" || /^127(?:\.\d{1,3}){3}$/u.test(hostname)) {
+      parsed.hostname = "host.docker.internal";
+    }
+    let mapped = parsed.toString();
+    if (!text.endsWith("/") && parsed.pathname === "/" && !parsed.search && !parsed.hash) {
+      mapped = mapped.slice(0, -1);
+    }
+    return mapped;
+  } catch {
+    return text;
+  }
+}
+
+function firstProxyValue(env, keys) {
+  for (const key of keys) {
+    const value = env[key];
+    if (typeof value === "string" && value.trim().length > 0) return value;
+  }
+  return null;
+}
+
+function containerProxyEnvironment(env) {
+  const http = containerProxyUrl(firstProxyValue(env, [
+    "HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy", "ALL_PROXY", "all_proxy"
+  ]));
+  const https = containerProxyUrl(firstProxyValue(env, [
+    "HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy", "ALL_PROXY", "all_proxy"
+  ]));
+  const all = containerProxyUrl(firstProxyValue(env, [
+    "ALL_PROXY", "all_proxy", "HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy"
+  ]));
+  if (!http && !https && !all) return {};
+  return {
+    SIGMA_CONTAINER_PROXY_ENABLED: "1",
+    SIGMA_CONTAINER_HTTP_PROXY: http ?? https ?? all,
+    SIGMA_CONTAINER_HTTPS_PROXY: https ?? http ?? all,
+    SIGMA_CONTAINER_ALL_PROXY: all ?? https ?? http,
+    SIGMA_CONTAINER_NO_PROXY: firstProxyValue(env, ["NO_PROXY", "no_proxy"]) ?? ""
+  };
+}
+
 export function harborEnvForRun(runDir, env = process.env, options = {}) {
   const harness = harnessKind(options.harness ?? env.SIGMA_BENCH_HARNESS);
   resolveHarborAgentImportPath(env, harness);
@@ -3225,11 +3303,11 @@ export function harborEnvForRun(runDir, env = process.env, options = {}) {
       next.CODEX_FORCE_AUTH_JSON = "1";
     }
   }
-  for (const key of ["HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "http_proxy", "https_proxy", "all_proxy"]) {
+  for (const key of proxyEnvironmentKeys) {
     const value = next[key];
-    if (typeof value === "string" && /^htpp:\/\//i.test(value)) {
-      next[key] = `http://${value.slice(7)}`;
-    }
+    next[key] = normalizedProxyScheme(value);
   }
+  for (const key of containerProxyEnvironmentKeys) delete next[key];
+  Object.assign(next, containerProxyEnvironment(next));
   return next;
 }

--- a/scripts/bench-common.mjs
+++ b/scripts/bench-common.mjs
@@ -46,6 +46,10 @@ export const harborAptRetryWrapperPath = path.join(
   harborRuntimeDir,
   "apt-network-retry"
 );
+export const harborCurlRetryWrapperPath = path.join(
+  harborRuntimeDir,
+  "curl-network-retry"
+);
 export const terminalBenchDataset = "terminal-bench/terminal-bench-2";
 export const portableAgentImportPath = "sigma_harbor_agent:SigmaCliHarborAgent";
 export const portableCodexAgentImportPath = "codex_harbor_agent:PortableCodex";
@@ -3194,7 +3198,8 @@ const containerProxyEnvironmentKeys = [
   "SIGMA_CONTAINER_ALL_PROXY",
   "SIGMA_CONTAINER_NO_PROXY",
   "SIGMA_CONTAINER_APT_CONFIG",
-  "SIGMA_CONTAINER_APT_RETRY_WRAPPER"
+  "SIGMA_CONTAINER_APT_RETRY_WRAPPER",
+  "SIGMA_CONTAINER_CURL_RETRY_WRAPPER"
 ];
 
 function normalizedProxyScheme(value) {
@@ -3249,7 +3254,8 @@ function containerProxyEnvironment(env) {
     SIGMA_CONTAINER_ALL_PROXY: all ?? https ?? http,
     SIGMA_CONTAINER_NO_PROXY: firstProxyValue(env, ["NO_PROXY", "no_proxy"]) ?? "",
     SIGMA_CONTAINER_APT_CONFIG: harborAptNetworkConfigPath,
-    SIGMA_CONTAINER_APT_RETRY_WRAPPER: harborAptRetryWrapperPath
+    SIGMA_CONTAINER_APT_RETRY_WRAPPER: harborAptRetryWrapperPath,
+    SIGMA_CONTAINER_CURL_RETRY_WRAPPER: harborCurlRetryWrapperPath
   };
 }
 

--- a/scripts/bench-common.mjs
+++ b/scripts/bench-common.mjs
@@ -36,12 +36,15 @@ export const harborSandboxComposePath = path.join(
 );
 export const terminalBenchDataset = "terminal-bench/terminal-bench-2";
 export const portableAgentImportPath = "sigma_harbor_agent:SigmaCliHarborAgent";
+export const portableCodexAgentImportPath = "codex_harbor_agent:PortableCodex";
+export const benchmarkHarnessKinds = Object.freeze(["sigma", "codex"]);
 export const agentImportPath = portableAgentImportPath;
 export const removedHarborPackageName = ["integrations", "harbor"].join(".");
 export const removedHarborDirectoryName = ["integrations", "harbor"].join("/");
 export const removedHarborAdapterErrorMessage =
   `${removedHarborDirectoryName} has been removed. Use portable runtime import path ${portableAgentImportPath}.`;
 export const defaultAgentCliTarball = path.join(artifactsDir, "agent-cli-linux-x64.tgz");
+export const defaultCodexCliTarball = path.join(artifactsDir, "codex-cli-linux-x64.tgz");
 export const defaultAgentTimeoutFallbackSec = 1800;
 export const defaultAgentTimeoutGraceSec = 120;
 export const defaultAgentTimeoutLeniencyMultiplier = 1.5;
@@ -59,6 +62,7 @@ export const terminalBenchCliFlags = Object.freeze([
   "dataset",
   "execution-mode",
   "expected-archive-sha256",
+  "harness",
   "harbor-topology",
   "help",
   "k",
@@ -72,6 +76,9 @@ export const terminalBenchCliFlags = Object.freeze([
   "retries",
   "reuse-package",
   "run-label",
+  "runtime-archive",
+  "runtime-layout",
+  "runtime-version",
   "smoke",
   "task-id",
   "tasks-file",
@@ -229,11 +236,30 @@ export function defaultAgentCliTarballForEnv(env = process.env) {
   return path.join(artifactsDir, `agent-cli-linux-${targetArch}.tgz`);
 }
 
-export function resolveHarborAgentImportPath(env = process.env) {
-  if (typeof env.SIGMA_HARBOR_AGENT_IMPORT_PATH === "string" && env.SIGMA_HARBOR_AGENT_IMPORT_PATH.trim()) {
+export function defaultCodexCliTarballForEnv(env = process.env) {
+  const targetArch = env.CODEX_TARGET_ARCH || env.AGENT_TARGET_ARCH || "x64";
+  return path.join(artifactsDir, `codex-cli-linux-${targetArch}.tgz`);
+}
+
+function harnessKind(value, fallback = "sigma") {
+  const harness = asString(value, fallback);
+  if (!benchmarkHarnessKinds.includes(harness)) {
+    throw new Error(`harness must be one of: ${benchmarkHarnessKinds.join(", ")}.`);
+  }
+  return harness;
+}
+
+export function resolveHarborAgentImportPath(env = process.env, harness = "sigma") {
+  const resolvedHarness = harnessKind(harness);
+  if (typeof env.HARBOR_AGENT_IMPORT_PATH === "string" && env.HARBOR_AGENT_IMPORT_PATH.trim()) {
+    return assertSupportedHarborAgentImportPath(env.HARBOR_AGENT_IMPORT_PATH.trim());
+  }
+  if (resolvedHarness === "sigma"
+    && typeof env.SIGMA_HARBOR_AGENT_IMPORT_PATH === "string"
+    && env.SIGMA_HARBOR_AGENT_IMPORT_PATH.trim()) {
     return assertSupportedHarborAgentImportPath(env.SIGMA_HARBOR_AGENT_IMPORT_PATH.trim());
   }
-  return portableAgentImportPath;
+  return resolvedHarness === "codex" ? portableCodexAgentImportPath : portableAgentImportPath;
 }
 
 function isRemovedHarborAgentImportPath(importPath) {
@@ -248,8 +274,13 @@ function assertSupportedHarborAgentImportPath(importPath) {
   return importPath;
 }
 
-function resolveAgentCliTarballPath(options = {}, env = process.env) {
-  return path.resolve(options.agentCliTarball ?? env.AGENT_CLI_TARBALL ?? defaultAgentCliTarballForEnv(env));
+export function resolveHarnessRuntimeArchive(options = {}, env = process.env) {
+  const harness = harnessKind(options.harness ?? env.SIGMA_BENCH_HARNESS);
+  const configured = options.runtimeArchive
+    ?? (harness === "codex" ? env.CODEX_CLI_TARBALL : env.AGENT_CLI_TARBALL);
+  return path.resolve(configured ?? (harness === "codex"
+    ? defaultCodexCliTarballForEnv(env)
+    : defaultAgentCliTarballForEnv(env)));
 }
 
 export function makeRunId(date, provider, model) {
@@ -356,6 +387,18 @@ function reasoningEffort(value, fallback = "auto") {
   return effort;
 }
 
+function runtimeLayout(harness, value) {
+  const defaults = harness === "codex" ? "npm-linux-x64" : "sigma-agent-cli";
+  const layout = asString(value, defaults);
+  const supported = harness === "codex"
+    ? ["npm-linux-x64", "portable-root"]
+    : ["sigma-agent-cli"];
+  if (!supported.includes(layout)) {
+    throw new Error(`runtime layout for ${harness} must be one of: ${supported.join(", ")}.`);
+  }
+  return layout;
+}
+
 function normalizedSha256(value, name) {
   if (value === undefined || value === null || value === "") return null;
   const text = String(value).trim().toLowerCase();
@@ -377,6 +420,7 @@ export function readTaskSelectionFile(filePath) {
 
 export function resolveRunOptions(argv, env = process.env) {
   const flags = parseTerminalBenchArgs(argv);
+  const harness = harnessKind(flags.harness ?? env.SIGMA_BENCH_HARNESS);
   const mode = flags.smoke ? "smoke" : asString(flags.mode, "k");
   if (!["smoke", "k", "task", "batch"].includes(mode)) {
     throw new Error(`Unsupported benchmark mode: ${mode}`);
@@ -392,6 +436,18 @@ export function resolveRunOptions(argv, env = process.env) {
   if (flags["reuse-package"] === true && !expectedArchiveSha256) {
     throw new Error("--reuse-package requires --expected-archive-sha256.");
   }
+  if (harness === "codex" && flags["reuse-package"] !== true) {
+    throw new Error("The Codex harness requires a SHA-pinned runtime and --reuse-package.");
+  }
+  const runtimeVersion = asString(flags["runtime-version"]
+    ?? (harness === "codex" ? env.CODEX_CLI_VERSION : env.SIGMA_RUNTIME_VERSION));
+  if (harness === "codex" && !runtimeVersion) {
+    throw new Error("The Codex harness requires --runtime-version.");
+  }
+  const runtimeArchive = resolveHarnessRuntimeArchive({
+    harness,
+    runtimeArchive: flags["runtime-archive"]
+  }, env);
 
   const runClass = benchmarkClass(flags["benchmark-class"] ?? env.SIGMA_BENCHMARK_CLASS);
   const requestedLeniencyMultiplier = flags["timeout-leniency-multiplier"]
@@ -426,6 +482,11 @@ export function resolveRunOptions(argv, env = process.env) {
   const configuredMaxTurns = flags["max-turns"] ?? env.AGENT_MAX_TURNS;
   return {
     mode,
+    harness,
+    agentImportPath: resolveHarborAgentImportPath(env, harness),
+    runtimeArchive,
+    runtimeLayout: runtimeLayout(harness, flags["runtime-layout"]),
+    runtimeVersion: runtimeVersion ?? null,
     benchmarkClass: runClass,
     dataset: asString(flags.dataset ?? env.SIGMA_BENCH_DATASET, terminalBenchDataset),
     provider: asString(flags.provider, env.AGENT_PROVIDER ?? "deepseek"),
@@ -691,8 +752,24 @@ function selectedTaskRecords(timeoutProbe) {
 }
 
 function benchmarkAgentKwargs(options, timeoutPlan = null) {
+  if (options.harness === "codex") {
+    if (!options.expectedArchiveSha256) {
+      throw new Error("The Codex harness requires a frozen runtime SHA-256.");
+    }
+    if (!options.runtimeVersion) {
+      throw new Error("The Codex harness requires a frozen runtime version.");
+    }
+    return {
+      codex_cli_tarball: resolveHarnessRuntimeArchive(options, options.env ?? process.env),
+      codex_cli_sha256: options.expectedArchiveSha256,
+      codex_cli_layout: options.runtimeLayout ?? "npm-linux-x64",
+      version: options.runtimeVersion,
+      model_name: options.model,
+      reasoning_effort: options.reasoningEffort ?? "auto"
+    };
+  }
   const agentKwargs = {
-    agent_cli_tarball: resolveAgentCliTarballPath(options, options.env ?? process.env),
+    agent_cli_tarball: resolveHarnessRuntimeArchive(options, options.env ?? process.env),
     provider: options.provider,
     reasoning_effort: options.reasoningEffort ?? "auto",
     agent_profile: options.agentProfile ?? "standard",
@@ -724,7 +801,8 @@ export function buildHarborJobConfig(options, jobsDir, timeoutPlan = null, timeo
   const agentName = options.mode === "smoke"
     ? "oracle"
     : assertSupportedHarborAgentImportPath(
-        options.agentImportPath ?? resolveHarborAgentImportPath(options.env ?? process.env)
+        options.agentImportPath
+          ?? resolveHarborAgentImportPath(options.env ?? process.env, options.harness)
       );
   const agentKwargs = options.mode === "smoke" ? {} : benchmarkAgentKwargs(options, timeoutPlan);
 
@@ -902,7 +980,8 @@ export function buildHarborArgs(options) {
   }
 
   const selectedAgentImportPath = assertSupportedHarborAgentImportPath(
-    options.agentImportPath ?? resolveHarborAgentImportPath(options.env ?? process.env)
+    options.agentImportPath
+      ?? resolveHarborAgentImportPath(options.env ?? process.env, options.harness)
   );
   const args = [
     "run",
@@ -933,7 +1012,28 @@ export function buildHarborArgs(options) {
     args.push(capabilities.agentTimeoutMultiplierFlag, agentTimeoutMultiplier);
   }
 
-  args.push("--ak", formatAgentKwarg("agent_cli_tarball", "str", resolveAgentCliTarballPath(options, options.env ?? process.env), capabilities));
+  if (options.harness === "codex") {
+    if (!options.expectedArchiveSha256 || !options.runtimeVersion || !options.model) {
+      throw new Error("The Codex harness requires frozen archive, version, and model controls.");
+    }
+    args.push("--ak", formatAgentKwarg(
+      "codex_cli_tarball", "str", resolveHarnessRuntimeArchive(options, options.env ?? process.env), capabilities
+    ));
+    args.push("--ak", formatAgentKwarg(
+      "codex_cli_sha256", "str", options.expectedArchiveSha256, capabilities
+    ));
+    args.push("--ak", formatAgentKwarg(
+      "codex_cli_layout", "str", options.runtimeLayout ?? "npm-linux-x64", capabilities
+    ));
+    args.push("--ak", formatAgentKwarg("version", "str", options.runtimeVersion, capabilities));
+    args.push("--ak", formatAgentKwarg("model_name", "str", options.model, capabilities));
+    args.push("--ak", formatAgentKwarg(
+      "reasoning_effort", "str", options.reasoningEffort ?? "auto", capabilities
+    ));
+    return args;
+  }
+
+  args.push("--ak", formatAgentKwarg("agent_cli_tarball", "str", resolveHarnessRuntimeArchive(options, options.env ?? process.env), capabilities));
   args.push("--ak", formatAgentKwarg("provider", "str", options.provider, capabilities));
   args.push("--ak", formatAgentKwarg(
     "reasoning_effort", "str", options.reasoningEffort ?? "auto", capabilities
@@ -988,6 +1088,11 @@ export function buildCommandScript(commandOrArgs, maybeArgs, maybeEnv) {
     "set -euo pipefail",
     `cd ${shellQuote(rootDir)}`,
     `export AGENT_CLI_TARBALL=${shellQuote(env.AGENT_CLI_TARBALL)}`,
+    `export CODEX_CLI_TARBALL=${shellQuote(env.CODEX_CLI_TARBALL ?? "")}`,
+    `export CODEX_CLI_VERSION=${shellQuote(env.CODEX_CLI_VERSION ?? "")}`,
+    `export CODEX_AUTH_JSON_PATH=${shellQuote(env.CODEX_AUTH_JSON_PATH ?? "")}`,
+    `export CODEX_FORCE_AUTH_JSON=${shellQuote(env.CODEX_FORCE_AUTH_JSON ?? "")}`,
+    `export SIGMA_BENCH_HARNESS=${shellQuote(env.SIGMA_BENCH_HARNESS ?? "sigma")}`,
     `export PYTHONPATH=${shellQuote(env.PYTHONPATH ?? "")}`,
     `export PYTHONDONTWRITEBYTECODE=${shellQuote(env.PYTHONDONTWRITEBYTECODE ?? "1")}`,
     `export PYTHONPYCACHEPREFIX=${shellQuote(env.PYTHONPYCACHEPREFIX ?? "")}`,
@@ -1615,21 +1720,80 @@ function summarizeTraceEvents(events) {
   return summary;
 }
 
+function summarizeAtifTrajectory(trajectory) {
+  const steps = Array.isArray(trajectory?.steps) ? trajectory.steps : [];
+  const agentSteps = steps.filter((step) => step?.source === "agent");
+  const toolCalls = agentSteps.flatMap((step) => Array.isArray(step?.tool_calls) ? step.tool_calls : []);
+  const finalMetrics = trajectory?.final_metrics && typeof trajectory.final_metrics === "object"
+    ? trajectory.final_metrics : {};
+  const timestamps = steps
+    .map((step) => Date.parse(step?.timestamp))
+    .filter(Number.isFinite);
+  const durationMs = timestamps.length > 1 ? Math.max(...timestamps) - Math.min(...timestamps) : 0;
+  return {
+    status: steps.length > 0 ? "completed" : undefined,
+    finish_reason: undefined,
+    commands_executed: toolCalls.length,
+    input_tokens: Number(finalMetrics.total_prompt_tokens ?? 0),
+    output_tokens: Number(finalMetrics.total_completion_tokens ?? 0),
+    reasoning_tokens: Number(finalMetrics.extra?.reasoning_output_tokens ?? 0),
+    cache_tokens: Number(finalMetrics.total_cached_tokens ?? 0),
+    cache_read_tokens: Number(finalMetrics.total_cached_tokens ?? 0),
+    provider_reported_input_tokens: Number(finalMetrics.total_prompt_tokens ?? 0),
+    provider_reported_cache_read_tokens: Number(finalMetrics.total_cached_tokens ?? 0),
+    warm_provider_input_tokens: 0,
+    warm_provider_cache_read_tokens: 0,
+    provider_reported_model_records: Number(
+      agentSteps.reduce((total, step) => total + Number(step?.llm_call_count ?? 0), 0)
+    ),
+    length_finish_count: 0,
+    converge_turns: 0,
+    cost_usd: Number.isFinite(Number(finalMetrics.total_cost_usd))
+      ? Number(finalMetrics.total_cost_usd) : null,
+    duration_ms: durationMs,
+    suspension_to_exit_ms: null,
+    terminal_origin: "harbor_atif",
+    termination_source: "harbor_atif",
+    network_mode_effective: null,
+    execution_mode: null,
+    managed_environment_mode: null,
+    harbor_topology: null,
+    agent_profile: null,
+    harbor_deadline_sec: null,
+    sigma_deadline_sec: null,
+    last_error: null
+  };
+}
+
 async function readTrialTraceFallback(runDir, trialDir) {
   const traceFiles = await listNamedFiles(trialDir, "trace.jsonl");
   const preferred = traceFiles.find((filePath) => /[\\/]agent[\\/]trace\.jsonl$/i.test(filePath)) ?? traceFiles[0];
-  if (!preferred) {
+  if (preferred) {
+    const events = await readTraceEvents(preferred);
     return {
-      agent_trace_path: null,
-      agent_trace_summary: {},
+      agent_trace_path: relativePathOrNull(runDir, preferred),
+      agent_trace_format: "sigma-jsonl",
+      agent_trace_summary: summarizeTraceEvents(events),
+      agent_trace_events: events
+    };
+  }
+  const trajectories = await listNamedFiles(trialDir, "trajectory.json");
+  const trajectoryPath = trajectories.find((filePath) => /[\\/]agent[\\/]trajectory\.json$/i.test(filePath))
+    ?? trajectories[0];
+  if (trajectoryPath) {
+    const trajectory = await readJsonSafe(trajectoryPath);
+    return {
+      agent_trace_path: relativePathOrNull(runDir, trajectoryPath),
+      agent_trace_format: "atif-json",
+      agent_trace_summary: summarizeAtifTrajectory(trajectory),
       agent_trace_events: []
     };
   }
-  const events = await readTraceEvents(preferred);
   return {
-    agent_trace_path: relativePathOrNull(runDir, preferred),
-    agent_trace_summary: summarizeTraceEvents(events),
-    agent_trace_events: events
+    agent_trace_path: null,
+    agent_trace_format: null,
+    agent_trace_summary: {},
+    agent_trace_events: []
   };
 }
 
@@ -1854,7 +2018,13 @@ async function runSlotIntegrityReasons(runDir, config) {
       const kwargs = Array.isArray(jobConfig.agents) && jobConfig.agents.length === 1
         && jobConfig.agents[0] && typeof jobConfig.agents[0] === "object"
         ? jobConfig.agents[0].kwargs : null;
-      const frozenControls = {
+      const frozenControls = config.harness === "codex" ? {
+        codex_cli_sha256: config.runtime_archive_sha256,
+        codex_cli_layout: config.runtime_layout,
+        version: config.runtime_version,
+        model_name: config.model,
+        reasoning_effort: config.reasoning_effort
+      } : {
         network_mode: config.network_mode,
         execution_mode: config.execution_mode,
         write_scope: config.write_scope,
@@ -1962,6 +2132,7 @@ function emptyTaskForTrial(trialResult, index) {
     failure_signals: [],
     summary_path: null,
     trace_path: null,
+    trace_format: null,
     commands_executed: 0,
     input_tokens: 0,
     cache_tokens: 0,
@@ -2144,6 +2315,7 @@ function mergeHarborTrialResult(task, trialResult) {
     agent_exception: agentExceptionFromTrial(trialResult, exceptionMessage),
     infra_warnings: Array.isArray(task.infra_warnings) ? [...task.infra_warnings] : [],
     trace_path: task.trace_path ?? trialResult?.agent_trace_path ?? null,
+    trace_format: task.trace_format ?? trialResult?.agent_trace_format ?? null,
     commands_executed: Number(
       agentMetadata.commands_executed ?? (task.commands_executed || traceSummary.commands_executed || 0)
     ),
@@ -2362,6 +2534,7 @@ async function taskReportFromDir(runDir, taskDir, index, config, globalLogText) 
     failure_signals: failureSignals,
     summary_path: relativePathOrNull(runDir, summaryPath),
     trace_path: relativePathOrNull(runDir, tracePath),
+    trace_format: existsSync(tracePath) ? "sigma-jsonl" : null,
     commands_executed: Number(summary.commands_executed ?? metadata.commands_executed ?? 0),
     input_tokens: Number(summary.input_tokens ?? metadata.n_input_tokens ?? 0),
     cache_tokens: Number(summary.cache_tokens ?? metadata.n_cache_tokens ?? 0),
@@ -2425,6 +2598,7 @@ function syntheticRunTask(config, globalLogText) {
     failure_signals: status === "passed" ? [] : collectFailureSignals({ logText: globalLogText }),
     summary_path: null,
     trace_path: null,
+    trace_format: null,
     commands_executed: 0,
     input_tokens: 0,
     cache_tokens: 0,
@@ -2513,6 +2687,24 @@ export function assertComparableBenchmarkReports(...reports) {
       `Benchmark reports use different reasoning efforts (${reasoningEfforts.join(", ")}) and cannot be combined.`
     ), { code: "benchmark_reasoning_effort_mismatch" });
   }
+  for (const [field, code] of [
+    ["harness", "benchmark_harness_mismatch"],
+    ["provider", "benchmark_provider_mismatch"],
+    ["model", "benchmark_model_mismatch"],
+    ["dataset", "benchmark_dataset_mismatch"],
+    ["network_mode", "benchmark_network_mismatch"],
+    ["execution_mode", "benchmark_execution_mode_mismatch"],
+    ["write_scope", "benchmark_write_scope_mismatch"],
+    ["managed_environment_mode", "benchmark_managed_environment_mismatch"],
+    ["harbor_topology", "benchmark_harbor_topology_mismatch"]
+  ]) {
+    const values = [...new Set(reports.map((report) => report?.[field]).filter((value) => value !== undefined))];
+    if (values.length > 1) {
+      throw Object.assign(new Error(
+        `Benchmark reports use different ${field} values (${values.join(", ")}) and cannot be combined.`
+      ), { code });
+    }
+  }
 }
 
 function taskHasSignal(task, pattern) {
@@ -2552,6 +2744,7 @@ export function formatMarkdownReport(report) {
     `- Status: ${report.status}`,
     `- Score status: ${report.score_status ?? report.status}`,
     `- Infra status: ${report.infra_status ?? "unknown"}`,
+    `- Harness: ${report.harness ?? "sigma"}`,
     `- Provider: ${report.provider}`,
     `- Model: ${report.model ?? "default"}`,
     `- Reasoning effort: ${report.reasoning_effort ?? "auto"}`,
@@ -2566,6 +2759,7 @@ export function formatMarkdownReport(report) {
     `- Command: ${markdownEscape(report.command ?? "")}`,
     `- Harbor: ${markdownEscape(report.harbor_command ?? "harbor")}${report.harbor_version ? ` (${markdownEscape(report.harbor_version)})` : ""}`,
     `- Concurrent trials: ${report.n_concurrent_trials ?? "unknown"}`,
+    `- Runtime archive SHA-256: ${report.runtime_archive_sha256 ?? "unknown"}`,
     "",
     "## Trial Accounting",
     "",
@@ -2870,6 +3064,7 @@ export async function generateBenchReport(runDir) {
     run_id: config.run_id ?? path.basename(runDir),
     started_at: config.started_at ?? null,
     finished_at: config.finished_at ?? null,
+    harness: config.harness ?? "sigma",
     provider: config.provider ?? "unknown",
     model: config.model ?? null,
     reasoning_effort: config.reasoning_effort ?? "auto",
@@ -2889,6 +3084,11 @@ export async function generateBenchReport(runDir) {
     tasks_file_sha256: config.tasks_file_sha256 ?? null,
     task_selection_sha256: config.task_selection_sha256 ?? null,
     run_slots: Array.isArray(config.run_slots) ? config.run_slots : [],
+    runtime_archive_sha256: config.runtime_archive_sha256 ?? config.agent_cli_sha256 ?? null,
+    runtime_layout: config.runtime_layout ?? null,
+    runtime_version: config.runtime_version ?? null,
+    frozen_runtime_integrity: config.frozen_runtime_integrity ?? null,
+    docker_cleanup: config.docker_cleanup ?? null,
     agent_cli_sha256: config.agent_cli_sha256 ?? null,
     package_reused: config.package_reused ?? false,
     n_concurrent_trials: resolvedJobConfig?.n_concurrent_trials ?? config.n_concurrent_trials ?? null,
@@ -2956,8 +3156,9 @@ export async function ensurePlaceholderTask(runDir, metadata) {
   });
 }
 
-export function harborEnvForRun(runDir, env = process.env) {
-  resolveHarborAgentImportPath(env);
+export function harborEnvForRun(runDir, env = process.env, options = {}) {
+  const harness = harnessKind(options.harness ?? env.SIGMA_BENCH_HARNESS);
+  resolveHarborAgentImportPath(env, harness);
   const pythonPathEntries = [harborRuntimeDir];
   if (env.PYTHONPATH) {
     pythonPathEntries.push(env.PYTHONPATH);
@@ -2976,7 +3177,16 @@ export function harborEnvForRun(runDir, env = process.env) {
 
   const next = {
     ...env,
-    AGENT_CLI_TARBALL: env.AGENT_CLI_TARBALL || defaultAgentCliTarballForEnv(env),
+    AGENT_CLI_TARBALL: harness === "sigma"
+      ? resolveHarnessRuntimeArchive({ harness, runtimeArchive: options.runtimeArchive }, env)
+      : env.AGENT_CLI_TARBALL || defaultAgentCliTarballForEnv(env),
+    CODEX_CLI_TARBALL: harness === "codex"
+      ? resolveHarnessRuntimeArchive({ harness, runtimeArchive: options.runtimeArchive }, env)
+      : env.CODEX_CLI_TARBALL,
+    CODEX_CLI_VERSION: harness === "codex"
+      ? options.runtimeVersion ?? env.CODEX_CLI_VERSION
+      : env.CODEX_CLI_VERSION,
+    SIGMA_BENCH_HARNESS: harness,
     PYTHONPATH: pythonPathEntries.filter(Boolean).join(path.delimiter),
     SIGMA_BENCH_RUN_DIR: runDir,
     SIGMA_HARBOR_RUN_ID: safePathPart(path.basename(path.resolve(runDir))),
@@ -2994,6 +3204,19 @@ export function harborEnvForRun(runDir, env = process.env) {
     next.SIGMA_HOST_CREDENTIAL_FILE = hostCredentialFile;
   } else {
     delete next.SIGMA_HOST_CREDENTIAL_FILE;
+  }
+  if (harness === "codex") {
+    const configuredCodexAuth = (env.CODEX_AUTH_JSON_PATH || "").trim();
+    if (configuredCodexAuth && !path.isAbsolute(configuredCodexAuth)) {
+      throw new Error("credential_path_invalid: CODEX_AUTH_JSON_PATH must be absolute");
+    }
+    const codexAuth = path.resolve(
+      configuredCodexAuth || path.join(os.homedir(), ".codex", "auth.json")
+    );
+    if (existsSync(codexAuth)) {
+      next.CODEX_AUTH_JSON_PATH = codexAuth;
+      next.CODEX_FORCE_AUTH_JSON = "1";
+    }
   }
   for (const key of ["HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "http_proxy", "https_proxy", "all_proxy"]) {
     const value = next[key];

--- a/scripts/bench-common.mjs
+++ b/scripts/bench-common.mjs
@@ -1029,7 +1029,7 @@ export function buildHarborArgs(options) {
       "codex_cli_layout", "str", options.runtimeLayout ?? "npm-linux-x64", capabilities
     ));
     args.push("--ak", formatAgentKwarg("version", "str", options.runtimeVersion, capabilities));
-    args.push("--ak", formatAgentKwarg("model_name", "str", options.model, capabilities));
+    args.push("--model", options.model);
     args.push("--ak", formatAgentKwarg(
       "reasoning_effort", "str", options.reasoningEffort ?? "auto", capabilities
     ));
@@ -1981,7 +1981,7 @@ async function resolvedJobConfigForReport(runDir, config) {
   return existsSync(filePath) ? await readJsonSafe(filePath) : null;
 }
 
-async function runSlotIntegrityReasons(runDir, config) {
+export async function runSlotIntegrityReasons(runDir, config) {
   const slots = Array.isArray(config.run_slots) ? config.run_slots : [];
   if (slots.length === 0) return [];
   const reasons = [];
@@ -2018,14 +2018,14 @@ async function runSlotIntegrityReasons(runDir, config) {
     }
     const jobConfig = await readJsonSafe(configPath);
     if (config.mode !== "smoke") {
-      const kwargs = Array.isArray(jobConfig.agents) && jobConfig.agents.length === 1
+      const agentConfig = Array.isArray(jobConfig.agents) && jobConfig.agents.length === 1
         && jobConfig.agents[0] && typeof jobConfig.agents[0] === "object"
-        ? jobConfig.agents[0].kwargs : null;
+        ? jobConfig.agents[0] : null;
+      const kwargs = agentConfig?.kwargs;
       const frozenControls = config.harness === "codex" ? {
         codex_cli_sha256: config.runtime_archive_sha256,
         codex_cli_layout: config.runtime_layout,
         version: config.runtime_version,
-        model_name: config.model,
         reasoning_effort: config.reasoning_effort
       } : {
         network_mode: config.network_mode,
@@ -2042,6 +2042,10 @@ async function runSlotIntegrityReasons(runDir, config) {
             reasons.push(`Harbor run slot ${slot.run_slot} agent control ${key} does not match its frozen run.`);
           }
         }
+      }
+      if (config.harness === "codex" && typeof config.model === "string"
+        && agentConfig?.model_name !== config.model) {
+        reasons.push(`Harbor run slot ${slot.run_slot} agent control model_name does not match its frozen run.`);
       }
     }
     if (slot.harbor_task_identity) {

--- a/scripts/bench-common.mjs
+++ b/scripts/bench-common.mjs
@@ -764,7 +764,6 @@ function benchmarkAgentKwargs(options, timeoutPlan = null) {
       codex_cli_sha256: options.expectedArchiveSha256,
       codex_cli_layout: options.runtimeLayout ?? "npm-linux-x64",
       version: options.runtimeVersion,
-      model_name: options.model,
       reasoning_effort: options.reasoningEffort ?? "auto"
     };
   }
@@ -818,6 +817,10 @@ export function buildHarborJobConfig(options, jobsDir, timeoutPlan = null, timeo
       }
     ]
   };
+
+  if (options.mode !== "smoke" && options.harness === "codex") {
+    config.agents[0].model_name = options.model;
+  }
 
   if (options.mode !== "smoke") {
     config.environment = {

--- a/scripts/bench-paired-analysis.mjs
+++ b/scripts/bench-paired-analysis.mjs
@@ -1,0 +1,568 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadPairedExperiment } from "./bench-paired-preregistration.mjs";
+
+function required(value, label) {
+  if (typeof value !== "string" || value.trim().length === 0) throw new Error(`${label} is required.`);
+  return value.trim();
+}
+
+function cliOptions(argv) {
+  const flags = {};
+  const values = new Set([
+    "preregistration-file", "expected-preregistration-sha256", "experiment-output", "output"
+  ]);
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === "--allow-partial") {
+      flags.allowPartial = true;
+      continue;
+    }
+    if (!token.startsWith("--") || !values.has(token.slice(2))) {
+      throw new Error(`Unsupported analysis option: ${token}`);
+    }
+    const value = argv[index + 1];
+    if (!value || value.startsWith("--")) throw new Error(`${token} requires a value.`);
+    flags[token.slice(2)] = value;
+    index += 1;
+  }
+  return {
+    preregistrationFile: path.resolve(required(flags["preregistration-file"], "--preregistration-file")),
+    expectedSha256: required(flags["expected-preregistration-sha256"], "--expected-preregistration-sha256"),
+    experimentOutput: path.resolve(required(flags["experiment-output"], "--experiment-output")),
+    output: path.resolve(required(flags.output, "--output")),
+    allowPartial: flags.allowPartial === true
+  };
+}
+
+async function json(filePath) {
+  return JSON.parse(await readFile(filePath, "utf8"));
+}
+
+function median(values) {
+  if (values.length === 0) return null;
+  const ordered = [...values].sort((left, right) => left - right);
+  const middle = Math.floor(ordered.length / 2);
+  return ordered.length % 2 === 0 ? (ordered[middle - 1] + ordered[middle]) / 2 : ordered[middle];
+}
+
+function mean(values) {
+  return values.length === 0 ? null : values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function quantile(values, probability) {
+  if (values.length === 0) return null;
+  const ordered = [...values].sort((left, right) => left - right);
+  const index = Math.min(ordered.length - 1, Math.max(0, Math.floor(probability * ordered.length)));
+  return ordered[index];
+}
+
+function wilson(successes, total, z = 1.959963984540054) {
+  if (total === 0) return { low: null, high: null };
+  const rate = successes / total;
+  const denominator = 1 + z * z / total;
+  const center = (rate + z * z / (2 * total)) / denominator;
+  const margin = z * Math.sqrt(rate * (1 - rate) / total + z * z / (4 * total * total)) / denominator;
+  return { low: Math.max(0, center - margin), high: Math.min(1, center + margin) };
+}
+
+function binomialCoefficient(n, k) {
+  let value = 1;
+  for (let index = 1; index <= Math.min(k, n - k); index += 1) {
+    value = value * (n - index + 1) / index;
+  }
+  return value;
+}
+
+function mcnemarExact(wins, losses) {
+  const discordant = wins + losses;
+  if (discordant === 0) return 1;
+  const tail = Math.min(wins, losses);
+  let probability = 0;
+  for (let index = 0; index <= tail; index += 1) {
+    probability += binomialCoefficient(discordant, index) / 2 ** discordant;
+  }
+  return Math.min(1, 2 * probability);
+}
+
+function canonical(value) {
+  if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonical(value[key])}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function sigmaTrace(records) {
+  let modelTurns = 0;
+  let toolCalls = 0;
+  let toolFailures = 0;
+  let validationEvents = 0;
+  const tools = {};
+  const sequence = [];
+  const signatures = [];
+  for (const wrapper of records) {
+    const event = wrapper?.sigma_event ?? wrapper ?? {};
+    const type = wrapper?.type ?? event.type;
+    const durableType = event.type ?? wrapper?.metadata?.event_type;
+    const payload = event.payload && typeof event.payload === "object" ? event.payload : {};
+    const metadata = wrapper?.metadata && typeof wrapper.metadata === "object" ? wrapper.metadata : {};
+    if (type === "model_end" || durableType === "model.completed") modelTurns += 1;
+    if (type === "tool_start" || durableType === "tool.started") {
+      toolCalls += 1;
+      const name = String(metadata.toolName ?? payload.toolName ?? payload.name ?? "unknown");
+      tools[name] = (tools[name] ?? 0) + 1;
+      sequence.push(name);
+      signatures.push(`${name}\0${canonical(payload.args ?? payload.input ?? metadata.args ?? {})}`);
+    }
+    if ((type === "tool_end" || durableType === "tool.completed")
+      && (metadata.error || payload.error || Number(payload.exitCode ?? metadata.exitCode ?? 0) !== 0)) {
+      toolFailures += 1;
+    }
+    if (String(durableType ?? "").startsWith("validation.")) validationEvents += 1;
+  }
+  return traceSummary({ modelTurns, toolCalls, toolFailures, validationEvents, tools, sequence, signatures });
+}
+
+function atifTrace(trajectory) {
+  const steps = Array.isArray(trajectory?.steps) ? trajectory.steps : [];
+  let modelTurns = 0;
+  let toolCalls = 0;
+  let toolFailures = 0;
+  const tools = {};
+  const sequence = [];
+  const signatures = [];
+  for (const step of steps) {
+    if (step?.source === "agent") modelTurns += Number(step.llm_call_count ?? 1);
+    const calls = Array.isArray(step?.tool_calls) ? step.tool_calls : [];
+    const results = Array.isArray(step?.observation?.results) ? step.observation.results : [];
+    for (const call of calls) {
+      toolCalls += 1;
+      const name = String(call?.function_name ?? "unknown");
+      tools[name] = (tools[name] ?? 0) + 1;
+      sequence.push(name);
+      signatures.push(`${name}\0${canonical(call?.arguments ?? {})}`);
+      const result = results.find((item) => item?.source_call_id === call?.tool_call_id);
+      if (result?.is_error === true) toolFailures += 1;
+    }
+  }
+  return traceSummary({
+    modelTurns,
+    toolCalls,
+    toolFailures,
+    validationEvents: 0,
+    tools,
+    sequence,
+    signatures
+  });
+}
+
+function traceSummary(input) {
+  const counts = new Map();
+  for (const signature of input.signatures) counts.set(signature, (counts.get(signature) ?? 0) + 1);
+  return {
+    model_turns: input.modelTurns,
+    tool_calls: input.toolCalls,
+    tool_failures: input.toolFailures,
+    validation_events: input.validationEvents,
+    repeated_tool_calls: [...counts.values()].reduce((sum, count) => sum + Math.max(0, count - 1), 0),
+    unique_tools: Object.keys(input.tools).length,
+    tool_histogram: Object.fromEntries(Object.entries(input.tools).sort(([left], [right]) => left.localeCompare(right))),
+    tool_sequence: input.sequence
+  };
+}
+
+async function loadTrace(record, experimentOutput) {
+  const evidence = record.trace?.evidence_path;
+  if (!evidence) return { available: false };
+  const filePath = path.resolve(experimentOutput, evidence);
+  try {
+    const text = await readFile(filePath, "utf8");
+    if (record.trace.format === "atif-json" || path.extname(filePath) === ".json") {
+      return { available: true, format: "atif-json", ...atifTrace(JSON.parse(text)) };
+    }
+    const records = text.split(/\r?\n/u).filter(Boolean).map((line) => JSON.parse(line));
+    return { available: true, format: "sigma-jsonl", ...sigmaTrace(records) };
+  } catch (error) {
+    return { available: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+function sequenceDistance(left, right) {
+  if (left.length === 0 && right.length === 0) return 0;
+  let previous = Array.from({ length: right.length + 1 }, (_unused, index) => index);
+  for (let i = 1; i <= left.length; i += 1) {
+    const current = [i];
+    for (let j = 1; j <= right.length; j += 1) {
+      current[j] = Math.min(
+        current[j - 1] + 1,
+        previous[j] + 1,
+        previous[j - 1] + (left[i - 1] === right[j - 1] ? 0 : 1)
+      );
+    }
+    previous = current;
+  }
+  return previous[right.length] / Math.max(left.length, right.length);
+}
+
+async function attemptRecords(manifest, experimentOutput, allowPartial) {
+  const records = [];
+  const missing = [];
+  for (const stage of manifest.execution.stages) {
+    for (const pair of stage.pairs) {
+      const label = `r${String(pair.repetition).padStart(2, "0")}-t${String(pair.task_index).padStart(3, "0")}`;
+      for (const arm of pair.arms) {
+        const filePath = path.join(
+          experimentOutput, "receipts", stage.id, label, `${arm}.completed.json`
+        );
+        try {
+          const record = await json(filePath);
+          records.push({ ...record, trace_summary: await loadTrace(record, experimentOutput) });
+        } catch (error) {
+          if (error?.code !== "ENOENT") throw error;
+          missing.push({ stage: stage.id, task_index: pair.task_index, repetition: pair.repetition, arm });
+        }
+      }
+    }
+  }
+  if (missing.length > 0 && !allowPartial) {
+    throw new Error(`Paired analysis is missing ${missing.length} preregistered attempts.`);
+  }
+  return { records, missing };
+}
+
+function armSummary(records, arm, repetitions) {
+  const items = records.filter((record) => record.arm === arm);
+  const valid = items.filter((record) => record.valid);
+  const passes = valid.filter((record) => record.passed).length;
+  const byTask = new Map();
+  for (const item of valid) {
+    const task = byTask.get(item.task_index) ?? [];
+    task.push(item);
+    byTask.set(item.task_index, task);
+  }
+  const completeTasks = [...byTask.values()].filter((itemsForTask) => itemsForTask.length === repetitions);
+  const metrics = (name) => valid.map((record) => record.metrics?.[name]).filter(Number.isFinite);
+  const traceMetrics = (name) => valid.map((record) => record.trace_summary?.[name]).filter(Number.isFinite);
+  const cost = metrics("cost_usd");
+  const totalCost = cost.length === valid.length && cost.length > 0
+    ? cost.reduce((sum, value) => sum + value, 0) : null;
+  return {
+    attempts: items.length,
+    valid_attempts: valid.length,
+    passes,
+    pass_rate: valid.length > 0 ? passes / valid.length : null,
+    pass_rate_wilson_95: wilson(passes, valid.length),
+    tasks_with_any_pass: completeTasks.filter((task) => task.some((item) => item.passed)).length,
+    task_pass_at_least_once_rate: completeTasks.length > 0
+      ? completeTasks.filter((task) => task.some((item) => item.passed)).length / completeTasks.length : null,
+    failure_categories: Object.fromEntries([...new Set(items.map((item) => item.failure_category ?? "none"))]
+      .sort().map((category) => [category, items.filter((item) => (item.failure_category ?? "none") === category).length])),
+    efficiency: {
+      duration_ms: distribution(metrics("duration_ms")),
+      uncached_tokens: distribution(metrics("uncached_tokens")),
+      input_tokens: distribution(metrics("input_tokens")),
+      cache_read_tokens: distribution(metrics("cache_read_tokens")),
+      output_tokens: distribution(metrics("output_tokens")),
+      reasoning_tokens: distribution(metrics("reasoning_tokens")),
+      commands_executed: distribution(metrics("commands_executed")),
+      cost_usd: distribution(cost),
+      total_cost_usd: totalCost,
+      cost_per_pass_usd: totalCost !== null && passes > 0 ? totalCost / passes : null,
+      uncached_tokens_per_pass: passes > 0
+        ? metrics("uncached_tokens").reduce((sum, value) => sum + value, 0) / passes : null
+    },
+    trace: {
+      available: items.filter((item) => item.trace_summary?.available).length,
+      model_turns: distribution(traceMetrics("model_turns")),
+      tool_calls: distribution(traceMetrics("tool_calls")),
+      tool_failures: distribution(traceMetrics("tool_failures")),
+      repeated_tool_calls: distribution(traceMetrics("repeated_tool_calls")),
+      validation_events: distribution(traceMetrics("validation_events")),
+      tool_histogram: aggregateHistogram(items.map((item) => item.trace_summary?.tool_histogram))
+    }
+  };
+}
+
+function distribution(values) {
+  return {
+    samples: values.length,
+    mean: mean(values),
+    median: median(values),
+    p25: quantile(values, 0.25),
+    p75: quantile(values, 0.75),
+    min: values.length > 0 ? Math.min(...values) : null,
+    max: values.length > 0 ? Math.max(...values) : null
+  };
+}
+
+function aggregateHistogram(histograms) {
+  const result = {};
+  for (const histogram of histograms) {
+    for (const [key, value] of Object.entries(histogram ?? {})) {
+      result[key] = (result[key] ?? 0) + Number(value ?? 0);
+    }
+  }
+  return Object.fromEntries(Object.entries(result).sort(([, left], [, right]) => right - left));
+}
+
+function pairedRows(records, arms) {
+  const map = new Map();
+  for (const record of records) {
+    const key = `${record.task_index}\0${record.repetition}`;
+    const pair = map.get(key) ?? { task_index: record.task_index, repetition: record.repetition };
+    pair[record.arm] = record;
+    map.set(key, pair);
+  }
+  return [...map.values()].filter((pair) => pair[arms[0]] && pair[arms[1]]);
+}
+
+function bootstrapByTask(rows, accessor, seedText) {
+  const taskIds = [...new Set(rows.map((row) => row.task_index))].sort((a, b) => a - b);
+  if (taskIds.length === 0) return null;
+  const byTask = new Map(taskIds.map((task) => [task, rows.filter((row) => row.task_index === task)]));
+  let state = Number.parseInt(createHash("sha256").update(seedText).digest("hex").slice(0, 8), 16) >>> 0;
+  const medians = [];
+  for (let iteration = 0; iteration < 4_000; iteration += 1) {
+    const values = [];
+    for (let index = 0; index < taskIds.length; index += 1) {
+      state = (Math.imul(state, 1_664_525) + 1_013_904_223) >>> 0;
+      const selected = taskIds[state % taskIds.length];
+      values.push(...byTask.get(selected).map(accessor).filter(Number.isFinite));
+    }
+    if (values.length > 0) medians.push(median(values));
+  }
+  return { low: quantile(medians, 0.025), high: quantile(medians, 0.975), samples: medians.length };
+}
+
+function pairedMetric(rows, reference, comparison, key, requireJointSuccess) {
+  const selected = rows.filter((row) => {
+    const left = row[reference];
+    const right = row[comparison];
+    return left.valid && right.valid
+      && (!requireJointSuccess || (left.passed && right.passed))
+      && Number.isFinite(left.metrics?.[key]) && Number.isFinite(right.metrics?.[key]);
+  });
+  const deltas = selected.map((row) => row[comparison].metrics[key] - row[reference].metrics[key]);
+  const ratios = selected.flatMap((row) => {
+    const before = row[reference].metrics[key];
+    const after = row[comparison].metrics[key];
+    return before === 0 ? after === 0 ? [1] : [] : [after / before];
+  });
+  return {
+    pairs: selected.length,
+    median_delta: median(deltas),
+    mean_delta: mean(deltas),
+    median_ratio: median(ratios),
+    better: deltas.filter((value) => value < 0).length,
+    tied: deltas.filter((value) => value === 0).length,
+    worse: deltas.filter((value) => value > 0).length,
+    cluster_bootstrap_median_delta_95: bootstrapByTask(
+      selected,
+      (row) => row[comparison].metrics[key] - row[reference].metrics[key],
+      `${reference}:${comparison}:${key}:delta`
+    ),
+    cluster_bootstrap_median_ratio_95: bootstrapByTask(
+      selected,
+      (row) => {
+        const before = row[reference].metrics[key];
+        return before === 0 ? NaN : row[comparison].metrics[key] / before;
+      },
+      `${reference}:${comparison}:${key}:ratio`
+    )
+  };
+}
+
+function pairedTraceMetric(rows, reference, comparison, key) {
+  const selected = rows.filter((row) => row[reference].trace_summary?.available
+    && row[comparison].trace_summary?.available
+    && Number.isFinite(row[reference].trace_summary[key])
+    && Number.isFinite(row[comparison].trace_summary[key]));
+  const deltas = selected.map((row) => row[comparison].trace_summary[key] - row[reference].trace_summary[key]);
+  return {
+    pairs: selected.length,
+    median_delta: median(deltas),
+    median_ratio: median(selected.flatMap((row) => {
+      const before = row[reference].trace_summary[key];
+      const after = row[comparison].trace_summary[key];
+      return before === 0 ? after === 0 ? [1] : [] : [after / before];
+    })),
+    better: deltas.filter((value) => value < 0).length,
+    tied: deltas.filter((value) => value === 0).length,
+    worse: deltas.filter((value) => value > 0).length
+  };
+}
+
+function pairedAnalysis(records, reference, comparison) {
+  const rows = pairedRows(records, [reference, comparison]);
+  let wins = 0;
+  let losses = 0;
+  for (const row of rows) {
+    if (row[comparison].passed && !row[reference].passed) wins += 1;
+    if (row[reference].passed && !row[comparison].passed) losses += 1;
+  }
+  const sequenceDistances = rows.flatMap((row) => {
+    const left = row[reference].trace_summary;
+    const right = row[comparison].trace_summary;
+    return left?.available && right?.available
+      ? [sequenceDistance(left.tool_sequence ?? [], right.tool_sequence ?? [])] : [];
+  });
+  const metrics = {};
+  for (const key of [
+    "duration_ms", "uncached_tokens", "input_tokens", "cache_read_tokens",
+    "output_tokens", "reasoning_tokens", "commands_executed", "cost_usd"
+  ]) {
+    metrics[key] = {
+      joint_valid: pairedMetric(rows, reference, comparison, key, false),
+      joint_success: pairedMetric(rows, reference, comparison, key, true)
+    };
+  }
+  const trace = {};
+  for (const key of [
+    "model_turns", "tool_calls", "tool_failures", "repeated_tool_calls", "validation_events"
+  ]) trace[key] = pairedTraceMetric(rows, reference, comparison, key);
+  return {
+    complete_pairs: rows.length,
+    correctness: {
+      comparison_only_passes: wins,
+      reference_only_passes: losses,
+      ties: rows.length - wins - losses,
+      mcnemar_exact_two_sided_p: mcnemarExact(wins, losses)
+    },
+    efficiency: metrics,
+    trace: {
+      ...trace,
+      tool_sequence_normalized_edit_distance: distribution(sequenceDistances)
+    },
+    order_strata: {
+      comparison_first: correctnessForRows(rows.filter((row) => row[comparison].order === 1), reference, comparison),
+      reference_first: correctnessForRows(rows.filter((row) => row[reference].order === 1), reference, comparison)
+    }
+  };
+}
+
+function correctnessForRows(rows, reference, comparison) {
+  let wins = 0;
+  let losses = 0;
+  for (const row of rows) {
+    if (row[comparison].passed && !row[reference].passed) wins += 1;
+    if (row[reference].passed && !row[comparison].passed) losses += 1;
+  }
+  return { pairs: rows.length, comparison_only_passes: wins, reference_only_passes: losses };
+}
+
+function formatPercent(value) {
+  return value === null ? "n/a" : `${(value * 100).toFixed(1)}%`;
+}
+
+function markdown(report) {
+  const [reference, comparison] = report.arm_order;
+  const left = report.arms[reference];
+  const right = report.arms[comparison];
+  const lines = [
+    "# Paired Harness Experiment",
+    "",
+    `- Status: ${report.status}`,
+    `- Experiment: ${report.experiment_id}`,
+    `- Model: ${report.model.provider}/${report.model.name} (${report.model.reasoning_effort})`,
+    `- Attempts observed: ${report.observed_attempts}/${report.expected_attempts}`,
+    `- Complete pairs: ${report.paired.complete_pairs}`,
+    "",
+    "## Outcome and efficiency",
+    "",
+    `| metric | ${reference} | ${comparison} |`,
+    "|---|---:|---:|",
+    `| attempt pass rate | ${formatPercent(left.pass_rate)} | ${formatPercent(right.pass_rate)} |`,
+    `| passed attempts | ${left.passes}/${left.valid_attempts} | ${right.passes}/${right.valid_attempts} |`,
+    `| task pass at least once | ${formatPercent(left.task_pass_at_least_once_rate)} | ${formatPercent(right.task_pass_at_least_once_rate)} |`,
+    `| median wall time (ms) | ${left.efficiency.duration_ms.median ?? "n/a"} | ${right.efficiency.duration_ms.median ?? "n/a"} |`,
+    `| median uncached tokens | ${left.efficiency.uncached_tokens.median ?? "n/a"} | ${right.efficiency.uncached_tokens.median ?? "n/a"} |`,
+    `| median model turns | ${left.trace.model_turns.median ?? "n/a"} | ${right.trace.model_turns.median ?? "n/a"} |`,
+    `| median tool calls | ${left.trace.tool_calls.median ?? "n/a"} | ${right.trace.tool_calls.median ?? "n/a"} |`,
+    "",
+    "## Paired correctness",
+    "",
+    `- ${comparison}-only passes: ${report.paired.correctness.comparison_only_passes}`,
+    `- ${reference}-only passes: ${report.paired.correctness.reference_only_passes}`,
+    `- Exact McNemar p-value: ${report.paired.correctness.mcnemar_exact_two_sided_p}`,
+    "",
+    "## Paired efficiency (comparison / reference)",
+    "",
+    "| metric | joint-success pairs | median ratio | bootstrap 95% interval | better/tied/worse |",
+    "|---|---:|---:|---:|---:|"
+  ];
+  for (const key of ["duration_ms", "uncached_tokens", "input_tokens", "output_tokens", "reasoning_tokens", "commands_executed"]) {
+    const metric = report.paired.efficiency[key].joint_success;
+    const interval = metric.cluster_bootstrap_median_ratio_95;
+    lines.push(`| ${key} | ${metric.pairs} | ${metric.median_ratio ?? "n/a"} | ${interval ? `${interval.low}–${interval.high}` : "n/a"} | ${metric.better}/${metric.tied}/${metric.worse} |`);
+  }
+  lines.push(
+    "",
+    "## Trace coverage",
+    "",
+    `- ${reference}: ${left.trace.available}/${left.attempts}`,
+    `- ${comparison}: ${right.trace.available}/${right.attempts}`,
+    `- Median normalized tool-sequence distance: ${report.paired.trace.tool_sequence_normalized_edit_distance.median ?? "n/a"}`,
+    "",
+    "Ratios below 1 favor the comparison arm for cost-like metrics. Confidence intervals cluster-resample tasks, retaining all repetitions within each sampled task.",
+    ""
+  );
+  return lines.join("\n");
+}
+
+export async function analyzePairedExperiment(input) {
+  const bundle = await loadPairedExperiment(input.preregistrationFile, input.expectedSha256);
+  const { manifest } = bundle;
+  const { records, missing } = await attemptRecords(
+    manifest, input.experimentOutput, input.allowPartial === true
+  );
+  const [reference, comparison] = manifest.arms.map((arm) => arm.id);
+  return {
+    schemaVersion: 1,
+    kind: "PairedHarnessAnalysis",
+    experiment_id: manifest.experiment_id,
+    consumption_identity_sha256: manifest.consumption_identity_sha256,
+    status: missing.length === 0 ? "complete" : "partial",
+    model: manifest.model,
+    task_selection: {
+      dataset: manifest.task_catalog.dataset,
+      sample_size: manifest.selection.sample_size,
+      repetitions: manifest.execution.repetitions,
+      selection_method: manifest.selection.method,
+      selection_seed: manifest.selection.seed,
+      selected_task_identity_sha256: manifest.selection.selected_task_identity_sha256
+    },
+    expected_attempts: manifest.execution.expected_attempts,
+    observed_attempts: records.length,
+    missing_attempts: missing,
+    arm_order: [reference, comparison],
+    arms: Object.fromEntries(manifest.arms.map((arm) => [
+      arm.id, armSummary(records, arm.id, manifest.execution.repetitions)
+    ])),
+    paired: pairedAnalysis(records, reference, comparison)
+  };
+}
+
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) {
+  const input = cliOptions(process.argv.slice(2));
+  analyzePairedExperiment(input).then(async (report) => {
+    await mkdir(input.output, { recursive: true });
+    await Promise.all([
+      writeFile(path.join(input.output, "analysis.json"), `${JSON.stringify(report, null, 2)}\n`, "utf8"),
+      writeFile(path.join(input.output, "analysis.md"), markdown(report), "utf8")
+    ]);
+    process.stdout.write(`${JSON.stringify({
+      status: report.status,
+      output: input.output,
+      observed_attempts: report.observed_attempts,
+      complete_pairs: report.paired.complete_pairs
+    })}\n`);
+  }).catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/bench-paired-analysis.mjs
+++ b/scripts/bench-paired-analysis.mjs
@@ -96,6 +96,20 @@ function canonical(value) {
   return JSON.stringify(value);
 }
 
+export function semanticToolCategory(name) {
+  const normalized = String(name ?? "unknown").trim().toLowerCase().replace(/[^a-z0-9]+/gu, "_");
+  if (["exec", "shell"].includes(normalized)) return "command";
+  if ([
+    "read", "grep", "list", "repository_inspect", "repository_stats", "git_status", "git_diff",
+    "web_run", "inspect_image"
+  ].includes(normalized)) return "inspect";
+  if (["edit", "write", "apply_patch"].includes(normalized)) return "edit";
+  if (["update_plan", "request_strategy"].includes(normalized)) return "plan";
+  if (normalized === "spawn_agent") return "delegate";
+  if (["wait", "join_agent"].includes(normalized)) return "wait";
+  return `other:${normalized || "unknown"}`;
+}
+
 function sigmaTrace(records) {
   let modelTurns = 0;
   let toolCalls = 0;
@@ -115,7 +129,7 @@ function sigmaTrace(records) {
       toolCalls += 1;
       const name = String(metadata.toolName ?? payload.toolName ?? payload.name ?? "unknown");
       tools[name] = (tools[name] ?? 0) + 1;
-      sequence.push(name);
+      sequence.push(semanticToolCategory(name));
       signatures.push(`${name}\0${canonical(payload.args ?? payload.input ?? metadata.args ?? {})}`);
     }
     if ((type === "tool_end" || durableType === "tool.completed")
@@ -143,7 +157,7 @@ function atifTrace(trajectory) {
       toolCalls += 1;
       const name = String(call?.function_name ?? "unknown");
       tools[name] = (tools[name] ?? 0) + 1;
-      sequence.push(name);
+      sequence.push(semanticToolCategory(name));
       signatures.push(`${name}\0${canonical(call?.arguments ?? {})}`);
       const result = results.find((item) => item?.source_call_id === call?.tool_call_id);
       if (result?.is_error === true) toolFailures += 1;
@@ -320,7 +334,7 @@ function pairedRows(records, arms) {
   return [...map.values()].filter((pair) => pair[arms[0]] && pair[arms[1]]);
 }
 
-function bootstrapByTask(rows, accessor, seedText) {
+export function bootstrapByTask(rows, accessor, seedText) {
   const taskIds = [...new Set(rows.map((row) => row.task_index))].sort((a, b) => a - b);
   if (taskIds.length === 0) return null;
   const byTask = new Map(taskIds.map((task) => [task, rows.filter((row) => row.task_index === task)]));
@@ -330,7 +344,7 @@ function bootstrapByTask(rows, accessor, seedText) {
     const values = [];
     for (let index = 0; index < taskIds.length; index += 1) {
       state = (Math.imul(state, 1_664_525) + 1_013_904_223) >>> 0;
-      const selected = taskIds[state % taskIds.length];
+      const selected = taskIds[Math.floor((state / 0x1_0000_0000) * taskIds.length)];
       values.push(...byTask.get(selected).map(accessor).filter(Number.isFinite));
     }
     if (values.length > 0) medians.push(median(values));
@@ -505,7 +519,7 @@ function markdown(report) {
     "",
     `- ${reference}: ${left.trace.available}/${left.attempts}`,
     `- ${comparison}: ${right.trace.available}/${right.attempts}`,
-    `- Median normalized tool-sequence distance: ${report.paired.trace.tool_sequence_normalized_edit_distance.median ?? "n/a"}`,
+    `- Median normalized semantic tool-category sequence distance: ${report.paired.trace.tool_sequence_normalized_edit_distance.median ?? "n/a"}`,
     "",
     "Ratios below 1 favor the comparison arm for cost-like metrics. Confidence intervals cluster-resample tasks, retaining all repetitions within each sampled task.",
     ""

--- a/scripts/bench-paired-analysis.mjs
+++ b/scripts/bench-paired-analysis.mjs
@@ -430,7 +430,7 @@ function pairedAnalysis(records, reference, comparison) {
       comparison_only_passes: wins,
       reference_only_passes: losses,
       ties: rows.length - wins - losses,
-      mcnemar_exact_two_sided_p: mcnemarExact(wins, losses)
+      mcnemar_exact_two_sided_p: rows.length > 0 ? mcnemarExact(wins, losses) : null
     },
     efficiency: metrics,
     trace: {
@@ -487,7 +487,7 @@ function markdown(report) {
     "",
     `- ${comparison}-only passes: ${report.paired.correctness.comparison_only_passes}`,
     `- ${reference}-only passes: ${report.paired.correctness.reference_only_passes}`,
-    `- Exact McNemar p-value: ${report.paired.correctness.mcnemar_exact_two_sided_p}`,
+    `- Exact McNemar p-value: ${report.paired.correctness.mcnemar_exact_two_sided_p ?? "n/a"}`,
     "",
     "## Paired efficiency (comparison / reference)",
     "",

--- a/scripts/bench-paired-experiment.mjs
+++ b/scripts/bench-paired-experiment.mjs
@@ -166,10 +166,22 @@ function selectStage(manifest, completed, requested) {
 
 function exactTask(report, expectedIdentity) {
   const tasks = Array.isArray(report?.tasks) ? report.tasks : [];
-  if (tasks.length !== 1 || tasks[0]?.selection_identity_sha256 !== expectedIdentity) {
-    throw new Error("The benchmark report does not contain the frozen task identity exactly once.");
+  if (tasks.length === 1 && tasks[0]?.selection_identity_sha256 === expectedIdentity) {
+    return { task: tasks[0], identityEvidence: "task" };
   }
-  return tasks[0];
+  const slots = Array.isArray(report?.run_slots) ? report.run_slots : [];
+  const reportIncomplete = report?.incomplete_reason !== null
+    || Number(report?.trial_accounting?.expected) !== 1
+    || Number(report?.trial_accounting?.observed) !== 1
+    || Number(report?.trial_accounting?.missing) !== 0;
+  if (reportIncomplete && slots.length === 1
+    && slots[0]?.selection_identity_sha256 === expectedIdentity) {
+    return {
+      task: tasks.length === 1 ? tasks[0] : {},
+      identityEvidence: "run_slot_attestation"
+    };
+  }
+  throw new Error("The benchmark report does not contain the frozen task identity exactly once.");
 }
 
 export function classifyBlockingCondition(report, task) {
@@ -212,7 +224,8 @@ export function summarizePairedAttempt(context) {
   const expectedIdentity = taskSelectionIdentitySha256(
     manifest.selection.selected_tasks[pair.task_index]
   );
-  const task = exactTask(report, expectedIdentity);
+  const { task, identityEvidence } = exactTask(report, expectedIdentity);
+  const blockingCondition = classifyBlockingCondition(report, task);
   const inputTokens = numberOrZero(task.input_tokens);
   const cacheReadTokens = numberOrZero(task.cache_read_tokens ?? task.cache_tokens);
   const outputTokens = numberOrZero(task.output_tokens);
@@ -226,12 +239,13 @@ export function summarizePairedAttempt(context) {
     arm: arm.id,
     harness: arm.harness,
     order: pair.arms.indexOf(arm.id) + 1,
-    valid: task.validity === "valid",
-    passed: task.validity === "valid" && task.verifier_outcome === "passed",
+    valid: blockingCondition === null && task.validity === "valid",
+    passed: blockingCondition === null && task.validity === "valid" && task.verifier_outcome === "passed",
     agent_outcome: task.agent_outcome ?? null,
     verifier_outcome: task.verifier_outcome ?? null,
     failure_category: task.failure_category ?? null,
-    blocking_condition: classifyBlockingCondition(report, task),
+    blocking_condition: blockingCondition,
+    task_identity_evidence: identityEvidence,
     metrics: {
       duration_ms: numberOrZero(task.duration_ms),
       input_tokens: inputTokens,

--- a/scripts/bench-paired-experiment.mjs
+++ b/scripts/bench-paired-experiment.mjs
@@ -24,7 +24,6 @@ const BLOCKING_FAILURES = new Set([
   "host_proxy_error", "host_encoding_error", "harbor_cli_error", "node_missing",
   "agent_setup_failed", "infrastructure_incomplete", "verifier_setup_failed"
 ]);
-const PROVIDER_BLOCKER = /(?:auth(?:entication|orization)?|credential|unauthori[sz]ed|invalid[_ -]?api[_ -]?key|rate[_ -]?limit|service unavailable|provider unavailable|connection (?:refused|reset)|could not resolve host)/iu;
 
 function required(value, label) {
   if (typeof value !== "string" || value.trim().length === 0) throw new Error(`${label} is required.`);
@@ -211,8 +210,7 @@ export function classifyBlockingCondition(report, task) {
   if (task?.validity === "infra_failed" || BLOCKING_FAILURES.has(task?.failure_category)) {
     return "infra_failed_attempt";
   }
-  const errorText = `${task?.last_error ?? ""}\n${task?.agent_exception?.message ?? ""}`;
-  if (task?.failure_category === "api_error" || PROVIDER_BLOCKER.test(errorText)) {
+  if (task?.failure_category === "api_error") {
     return "credential_or_provider_unavailable";
   }
   if (report.frozen_runtime_integrity === "failed" || report.docker_cleanup?.clean === false

--- a/scripts/bench-paired-experiment.mjs
+++ b/scripts/bench-paired-experiment.mjs
@@ -1,0 +1,512 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { constants } from "node:fs";
+import { copyFile, mkdir, open, readFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  packageHarborRuntime,
+  rootDir,
+  safePathPart,
+  taskSelectionIdentitySha256
+} from "./bench-common.mjs";
+import { runTerminalBenchCli } from "./bench-terminal-bench.mjs";
+import { loadPairedExperiment, pairedSha256 } from "./bench-paired-preregistration.mjs";
+
+const BLOCKING_FAILURES = new Set([
+  "host_proxy_error", "host_encoding_error", "harbor_cli_error", "node_missing",
+  "agent_setup_failed", "infrastructure_incomplete", "verifier_setup_failed"
+]);
+const PROVIDER_BLOCKER = /(?:auth(?:entication|orization)?|credential|unauthori[sz]ed|invalid[_ -]?api[_ -]?key|rate[_ -]?limit|service unavailable|provider unavailable|connection (?:refused|reset)|could not resolve host)/iu;
+
+function required(value, label) {
+  if (typeof value !== "string" || value.trim().length === 0) throw new Error(`${label} is required.`);
+  return value.trim();
+}
+
+function options(argv) {
+  const flags = {};
+  const supported = new Set([
+    "preregistration-file", "expected-preregistration-sha256", "output", "stage"
+  ]);
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token.startsWith("--") || !supported.has(token.slice(2))) {
+      throw new Error(`Unsupported paired runner option: ${token}`);
+    }
+    const value = argv[index + 1];
+    if (!value || value.startsWith("--")) throw new Error(`${token} requires a value.`);
+    flags[token.slice(2)] = value;
+    index += 1;
+  }
+  return {
+    preregistrationFile: path.resolve(required(flags["preregistration-file"], "--preregistration-file")),
+    expectedSha256: required(flags["expected-preregistration-sha256"], "--expected-preregistration-sha256"),
+    outputDir: flags.output ? path.resolve(flags.output) : null,
+    stage: flags.stage ?? "next"
+  };
+}
+
+async function writeExclusive(filePath, value) {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  const bytes = Buffer.isBuffer(value) ? value : Buffer.from(`${JSON.stringify(value, null, 2)}\n`);
+  const handle = await open(filePath, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY, 0o600);
+  try {
+    await handle.writeFile(bytes);
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+}
+
+async function jsonIfPresent(filePath) {
+  try {
+    return JSON.parse(await readFile(filePath, "utf8"));
+  } catch (error) {
+    if (error?.code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+async function fileSha256(filePath) {
+  return createHash("sha256").update(await readFile(filePath)).digest("hex");
+}
+
+function armArchives(manifest, manifestPath) {
+  const baseDir = path.dirname(manifestPath);
+  return new Map(manifest.arms.map((arm) => [arm.id, {
+    ...arm,
+    archive: path.resolve(baseDir, arm.runtime.archive_path)
+  }]));
+}
+
+async function assertFrozenArchives(arms) {
+  for (const arm of arms.values()) {
+    let observed;
+    try {
+      observed = await fileSha256(arm.archive);
+    } catch (error) {
+      throw new Error(`Runtime archive for arm ${arm.id} is unavailable: ${arm.archive}`, { cause: error });
+    }
+    if (observed !== arm.runtime.archive_sha256) {
+      throw new Error(`Runtime archive for arm ${arm.id} does not match its frozen SHA-256.`);
+    }
+  }
+}
+
+function credentialAvailable(harness, env = process.env) {
+  if (harness === "codex") {
+    const configured = env.CODEX_AUTH_JSON_PATH;
+    const candidate = configured && path.isAbsolute(configured)
+      ? configured : path.join(os.homedir(), ".codex", "auth.json");
+    return Boolean(env.OPENAI_API_KEY) || path.isAbsolute(candidate);
+  }
+  const configured = env.SIGMA_HOST_CREDENTIAL_FILE || env.SIGMA_CREDENTIAL_FILE;
+  const candidate = configured && path.isAbsolute(configured)
+    ? configured : path.join(os.homedir(), ".sigma", "auth.json");
+  return Boolean(env.OPENAI_API_KEY) || path.isAbsolute(candidate);
+}
+
+async function assertCredentials(arms, env = process.env) {
+  for (const arm of arms.values()) {
+    if (!credentialAvailable(arm.harness, env)) {
+      throw new Error(`No host credential source is configured for ${arm.harness}.`);
+    }
+    const candidate = arm.harness === "codex"
+      ? env.CODEX_AUTH_JSON_PATH || path.join(os.homedir(), ".codex", "auth.json")
+      : env.SIGMA_HOST_CREDENTIAL_FILE || env.SIGMA_CREDENTIAL_FILE
+        || path.join(os.homedir(), ".sigma", "auth.json");
+    if (!env.OPENAI_API_KEY) {
+      try {
+        await readFile(candidate);
+      } catch (error) {
+        throw new Error(`Credential file for ${arm.harness} is unavailable: ${candidate}`, { cause: error });
+      }
+    }
+  }
+}
+
+function stagePaths(outputDir, stageId) {
+  const root = path.join(outputDir, "receipts", safePathPart(stageId));
+  return {
+    root,
+    started: path.join(root, "stage.started.json"),
+    completed: path.join(root, "stage.completed.json")
+  };
+}
+
+async function completedPrefix(manifest, outputDir) {
+  const completed = [];
+  let foundGap = false;
+  for (const stage of manifest.execution.stages) {
+    const paths = stagePaths(outputDir, stage.id);
+    const [started, receipt] = await Promise.all([
+      jsonIfPresent(paths.started), jsonIfPresent(paths.completed)
+    ]);
+    if (receipt && !started) throw new Error(`Stage ${stage.id} has a completion receipt without a start receipt.`);
+    if (foundGap && (started || receipt)) throw new Error("Stage receipts are not an append-only prefix.");
+    if (started && !receipt) {
+      throw new Error(`Stage ${stage.id} was consumed but did not complete; solver attempts cannot be retried.`);
+    }
+    if (receipt) completed.push(stage.id);
+    else foundGap = true;
+  }
+  return completed;
+}
+
+function selectStage(manifest, completed, requested) {
+  const next = manifest.execution.stages[completed.length];
+  if (!next) throw new Error("Every preregistered stage is already complete.");
+  if (requested !== "next" && requested !== next.id) {
+    throw new Error(`The next unconsumed stage is ${next.id}; received ${requested}.`);
+  }
+  return next;
+}
+
+function exactTask(report, expectedIdentity) {
+  const tasks = Array.isArray(report?.tasks) ? report.tasks : [];
+  if (tasks.length !== 1 || tasks[0]?.selection_identity_sha256 !== expectedIdentity) {
+    throw new Error("The benchmark report does not contain the frozen task identity exactly once.");
+  }
+  return tasks[0];
+}
+
+export function classifyBlockingCondition(report, task) {
+  if (!report || report.incomplete_reason !== null
+    || Number(report.trial_accounting?.expected) !== 1
+    || Number(report.trial_accounting?.observed) !== 1
+    || Number(report.trial_accounting?.missing) !== 0) {
+    return "missing_or_incomplete_report";
+  }
+  if (task?.validity === "infra_failed" || BLOCKING_FAILURES.has(task?.failure_category)) {
+    return "infra_failed_attempt";
+  }
+  const errorText = `${task?.last_error ?? ""}\n${task?.agent_exception?.message ?? ""}`;
+  if (task?.failure_category === "api_error" || PROVIDER_BLOCKER.test(errorText)) {
+    return "credential_or_provider_unavailable";
+  }
+  if (report.frozen_runtime_integrity === "failed" || report.docker_cleanup?.clean === false
+    || (Array.isArray(report.notes) && report.notes.some((note) => /Docker resources remained|postflight failed/iu.test(note)))) {
+    return "dirty_runtime_or_docker_cleanup";
+  }
+  return null;
+}
+
+function numberOrZero(value) {
+  const number = Number(value);
+  return Number.isFinite(number) && number >= 0 ? number : 0;
+}
+
+export function summarizePairedAttempt(context) {
+  const { manifest, stage, pair, arm, result } = context;
+  const report = result?.report;
+  if (!report || report.harness !== arm.harness
+    || report.provider !== manifest.model.provider
+    || report.model !== manifest.model.name
+    || report.reasoning_effort !== manifest.model.reasoning_effort
+    || report.dataset !== manifest.task_catalog.dataset
+    || report.runtime_archive_sha256 !== arm.runtime.archive_sha256) {
+    throw new Error("Benchmark report controls drifted from the paired preregistration.");
+  }
+  const expectedIdentity = taskSelectionIdentitySha256(
+    manifest.selection.selected_tasks[pair.task_index]
+  );
+  const task = exactTask(report, expectedIdentity);
+  const inputTokens = numberOrZero(task.input_tokens);
+  const cacheReadTokens = numberOrZero(task.cache_read_tokens ?? task.cache_tokens);
+  const outputTokens = numberOrZero(task.output_tokens);
+  return {
+    schemaVersion: 1,
+    experiment_id: manifest.experiment_id,
+    stage: stage.id,
+    task_index: pair.task_index,
+    task_identity_sha256: expectedIdentity,
+    repetition: pair.repetition,
+    arm: arm.id,
+    harness: arm.harness,
+    order: pair.arms.indexOf(arm.id) + 1,
+    valid: task.validity === "valid",
+    passed: task.validity === "valid" && task.verifier_outcome === "passed",
+    agent_outcome: task.agent_outcome ?? null,
+    verifier_outcome: task.verifier_outcome ?? null,
+    failure_category: task.failure_category ?? null,
+    blocking_condition: classifyBlockingCondition(report, task),
+    metrics: {
+      duration_ms: numberOrZero(task.duration_ms),
+      input_tokens: inputTokens,
+      cache_read_tokens: cacheReadTokens,
+      output_tokens: outputTokens,
+      reasoning_tokens: numberOrZero(task.reasoning_tokens),
+      uncached_tokens: Math.max(0, inputTokens - cacheReadTokens) + outputTokens,
+      commands_executed: numberOrZero(task.commands_executed),
+      cost_usd: Number.isFinite(Number(task.cost_usd)) && Number(task.cost_usd) > 0
+        ? Number(task.cost_usd) : null
+    },
+    trace: {
+      source_path: task.trace_path ?? null,
+      format: task.trace_format ?? null,
+      evidence_path: null
+    },
+    run_dir: result.runDir
+  };
+}
+
+async function copyTraceEvidence(summary, outputDir) {
+  if (!summary.trace.source_path) return summary;
+  const source = path.resolve(summary.run_dir, summary.trace.source_path);
+  try {
+    await readFile(source);
+  } catch {
+    return summary;
+  }
+  const extension = path.extname(source) || ".trace";
+  const relative = path.join(
+    "evidence",
+    `r${String(summary.repetition).padStart(2, "0")}-t${String(summary.task_index).padStart(3, "0")}`,
+    `${safePathPart(summary.arm)}${extension}`
+  );
+  const target = path.join(outputDir, relative);
+  await mkdir(path.dirname(target), { recursive: true });
+  await copyFile(source, target, constants.COPYFILE_EXCL);
+  return {
+    ...summary,
+    trace: { ...summary.trace, evidence_path: relative.replaceAll("\\", "/") }
+  };
+}
+
+function armArguments(manifest, pair, arm, archive, taskFile) {
+  const controls = manifest.controls;
+  return [
+    "--mode", "batch",
+    "--tasks-file", taskFile,
+    "--dataset", manifest.task_catalog.dataset,
+    "--harness", arm.harness,
+    "--provider", manifest.model.provider,
+    "--model", manifest.model.name,
+    "--reasoning-effort", manifest.model.reasoning_effort,
+    "--benchmark-class", controls.benchmark_class,
+    "--agent-profile", controls.agent_profile,
+    "--max-turns", String(controls.max_turns),
+    "--command-timeout-sec", String(controls.command_timeout_sec),
+    "--agent-timeout-grace-sec", String(controls.cleanup_grace_sec),
+    "--network", controls.network_mode,
+    "--execution-mode", controls.execution_mode,
+    "--write-scope", controls.write_scope,
+    "--managed-environment-mode", controls.managed_environment_mode,
+    "--harbor-topology", controls.harbor_topology,
+    "--concurrency", "1",
+    "--attempts", "1",
+    "--retries", "0",
+    "--timeout-leniency-multiplier", "1",
+    "--timeout-leniency-min-extra-sec", "0",
+    "--runtime-archive", archive,
+    "--runtime-layout", arm.runtime.layout,
+    ...(arm.runtime.version ? ["--runtime-version", arm.runtime.version] : []),
+    "--reuse-package",
+    "--expected-archive-sha256", arm.runtime.archive_sha256,
+    "--run-label", `paired-${safePathPart(manifest.experiment_id)}-r${pair.repetition}-t${pair.task_index}-${safePathPart(arm.id)}`
+  ];
+}
+
+async function ensureStableTaskFile(filePath, task) {
+  const expected = `${JSON.stringify([task], null, 2)}\n`;
+  try {
+    const existing = await readFile(filePath, "utf8");
+    if (existing !== expected) throw new Error(`Frozen task file drifted: ${filePath}`);
+  } catch (error) {
+    if (error?.code !== "ENOENT") throw error;
+    await writeExclusive(filePath, Buffer.from(expected));
+  }
+}
+
+async function executePair(context, pair) {
+  const { manifest, stage, outputDir, arms, preparedRuntime, deps, state } = context;
+  const label = `r${String(pair.repetition).padStart(2, "0")}-t${String(pair.task_index).padStart(3, "0")}`;
+  const taskFile = path.join(outputDir, "control", `${label}.task.json`);
+  await ensureStableTaskFile(taskFile, manifest.selection.selected_tasks[pair.task_index]);
+  const summaries = [];
+  for (const armId of pair.arms) {
+    if (state.blocking) break;
+    const arm = arms.get(armId);
+    const receiptDir = path.join(outputDir, "receipts", safePathPart(stage.id), label);
+    const startedPath = path.join(receiptDir, `${safePathPart(armId)}.started.json`);
+    const completedPath = path.join(receiptDir, `${safePathPart(armId)}.completed.json`);
+    if (await jsonIfPresent(startedPath) || await jsonIfPresent(completedPath)) {
+      throw new Error(`Attempt ${label}/${armId} was already consumed.`);
+    }
+    let dispatched = false;
+    const beforeHarborDispatch = async () => {
+      await writeExclusive(startedPath, {
+        schemaVersion: 1,
+        experiment_id: manifest.experiment_id,
+        stage: stage.id,
+        task_index: pair.task_index,
+        repetition: pair.repetition,
+        arm: armId,
+        runtime_archive_sha256: arm.runtime.archive_sha256,
+        started_at: new Date().toISOString()
+      });
+      dispatched = true;
+    };
+    const runner = deps.runArm ?? (async (args) => runTerminalBenchCli(args, {
+      env: {
+        ...process.env,
+        AGENT_CLI_TARBALL: [...arms.values()].find((item) => item.harness === "sigma")?.archive,
+        CODEX_CLI_TARBALL: [...arms.values()].find((item) => item.harness === "codex")?.archive,
+        SIGMA_BENCH_HARNESS: arm.harness
+      },
+      benchRootDir: path.join(outputDir, "runs"),
+      packageHarborRuntime: async () => preparedRuntime,
+      beforeHarborDispatch
+    }));
+    let result;
+    try {
+      result = await runner(
+        armArguments(manifest, pair, arm, arm.archive, taskFile),
+        { arm, pair, stage, beforeHarborDispatch }
+      );
+    } catch (error) {
+      if (dispatched) {
+        state.blocking = "missing_or_incomplete_report";
+        throw new Error(`Consumed attempt ${label}/${armId} failed after dispatch.`, { cause: error });
+      }
+      throw error;
+    }
+    if (!dispatched && deps.runArm) await beforeHarborDispatch();
+    let summary = summarizePairedAttempt({ manifest, stage, pair, arm, result });
+    summary = await copyTraceEvidence(summary, outputDir);
+    summary = {
+      ...summary,
+      run_dir: path.relative(outputDir, result.runDir).replaceAll("\\", "/"),
+      completed_at: new Date().toISOString()
+    };
+    await writeExclusive(completedPath, summary);
+    summaries.push(summary);
+    if (summary.blocking_condition) state.blocking = summary.blocking_condition;
+  }
+  return summaries;
+}
+
+async function concurrencyMap(items, maximum, worker, state) {
+  const results = new Array(items.length);
+  let cursor = 0;
+  async function consume() {
+    for (;;) {
+      if (state.blocking) return;
+      const index = cursor;
+      cursor += 1;
+      if (index >= items.length) return;
+      results[index] = await worker(items[index]);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(maximum, items.length) }, consume));
+  return results.filter(Boolean).flat();
+}
+
+async function prepareRuntime(outputDir, arms, deps) {
+  const sigmaArchive = [...arms.values()].find((arm) => arm.harness === "sigma")?.archive;
+  const packager = deps.packageHarborRuntime ?? packageHarborRuntime;
+  const result = await packager({
+    cwd: rootDir,
+    env: { ...process.env, ...(sigmaArchive ? { AGENT_CLI_TARBALL: sigmaArchive } : {}) },
+    stdoutPath: path.join(outputDir, "preflight", "harbor-runtime.stdout.log"),
+    stderrPath: path.join(outputDir, "preflight", "harbor-runtime.stderr.log"),
+    rawPath: path.join(outputDir, "preflight", "harbor-runtime.raw.log")
+  });
+  if (result.exitCode !== 0) throw new Error("Portable Harbor runtime packaging failed.");
+  return result;
+}
+
+export async function runPairedExperiment(argv = process.argv.slice(2), deps = {}) {
+  const runOptions = options(argv);
+  const bundle = await loadPairedExperiment(runOptions.preregistrationFile, runOptions.expectedSha256);
+  const { manifest } = bundle;
+  const outputDir = runOptions.outputDir
+    ?? path.join(rootDir, ".artifacts", "paired-experiments", safePathPart(manifest.experiment_id));
+  await mkdir(outputDir, { recursive: true });
+  const frozenPath = path.join(outputDir, "control", "preregistration.json");
+  const frozen = await jsonIfPresent(frozenPath);
+  if (frozen && frozen.consumption_identity_sha256 !== manifest.consumption_identity_sha256) {
+    throw new Error("Output directory belongs to a different paired experiment.");
+  }
+  if (!frozen) await writeExclusive(frozenPath, manifest);
+  const arms = armArchives(manifest, bundle.path);
+  await (deps.assertFrozenArchives ?? assertFrozenArchives)(arms);
+  await (deps.assertCredentials ?? assertCredentials)(arms, deps.env ?? process.env);
+  const completed = await completedPrefix(manifest, outputDir);
+  const stage = selectStage(manifest, completed, runOptions.stage);
+  const paths = stagePaths(outputDir, stage.id);
+  const preparedRuntime = await prepareRuntime(outputDir, arms, deps);
+  await writeExclusive(paths.started, {
+    schemaVersion: 1,
+    experiment_id: manifest.experiment_id,
+    consumption_identity_sha256: manifest.consumption_identity_sha256,
+    stage: stage.id,
+    started_at: new Date().toISOString(),
+    expected_pairs: stage.pairs.length
+  });
+  const state = { blocking: null };
+  let records = [];
+  try {
+    records = await concurrencyMap(
+      stage.pairs,
+      manifest.execution.concurrency,
+      (pair) => executePair({ manifest, stage, outputDir, arms, preparedRuntime, deps, state }, pair),
+      state
+    );
+  } catch (error) {
+    state.blocking ??= "missing_or_incomplete_report";
+    await writeExclusive(path.join(paths.root, "stage.stopped.json"), {
+      schemaVersion: 1,
+      experiment_id: manifest.experiment_id,
+      stage: stage.id,
+      blocking_condition: state.blocking,
+      stopped_at: new Date().toISOString(),
+      completed_attempts: records.length,
+      error: error instanceof Error ? error.message : String(error)
+    });
+    throw error;
+  }
+  if (state.blocking) {
+    await writeExclusive(path.join(paths.root, "stage.stopped.json"), {
+      schemaVersion: 1,
+      experiment_id: manifest.experiment_id,
+      stage: stage.id,
+      blocking_condition: state.blocking,
+      stopped_at: new Date().toISOString(),
+      completed_attempts: records.length
+    });
+    return { outputDir, stage: stage.id, status: "stopped", blocking: state.blocking, records };
+  }
+  if (records.length !== stage.pairs.length * manifest.arms.length) {
+    throw new Error(`Stage ${stage.id} did not produce every paired attempt.`);
+  }
+  const receipt = {
+    schemaVersion: 1,
+    experiment_id: manifest.experiment_id,
+    consumption_identity_sha256: manifest.consumption_identity_sha256,
+    stage: stage.id,
+    status: "complete",
+    completed_at: new Date().toISOString(),
+    attempts: records.length,
+    records_sha256: pairedSha256(JSON.stringify(records))
+  };
+  await writeExclusive(paths.completed, receipt);
+  return { outputDir, stage: stage.id, status: "complete", records, receipt };
+}
+
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) runPairedExperiment().then((result) => {
+  process.stdout.write(`${JSON.stringify({
+    output: result.outputDir,
+    stage: result.stage,
+    status: result.status,
+    blocking_condition: result.blocking ?? null,
+    attempts: result.records.length
+  })}\n`);
+  if (result.status === "stopped") process.exitCode = 2;
+}).catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/bench-paired-experiment.mjs
+++ b/scripts/bench-paired-experiment.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { createHash } from "node:crypto";
-import { constants } from "node:fs";
+import { appendFileSync, constants } from "node:fs";
 import { copyFile, mkdir, open, readFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -361,6 +361,7 @@ async function executePair(context, pair) {
     if (state.blocking) break;
     const arm = arms.get(armId);
     const receiptDir = path.join(outputDir, "receipts", safePathPart(stage.id), label);
+    const progressDir = path.join(outputDir, "progress", safePathPart(stage.id), label);
     const startedPath = path.join(receiptDir, `${safePathPart(armId)}.started.json`);
     const completedPath = path.join(receiptDir, `${safePathPart(armId)}.completed.json`);
     if (await jsonIfPresent(startedPath) || await jsonIfPresent(completedPath)) {
@@ -380,17 +381,22 @@ async function executePair(context, pair) {
       });
       dispatched = true;
     };
-    const runner = deps.runArm ?? (async (args) => runTerminalBenchCli(args, {
-      env: {
-        ...process.env,
-        AGENT_CLI_TARBALL: [...arms.values()].find((item) => item.harness === "sigma")?.archive,
-        CODEX_CLI_TARBALL: [...arms.values()].find((item) => item.harness === "codex")?.archive,
-        SIGMA_BENCH_HARNESS: arm.harness
-      },
-      benchRootDir: path.join(outputDir, "runs"),
-      packageHarborRuntime: async () => preparedRuntime,
-      beforeHarborDispatch
-    }));
+    const runner = deps.runArm ?? (async (args) => {
+      await mkdir(progressDir, { recursive: true });
+      const progressPath = path.join(progressDir, `${safePathPart(armId)}.log`);
+      return runTerminalBenchCli(args, {
+        env: {
+          ...process.env,
+          AGENT_CLI_TARBALL: [...arms.values()].find((item) => item.harness === "sigma")?.archive,
+          CODEX_CLI_TARBALL: [...arms.values()].find((item) => item.harness === "codex")?.archive,
+          SIGMA_BENCH_HARNESS: arm.harness
+        },
+        benchRootDir: path.join(outputDir, "runs"),
+        packageHarborRuntime: async () => preparedRuntime,
+        beforeHarborDispatch,
+        writeOutput: (text) => appendFileSync(progressPath, text, "utf8")
+      });
+    });
     let result;
     try {
       result = await runner(
@@ -600,16 +606,23 @@ export async function runPairedExperiment(argv = process.argv.slice(2), deps = {
 }
 
 const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
-if (isMain) runPairedExperiment().then((result) => {
-  process.stdout.write(`${JSON.stringify({
-    output: result.outputDir,
-    stage: result.stage,
-    status: result.status,
-    blocking_condition: result.blocking ?? null,
-    attempts: result.records.length
-  })}\n`);
-  if (result.status === "stopped") process.exitCode = 2;
-}).catch((error) => {
-  process.stderr.write(`${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
-  process.exitCode = 1;
-});
+if (isMain) {
+  for (const stream of [process.stdout, process.stderr]) {
+    stream.on("error", (error) => {
+      if (error?.code !== "EPIPE") throw error;
+    });
+  }
+  runPairedExperiment().then((result) => {
+    process.stdout.write(`${JSON.stringify({
+      output: result.outputDir,
+      stage: result.stage,
+      status: result.status,
+      blocking_condition: result.blocking ?? null,
+      attempts: result.records.length
+    })}\n`);
+    if (result.status === "stopped") process.exitCode = 2;
+  }).catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/bench-paired-experiment.mjs
+++ b/scripts/bench-paired-experiment.mjs
@@ -6,8 +6,14 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  buildHarborTimeoutProbeConfig,
+  harborEnvForRun,
+  harborPythonCommand,
+  harborTaskExecutionIdentitySha256,
   packageHarborRuntime,
+  parseHarborTimeoutProbe,
   rootDir,
+  runProcess,
   safePathPart,
   taskSelectionIdentitySha256
 } from "./bench-common.mjs";
@@ -66,6 +72,17 @@ async function jsonIfPresent(filePath) {
   } catch (error) {
     if (error?.code === "ENOENT") return null;
     throw error;
+  }
+}
+
+async function ensureStableJson(filePath, value) {
+  const expected = `${JSON.stringify(value, null, 2)}\n`;
+  try {
+    const existing = await readFile(filePath, "utf8");
+    if (existing !== expected) throw new Error(`Frozen control file drifted: ${filePath}`);
+  } catch (error) {
+    if (error?.code !== "ENOENT") throw error;
+    await writeExclusive(filePath, Buffer.from(expected));
   }
 }
 
@@ -432,6 +449,75 @@ async function prepareRuntime(outputDir, arms, deps) {
   return result;
 }
 
+async function prefetchPairedTasks({ manifest, stage, outputDir, arms }) {
+  const arm = [...arms.values()].find((candidate) => candidate.harness === "sigma")
+    ?? [...arms.values()][0];
+  if (!arm) throw new Error("Paired task prefetch requires at least one harness arm.");
+  const preflightDir = path.join(outputDir, "preflight");
+  const prefetchRunDir = path.join(preflightDir, "task-cache");
+  const env = harborEnvForRun(prefetchRunDir, process.env, {
+    harness: arm.harness,
+    runtimeArchive: arm.archive,
+    runtimeVersion: arm.runtime.version
+  });
+  const config = buildHarborTimeoutProbeConfig({
+    mode: "batch",
+    tasks: manifest.selection.selected_tasks,
+    harness: arm.harness,
+    provider: manifest.model.provider,
+    model: manifest.model.name,
+    reasoningEffort: manifest.model.reasoning_effort,
+    agentProfile: manifest.controls.agent_profile,
+    maxTurns: manifest.controls.max_turns,
+    commandTimeoutSec: manifest.controls.command_timeout_sec,
+    networkMode: manifest.controls.network_mode,
+    executionMode: manifest.controls.execution_mode,
+    writeScope: manifest.controls.write_scope,
+    managedEnvironmentMode: manifest.controls.managed_environment_mode,
+    harborTopology: manifest.controls.harbor_topology,
+    attemptsPerTask: 1,
+    retries: 0,
+    nConcurrentTrials: 1,
+    expectedArchiveSha256: arm.runtime.archive_sha256,
+    runtimeArchive: arm.archive,
+    runtimeLayout: arm.runtime.layout,
+    runtimeVersion: arm.runtime.version,
+    env
+  }, path.join(prefetchRunDir, "jobs"));
+  const configPath = path.join(preflightDir, "task-cache.config.json");
+  await ensureStableJson(configPath, config);
+  const label = `task-cache-${safePathPart(stage.id)}`;
+  const result = await runProcess(
+    harborPythonCommand(env),
+    [path.join(rootDir, "scripts", "probe-harbor-timeouts.py"), configPath],
+    {
+      cwd: rootDir,
+      env,
+      stdoutPath: path.join(preflightDir, `${label}.stdout.log`),
+      stderrPath: path.join(preflightDir, `${label}.stderr.log`),
+      rawPath: path.join(preflightDir, `${label}.raw.log`)
+    }
+  );
+  if (result.exitCode !== 0) {
+    throw new Error(`Harbor task-cache prefetch failed before stage ${stage.id}.`);
+  }
+  const probe = parseHarborTimeoutProbe(result.stdout);
+  const expected = manifest.selection.selected_tasks
+    .map((task) => harborTaskExecutionIdentitySha256(task)).sort();
+  const observed = (Array.isArray(probe?.resolved_tasks) ? probe.resolved_tasks : [])
+    .map((task) => harborTaskExecutionIdentitySha256(task)).sort();
+  if (JSON.stringify(observed) !== JSON.stringify(expected)) {
+    throw new Error("Harbor task-cache prefetch did not resolve the frozen selected task set exactly.");
+  }
+  await ensureStableJson(path.join(preflightDir, `${label}.completed.json`), {
+    schemaVersion: 1,
+    experiment_id: manifest.experiment_id,
+    stage: stage.id,
+    task_count: observed.length,
+    task_execution_identities: observed
+  });
+}
+
 export async function runPairedExperiment(argv = process.argv.slice(2), deps = {}) {
   const runOptions = options(argv);
   const bundle = await loadPairedExperiment(runOptions.preregistrationFile, runOptions.expectedSha256);
@@ -452,6 +538,9 @@ export async function runPairedExperiment(argv = process.argv.slice(2), deps = {
   const stage = selectStage(manifest, completed, runOptions.stage);
   const paths = stagePaths(outputDir, stage.id);
   const preparedRuntime = await prepareRuntime(outputDir, arms, deps);
+  await (deps.prefetchTasks ?? prefetchPairedTasks)({
+    manifest, stage, outputDir, arms, preparedRuntime
+  });
   await writeExclusive(paths.started, {
     schemaVersion: 1,
     experiment_id: manifest.experiment_id,

--- a/scripts/bench-paired-preregistration.mjs
+++ b/scripts/bench-paired-preregistration.mjs
@@ -1,0 +1,401 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { constants } from "node:fs";
+import { open, readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  assertUniqueHarborTaskExecutionIdentities,
+  taskSelectionIdentity,
+  taskSelectionIdentitySha256,
+  validateExternalTaskRecord
+} from "./harbor-task-identity.mjs";
+
+const SHA256 = /^[a-f0-9]{64}$/u;
+const GIT_COMMIT = /^[a-f0-9]{40}$/u;
+const IDENTIFIER = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/u;
+const REASONING = new Set(["auto", "none", "low", "medium", "high", "xhigh", "max"]);
+
+function object(value, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object.`);
+  }
+  return value;
+}
+
+function exact(value, keys, label) {
+  const expected = new Set(keys);
+  const missing = keys.filter((key) => !Object.hasOwn(value, key));
+  const unknown = Object.keys(value).filter((key) => !expected.has(key));
+  if (missing.length > 0 || unknown.length > 0) {
+    throw new Error(`${label} has an invalid field set (missing: ${missing.join(", ") || "none"}; unknown: ${unknown.join(", ") || "none"}).`);
+  }
+}
+
+function string(value, label, expression = null) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${label} must be a non-empty string.`);
+  }
+  const text = value.trim();
+  if (expression && !expression.test(text)) throw new Error(`${label} has an invalid format.`);
+  return text;
+}
+
+function digest(value, label, expression = SHA256) {
+  return string(value, label, expression).toLowerCase();
+}
+
+function positiveInteger(value, label, maximum = Number.MAX_SAFE_INTEGER) {
+  if (!Number.isSafeInteger(value) || value < 1 || value > maximum) {
+    throw new Error(`${label} must be an integer from 1 to ${maximum}.`);
+  }
+  return value;
+}
+
+function canonical(value) {
+  if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonical(value[key])}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+export function pairedSha256(value) {
+  return createHash("sha256").update(Buffer.isBuffer(value) ? value : String(value)).digest("hex");
+}
+
+export function canonicalPairedJson(value) {
+  return canonical(value);
+}
+
+function normalizedRuntime(value, harness, label) {
+  const runtime = object(value, label);
+  exact(runtime, ["archive_path", "archive_sha256", "version", "layout"], label);
+  const archivePath = string(runtime.archive_path, `${label}.archive_path`);
+  if (path.isAbsolute(archivePath)) {
+    throw new Error(`${label}.archive_path must be relative to the preregistration.`);
+  }
+  const version = runtime.version === null ? null : string(runtime.version, `${label}.version`);
+  const layouts = harness === "codex" ? ["npm-linux-x64", "portable-root"] : ["sigma-agent-cli"];
+  const layout = string(runtime.layout, `${label}.layout`);
+  if (!layouts.includes(layout)) throw new Error(`${label}.layout is not supported for ${harness}.`);
+  if (harness === "codex" && version === null) throw new Error(`${label}.version is required for Codex.`);
+  return {
+    archive_path: archivePath.replaceAll("\\", "/"),
+    archive_sha256: digest(runtime.archive_sha256, `${label}.archive_sha256`),
+    version,
+    layout
+  };
+}
+
+function normalizedArms(value) {
+  if (!Array.isArray(value) || value.length !== 2) throw new Error("arms must contain exactly two entries.");
+  const arms = value.map((item, index) => {
+    const arm = object(item, `arms[${index}]`);
+    exact(arm, ["id", "harness", "runtime"], `arms[${index}]`);
+    const harness = string(arm.harness, `arms[${index}].harness`);
+    if (!["sigma", "codex"].includes(harness)) throw new Error(`arms[${index}].harness is unsupported.`);
+    return {
+      id: string(arm.id, `arms[${index}].id`, IDENTIFIER),
+      harness,
+      runtime: normalizedRuntime(arm.runtime, harness, `arms[${index}].runtime`)
+    };
+  });
+  if (new Set(arms.map((arm) => arm.id)).size !== 2) throw new Error("arm ids must be unique.");
+  return arms;
+}
+
+function normalizedModel(value) {
+  const model = object(value, "model");
+  exact(model, ["provider", "name", "reasoning_effort"], "model");
+  const reasoning = string(model.reasoning_effort, "model.reasoning_effort");
+  if (!REASONING.has(reasoning)) throw new Error("model.reasoning_effort is invalid.");
+  return {
+    provider: string(model.provider, "model.provider"),
+    name: string(model.name, "model.name"),
+    reasoning_effort: reasoning
+  };
+}
+
+function catalogIdentity(tasks) {
+  return tasks.map((task) => taskSelectionIdentity(task))
+    .sort((left, right) => canonical(left).localeCompare(canonical(right)));
+}
+
+export function pairedTaskCatalogSha256(tasks) {
+  return pairedSha256(canonical(catalogIdentity(tasks)));
+}
+
+function normalizedCatalog(value, baseDir) {
+  const catalog = object(value, "task_catalog");
+  exact(catalog, ["dataset", "revision", "tasks"], "task_catalog");
+  if (!Array.isArray(catalog.tasks) || catalog.tasks.length < 2) {
+    throw new Error("task_catalog.tasks must contain at least two tasks.");
+  }
+  const revision = digest(catalog.revision, "task_catalog.revision", GIT_COMMIT);
+  const tasks = catalog.tasks.map((task, index) => validateExternalTaskRecord(task, index, baseDir));
+  assertUniqueHarborTaskExecutionIdentities(tasks);
+  if (tasks.some((task) => task.git_commit_id !== revision)) {
+    throw new Error("Every catalog task must be pinned to task_catalog.revision.");
+  }
+  return {
+    dataset: string(catalog.dataset, "task_catalog.dataset"),
+    revision,
+    tasks,
+    task_count: tasks.length,
+    task_catalog_sha256: pairedTaskCatalogSha256(tasks)
+  };
+}
+
+function normalizedSelection(value, catalog) {
+  const selection = object(value, "selection");
+  exact(selection, ["method", "seed", "sample_size"], "selection");
+  if (selection.method !== "sha256_rank_v1") throw new Error("selection.method must be sha256_rank_v1.");
+  const seed = string(selection.seed, "selection.seed");
+  const sampleSize = positiveInteger(selection.sample_size, "selection.sample_size", catalog.tasks.length);
+  const ranked = catalog.tasks.map((task) => {
+    const identity = taskSelectionIdentitySha256(task);
+    return { task, identity, rank: pairedSha256(`${seed}\0${identity}`) };
+  }).sort((left, right) => left.rank.localeCompare(right.rank) || left.identity.localeCompare(right.identity));
+  const tasks = ranked.slice(0, sampleSize).map((item) => item.task);
+  return {
+    method: "sha256_rank_v1",
+    seed,
+    sample_size: sampleSize,
+    selected_tasks: tasks,
+    selected_task_identity_sha256: pairedSha256(canonical(tasks.map(taskSelectionIdentity)))
+  };
+}
+
+function enumValue(value, allowed, label) {
+  const text = string(value, label);
+  if (!allowed.includes(text)) throw new Error(`${label} must be one of: ${allowed.join(", ")}.`);
+  return text;
+}
+
+function normalizedControls(value) {
+  const controls = object(value, "controls");
+  exact(controls, [
+    "benchmark_class", "agent_profile", "max_turns", "command_timeout_sec",
+    "cleanup_grace_sec", "network_mode", "execution_mode", "write_scope",
+    "managed_environment_mode", "harbor_topology"
+  ], "controls");
+  const normalized = {
+    benchmark_class: enumValue(controls.benchmark_class, ["standard"], "controls.benchmark_class"),
+    agent_profile: enumValue(controls.agent_profile, ["standard", "strict"], "controls.agent_profile"),
+    max_turns: positiveInteger(controls.max_turns, "controls.max_turns", 10_000),
+    command_timeout_sec: positiveInteger(controls.command_timeout_sec, "controls.command_timeout_sec", 600),
+    cleanup_grace_sec: positiveInteger(controls.cleanup_grace_sec, "controls.cleanup_grace_sec", 3_600),
+    network_mode: enumValue(controls.network_mode, ["none", "loopback", "full"], "controls.network_mode"),
+    execution_mode: enumValue(controls.execution_mode, ["sandboxed", "container"], "controls.execution_mode"),
+    write_scope: enumValue(controls.write_scope, ["auto", "workspace", "enclosing-container"], "controls.write_scope"),
+    managed_environment_mode: enumValue(controls.managed_environment_mode, ["disabled", "required"], "controls.managed_environment_mode"),
+    harbor_topology: enumValue(controls.harbor_topology, ["main_only", "managed_three_role"], "controls.harbor_topology")
+  };
+  if (normalized.managed_environment_mode === "required"
+    && (normalized.execution_mode !== "container" || normalized.network_mode !== "full"
+      || normalized.harbor_topology !== "managed_three_role")) {
+    throw new Error("Required managed execution needs container/full/managed_three_role controls.");
+  }
+  if (normalized.harbor_topology === "managed_three_role"
+    && normalized.managed_environment_mode !== "required") {
+    throw new Error("managed_three_role requires managed_environment_mode=required.");
+  }
+  return normalized;
+}
+
+function normalizedRamp(value, sampleSize) {
+  if (!Array.isArray(value) || value.length === 0) throw new Error("execution.ramp_task_counts must be non-empty.");
+  const counts = value.map((item, index) => positiveInteger(
+    item, `execution.ramp_task_counts[${index}]`, sampleSize
+  ));
+  if (counts.some((item, index) => index > 0 && item <= counts[index - 1])
+    || counts.at(-1) !== sampleSize) {
+    throw new Error("execution.ramp_task_counts must be strictly increasing and end at sample_size.");
+  }
+  return counts;
+}
+
+function pairedOrder(arms, taskIndex, repetition) {
+  return (taskIndex + repetition) % 2 === 0
+    ? [arms[0].id, arms[1].id]
+    : [arms[1].id, arms[0].id];
+}
+
+function derivedStages(arms, sampleSize, repetitions, ramp) {
+  const stages = [];
+  let previous = 0;
+  for (const count of ramp) {
+    stages.push({
+      id: `r1-t${String(previous + 1).padStart(2, "0")}-${String(count).padStart(2, "0")}`,
+      pairs: Array.from({ length: count - previous }, (_unused, offset) => {
+        const taskIndex = previous + offset;
+        return { task_index: taskIndex, repetition: 1, arms: pairedOrder(arms, taskIndex, 1) };
+      })
+    });
+    previous = count;
+  }
+  for (let repetition = 2; repetition <= repetitions; repetition += 1) {
+    stages.push({
+      id: `r${repetition}-all`,
+      pairs: Array.from({ length: sampleSize }, (_unused, taskIndex) => ({
+        task_index: taskIndex,
+        repetition,
+        arms: pairedOrder(arms, taskIndex, repetition)
+      }))
+    });
+  }
+  return stages;
+}
+
+function normalizedExecution(value, arms, selection) {
+  const execution = object(value, "execution");
+  exact(execution, ["repetitions", "concurrency", "retries", "ramp_task_counts"], "execution");
+  const repetitions = positiveInteger(execution.repetitions, "execution.repetitions", 100);
+  const concurrency = positiveInteger(execution.concurrency, "execution.concurrency", 64);
+  if (execution.retries !== 0) throw new Error("Paired experiments require retries=0.");
+  const ramp = normalizedRamp(execution.ramp_task_counts, selection.sample_size);
+  return {
+    repetitions,
+    concurrency,
+    retries: 0,
+    ramp_task_counts: ramp,
+    stages: derivedStages(arms, selection.sample_size, repetitions, ramp),
+    expected_attempts: selection.sample_size * repetitions * arms.length
+  };
+}
+
+function payloadFromDraft(draft, baseDir) {
+  const input = object(draft, "paired experiment draft");
+  exact(input, [
+    "experiment_id", "arms", "model", "task_catalog", "selection", "controls", "execution"
+  ], "paired experiment draft");
+  const arms = normalizedArms(input.arms);
+  const catalog = normalizedCatalog(input.task_catalog, baseDir);
+  const selection = normalizedSelection(input.selection, catalog);
+  return {
+    schemaVersion: 1,
+    kind: "PairedHarnessExperiment",
+    experiment_id: string(input.experiment_id, "experiment_id", IDENTIFIER),
+    arms,
+    model: normalizedModel(input.model),
+    task_catalog: catalog,
+    selection,
+    controls: normalizedControls(input.controls),
+    execution: normalizedExecution(input.execution, arms, selection),
+    stop_loss: {
+      score_independent: true,
+      verifier_feedback_to_solver: false,
+      retry_consumed_attempts: false,
+      blocking_conditions: [
+        "control_drift", "missing_or_incomplete_report", "infra_failed_attempt",
+        "credential_or_provider_unavailable", "dirty_runtime_or_docker_cleanup"
+      ]
+    }
+  };
+}
+
+export function pairedExperimentPreregistration(draft, options = {}) {
+  const payload = payloadFromDraft(draft, path.resolve(options.baseDir ?? process.cwd()));
+  return {
+    ...payload,
+    consumption_identity_sha256: pairedSha256(canonical(payload))
+  };
+}
+
+export function validatePairedExperiment(value, options = {}) {
+  const manifest = object(value, "paired experiment");
+  exact(manifest, [
+    "schemaVersion", "kind", "experiment_id", "arms", "model", "task_catalog", "selection",
+    "controls", "execution", "stop_loss", "consumption_identity_sha256"
+  ], "paired experiment");
+  if (manifest.schemaVersion !== 1 || manifest.kind !== "PairedHarnessExperiment") {
+    throw new Error("Unsupported paired experiment schema.");
+  }
+  const draft = {
+    experiment_id: manifest.experiment_id,
+    arms: manifest.arms,
+    model: manifest.model,
+    task_catalog: {
+      dataset: manifest.task_catalog?.dataset,
+      revision: manifest.task_catalog?.revision,
+      tasks: manifest.task_catalog?.tasks
+    },
+    selection: {
+      method: manifest.selection?.method,
+      seed: manifest.selection?.seed,
+      sample_size: manifest.selection?.sample_size
+    },
+    controls: manifest.controls,
+    execution: {
+      repetitions: manifest.execution?.repetitions,
+      concurrency: manifest.execution?.concurrency,
+      retries: manifest.execution?.retries,
+      ramp_task_counts: manifest.execution?.ramp_task_counts
+    }
+  };
+  const expected = pairedExperimentPreregistration(draft, options);
+  if (canonical(expected) !== canonical(manifest)) {
+    throw new Error("Paired experiment derived fields or consumption identity are stale.");
+  }
+  return expected;
+}
+
+export async function loadPairedExperiment(filePath, expectedSha256) {
+  const resolved = path.resolve(filePath);
+  const bytes = await readFile(resolved);
+  if (digest(expectedSha256, "--expected-preregistration-sha256") !== pairedSha256(bytes)) {
+    throw new Error("Paired preregistration file does not match its expected SHA-256.");
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(bytes.toString("utf8"));
+  } catch (error) {
+    throw new Error("Paired preregistration is not valid JSON.", { cause: error });
+  }
+  return {
+    manifest: validatePairedExperiment(parsed, { baseDir: path.dirname(resolved) }),
+    path: resolved,
+    sha256: pairedSha256(bytes)
+  };
+}
+
+async function writePreregistration(draftPath, outputPath) {
+  const draftFile = path.resolve(string(draftPath, "--draft"));
+  const outputFile = path.resolve(string(outputPath, "--output"));
+  const draft = JSON.parse(await readFile(draftFile, "utf8"));
+  const manifest = pairedExperimentPreregistration(draft, { baseDir: path.dirname(draftFile) });
+  const bytes = Buffer.from(`${JSON.stringify(manifest, null, 2)}\n`);
+  const handle = await open(outputFile, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY, 0o600);
+  try {
+    await handle.writeFile(bytes);
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+  return { path: outputFile, sha256: pairedSha256(bytes), manifest };
+}
+
+function cliOptions(argv) {
+  const flags = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const name = argv[index];
+    if (!["--draft", "--output"].includes(name)) throw new Error(`Unsupported option: ${name}`);
+    const value = argv[index + 1];
+    if (!value || value.startsWith("--")) throw new Error(`${name} requires a value.`);
+    flags[name.slice(2)] = value;
+    index += 1;
+  }
+  return flags;
+}
+
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) {
+  const flags = cliOptions(process.argv.slice(2));
+  writePreregistration(flags.draft, flags.output).then((result) => {
+    process.stdout.write(`${JSON.stringify({ path: result.path, sha256: result.sha256 })}\n`);
+  }).catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/bench-terminal-bench.mjs
+++ b/scripts/bench-terminal-bench.mjs
@@ -204,6 +204,14 @@ export async function runTerminalBenchCli(argv, deps = {}) {
 }
 
 async function runTerminalBenchCliImpl(argv, deps, signal) {
+  const writeOutput = deps.writeOutput ?? ((text) => process.stdout.write(text));
+  const writeProgress = (text) => {
+    try {
+      writeOutput(text);
+    } catch (error) {
+      if (error?.code !== "EPIPE") throw error;
+    }
+  };
   const runtimeEnv = deps.env ?? process.env;
   loadDotEnv(undefined, runtimeEnv);
   const options = resolveRunOptions(argv, runtimeEnv);
@@ -280,12 +288,12 @@ async function runTerminalBenchCliImpl(argv, deps, signal) {
   await writeRunFiles(runDir, config, harborCommand, harborArgs, env);
 
   if (options.reusePackage) {
-    process.stdout.write(`Reusing SHA-pinned ${options.harness} runtime archive...\n`);
+    writeProgress(`Reusing SHA-pinned ${options.harness} runtime archive...\n`);
     await writeFile(path.join(runDir, "package.stdout.log"), "Reused existing SHA-pinned archive.\n", "utf8");
     await writeFile(path.join(runDir, "package.stderr.log"), "", "utf8");
     await writeFile(path.join(runDir, "package.raw.log"), "package_reused: true\n", "utf8");
   } else {
-    process.stdout.write(`Packaging Sigma agent CLI for Terminal-Bench...\n`);
+    writeProgress(`Packaging Sigma agent CLI for Terminal-Bench...\n`);
     const packageResult = await packager({
       cwd: rootDir,
       env: runtimeEnv,
@@ -329,7 +337,7 @@ async function runTerminalBenchCliImpl(argv, deps, signal) {
     );
   }
 
-  process.stdout.write(`Packaging portable Harbor runtime...\n`);
+  writeProgress(`Packaging portable Harbor runtime...\n`);
   const harborRuntimeResult = await harborRuntimePackager({
     cwd: rootDir,
     env: runtimeEnv,
@@ -405,7 +413,7 @@ async function runTerminalBenchCliImpl(argv, deps, signal) {
   };
   await writeJson(path.join(runDir, "config.json"), config);
 
-  process.stdout.write(`Inspecting Harbor CLI support...\n`);
+  writeProgress(`Inspecting Harbor CLI support...\n`);
   const versionResult = await runner(harborCommand, ["--version"], {
     cwd: rootDir,
     env,
@@ -443,7 +451,7 @@ async function runTerminalBenchCliImpl(argv, deps, signal) {
   let timeoutProbe = null;
   let timeoutPlan;
   if (options.mode !== "smoke") {
-    process.stdout.write(`Inspecting selected task timeout metadata...\n`);
+    writeProgress(`Inspecting selected task timeout metadata...\n`);
     const timeoutProbeJobsDir = path.join(runDir, "harbor-timeout-probe-jobs");
     const timeoutProbeConfig = buildHarborTimeoutProbeConfig(
       {
@@ -674,7 +682,7 @@ async function runTerminalBenchCliImpl(argv, deps, signal) {
     launchSlots,
     options.nConcurrentTrials,
     async (slot) => {
-      process.stdout.write(`Running Harbor benchmark slot ${slot.runSlot}: ${commandText(harborCommand, slot.args)}\n`);
+      writeProgress(`Running Harbor benchmark slot ${slot.runSlot}: ${commandText(harborCommand, slot.args)}\n`);
       const stdoutPath = path.join(runDir, `harbor-${slot.runSlot}.stdout.log`);
       const stderrPath = path.join(runDir, `harbor-${slot.runSlot}.stderr.log`);
       const rawPath = path.join(runDir, `result-${slot.runSlot}.raw.log`);
@@ -759,8 +767,8 @@ async function runTerminalBenchCliImpl(argv, deps, signal) {
 
   const report = await generateBenchReport(runDir);
 
-  process.stdout.write(`Benchmark artifacts: ${runDir}\n`);
-  process.stdout.write(`Report: ${path.join(runDir, "report.md")}\n`);
+  writeProgress(`Benchmark artifacts: ${runDir}\n`);
+  writeProgress(`Report: ${path.join(runDir, "report.md")}\n`);
   const exitCode = report?.status === "passed"
     ? cleanupAfter.clean ? 0 : 1
     : effectiveExitCode && effectiveExitCode !== 0
@@ -771,6 +779,11 @@ async function runTerminalBenchCliImpl(argv, deps, signal) {
 
 const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
 if (isMain) {
+  for (const stream of [process.stdout, process.stderr]) {
+    stream.on("error", (error) => {
+      if (error?.code !== "EPIPE") throw error;
+    });
+  }
   try {
     const result = await runTerminalBenchCli(process.argv.slice(2));
     process.exitCode = result.exitCode;

--- a/scripts/bench-terminal-bench.mjs
+++ b/scripts/bench-terminal-bench.mjs
@@ -69,11 +69,15 @@ Selection:
   --dataset <name>                  Harbor dataset identifier
 
 Agent:
+  --harness <sigma|codex>           Harness implementation (default: sigma)
   --provider <id>                   Model provider (default: deepseek)
   --model <id>                      Provider model
   --reasoning-effort <level>        auto, none, low, medium, high, xhigh, or max
   --agent-profile <standard|strict> Sigma profile (default: standard)
   --max-turns <count>               Hard model-turn limit
+  --runtime-archive <path>          Immutable harness runtime archive
+  --runtime-version <version>       Runtime version (required for Codex)
+  --runtime-layout <layout>         sigma-agent-cli, npm-linux-x64, or portable-root
 
 Execution:
   --concurrency <count>             Concurrent trials
@@ -200,8 +204,9 @@ export async function runTerminalBenchCli(argv, deps = {}) {
 }
 
 async function runTerminalBenchCliImpl(argv, deps, signal) {
-  loadDotEnv();
-  const options = resolveRunOptions(argv);
+  const runtimeEnv = deps.env ?? process.env;
+  loadDotEnv(undefined, runtimeEnv);
+  const options = resolveRunOptions(argv, runtimeEnv);
   if (options.mode === "task" && !options.taskId) {
     throw new Error("Task mode requires --task-id <task-id>.");
   }
@@ -209,11 +214,11 @@ async function runTerminalBenchCliImpl(argv, deps, signal) {
     throw new Error("Batch mode requires at least one externally selected task.");
   }
 
-  const baseRunId = makeRunId(new Date(), options.provider, options.model);
+  const baseRunId = makeRunId(new Date(), options.provider, `${options.model ?? "default"}-${options.harness}`);
   const runId = boundedBenchmarkRunId(baseRunId, options.runLabel);
-  const runDir = path.join(benchRootDir, runId);
+  const runDir = path.join(path.resolve(deps.benchRootDir ?? benchRootDir), runId);
   const jobsDir = deps.harborJobsDir ?? portableHarborJobsDir(runDir);
-  const env = harborEnvForRun(runDir);
+  const env = harborEnvForRun(runDir, runtimeEnv, options);
   const startedAt = new Date().toISOString();
   const baseRunner = deps.runProcess ?? runProcess;
   const runner = (command, args, runnerOptions = {}) => baseRunner(command, args, {
@@ -234,6 +239,7 @@ async function runTerminalBenchCliImpl(argv, deps, signal) {
     started_at: startedAt,
     finished_at: null,
     mode: options.mode,
+    harness: options.harness,
     benchmark_class: options.benchmarkClass,
     agent_profile: options.agentProfile,
     evaluation_lane: evaluationLane(options.agentProfile),
@@ -253,8 +259,13 @@ async function runTerminalBenchCliImpl(argv, deps, signal) {
     tasks_file_sha256: options.tasksFileSha256,
     package_reused: options.reusePackage,
     expected_agent_cli_sha256: options.expectedArchiveSha256,
+    expected_runtime_archive_sha256: options.expectedArchiveSha256,
+    runtime_archive: options.runtimeArchive,
+    runtime_archive_sha256: null,
+    runtime_layout: options.runtimeLayout,
+    runtime_version: options.runtimeVersion,
     agent_cli_sha256: null,
-    agent_cli_tarball: env.AGENT_CLI_TARBALL,
+    agent_cli_tarball: options.harness === "sigma" ? options.runtimeArchive : null,
     harbor_jobs_dir: jobsDir,
     harbor_command: harborCommand,
     harbor_command_source: harborCommandInfo.source,
@@ -269,7 +280,7 @@ async function runTerminalBenchCliImpl(argv, deps, signal) {
   await writeRunFiles(runDir, config, harborCommand, harborArgs, env);
 
   if (options.reusePackage) {
-    process.stdout.write(`Reusing SHA-pinned Sigma agent CLI archive...\n`);
+    process.stdout.write(`Reusing SHA-pinned ${options.harness} runtime archive...\n`);
     await writeFile(path.join(runDir, "package.stdout.log"), "Reused existing SHA-pinned archive.\n", "utf8");
     await writeFile(path.join(runDir, "package.stderr.log"), "", "utf8");
     await writeFile(path.join(runDir, "package.raw.log"), "package_reused: true\n", "utf8");
@@ -277,7 +288,7 @@ async function runTerminalBenchCliImpl(argv, deps, signal) {
     process.stdout.write(`Packaging Sigma agent CLI for Terminal-Bench...\n`);
     const packageResult = await packager({
       cwd: rootDir,
-      env: process.env,
+      env: runtimeEnv,
       stdoutPath: path.join(runDir, "package.stdout.log"),
       stderrPath: path.join(runDir, "package.stderr.log"),
       rawPath: path.join(runDir, "package.raw.log")
@@ -292,23 +303,28 @@ async function runTerminalBenchCliImpl(argv, deps, signal) {
     }
   }
 
-  if (!existsSync(env.AGENT_CLI_TARBALL)) {
+  const runtimeArchive = options.runtimeArchive;
+  if (!existsSync(runtimeArchive)) {
     return await failBeforeHarbor(
       runDir,
       config,
-      `AGENT_CLI_TARBALL does not exist after packaging: ${env.AGENT_CLI_TARBALL}`,
+      `Harness runtime archive does not exist after packaging: ${runtimeArchive}`,
       1
     );
   }
 
-  const agentCliSha256 = await sha256File(env.AGENT_CLI_TARBALL);
-  config = { ...config, agent_cli_sha256: agentCliSha256 };
+  const runtimeArchiveSha256 = await sha256File(runtimeArchive);
+  config = {
+    ...config,
+    runtime_archive_sha256: runtimeArchiveSha256,
+    agent_cli_sha256: options.harness === "sigma" ? runtimeArchiveSha256 : null
+  };
   await writeJson(path.join(runDir, "config.json"), config);
-  if (options.expectedArchiveSha256 && agentCliSha256 !== options.expectedArchiveSha256) {
+  if (options.expectedArchiveSha256 && runtimeArchiveSha256 !== options.expectedArchiveSha256) {
     return await failBeforeHarbor(
       runDir,
       config,
-      `Agent CLI archive SHA-256 ${agentCliSha256} does not match frozen ${options.expectedArchiveSha256}.`,
+      `Harness runtime archive SHA-256 ${runtimeArchiveSha256} does not match frozen ${options.expectedArchiveSha256}.`,
       1
     );
   }
@@ -316,7 +332,7 @@ async function runTerminalBenchCliImpl(argv, deps, signal) {
   process.stdout.write(`Packaging portable Harbor runtime...\n`);
   const harborRuntimeResult = await harborRuntimePackager({
     cwd: rootDir,
-    env: process.env,
+    env: runtimeEnv,
     stdoutPath: path.join(runDir, "package-harbor-runtime.stdout.log"),
     stderrPath: path.join(runDir, "package-harbor-runtime.stderr.log"),
     rawPath: path.join(runDir, "package-harbor-runtime.raw.log")
@@ -342,10 +358,11 @@ async function runTerminalBenchCliImpl(argv, deps, signal) {
       1
     );
   }
+  const importModule = options.harness === "codex" ? "codex_harbor_agent" : "sigma_harbor_agent";
   const importSmokeScript = [
-    "import pathlib, sys, sigma_harbor_agent",
+    `import pathlib, sys, ${importModule}`,
     "expected = pathlib.Path(sys.argv[1]).resolve()",
-    "actual = pathlib.Path(sigma_harbor_agent.__file__).resolve().parent",
+    `actual = pathlib.Path(${importModule}.__file__).resolve().parent`,
     "assert actual == expected, f'loaded {actual}, expected {expected}'"
   ].join("; ");
   const importSmoke = await runner(
@@ -431,7 +448,8 @@ async function runTerminalBenchCliImpl(argv, deps, signal) {
     const timeoutProbeConfig = buildHarborTimeoutProbeConfig(
       {
         ...options,
-        agentCliTarball: env.AGENT_CLI_TARBALL
+        env,
+        runtimeArchive
       },
       timeoutProbeJobsDir
     );
@@ -470,7 +488,8 @@ async function runTerminalBenchCliImpl(argv, deps, signal) {
 
   const attemptOptions = {
     ...options,
-    agentCliTarball: env.AGENT_CLI_TARBALL
+    env,
+    runtimeArchive
   };
   const timeoutGroups = options.mode === "smoke"
     ? [{ tasks: [], resolved_tasks: [], configured_tasks: [], timeout_probe: null }]

--- a/scripts/harbor_task_download_retry.py
+++ b/scripts/harbor_task_download_retry.py
@@ -1,0 +1,65 @@
+"""Generic, pre-solver retry boundary for Harbor Git task acquisition."""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+import sys
+from typing import Any
+
+
+TASK_DOWNLOAD_ATTEMPTS = 5
+
+
+def retryable_git_download(error: subprocess.CalledProcessError) -> bool:
+    command = [str(part).lower() for part in error.cmd]
+    return len(command) >= 2 and command[0].endswith("git") and command[1] in {
+        "clone",
+        "fetch",
+    }
+
+
+async def download_git_tasks_with_retry(
+    client: Any,
+    original: Any,
+    git_url: str,
+    task_download_configs: list[Any],
+    *,
+    attempts: int = TASK_DOWNLOAD_ATTEMPTS,
+    sleep: Any = asyncio.sleep,
+) -> Any:
+    for attempt in range(1, attempts + 1):
+        try:
+            return await original(client, git_url, task_download_configs)
+        except subprocess.CalledProcessError as error:
+            if attempt >= attempts or not retryable_git_download(error):
+                raise
+            delay = min(2 ** (attempt - 1), 8)
+            print(
+                f"Transient Git task download failed; retrying preflight "
+                f"({attempt}/{attempts}) in {delay}s.",
+                file=sys.stderr,
+            )
+            await sleep(delay)
+    raise AssertionError("unreachable")
+
+
+def install_git_task_download_retry(task_client_class: Any) -> None:
+    if getattr(task_client_class, "_sigma_preflight_retry_installed", False):
+        return
+    original = task_client_class._download_tasks_from_git_url
+
+    async def download_with_retry(
+        client: Any,
+        git_url: str,
+        task_download_configs: list[Any],
+    ) -> Any:
+        return await download_git_tasks_with_retry(
+            client,
+            original,
+            git_url,
+            task_download_configs,
+        )
+
+    task_client_class._download_tasks_from_git_url = download_with_retry
+    task_client_class._sigma_preflight_retry_installed = True

--- a/scripts/package-codex-runtime.mjs
+++ b/scripts/package-codex-runtime.mjs
@@ -17,6 +17,17 @@ function npmCommand(platform = process.platform) {
   return platform === "win32" ? "npm.cmd" : "npm";
 }
 
+export function normalizedProxyEnv(env = process.env) {
+  const next = { ...env };
+  for (const key of ["HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "http_proxy", "https_proxy", "all_proxy"]) {
+    const value = next[key];
+    if (typeof value === "string" && /^htpp:\/\//i.test(value)) {
+      next[key] = `http://${value.slice(7)}`;
+    }
+  }
+  return next;
+}
+
 function run(command, args, options = {}) {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
@@ -56,7 +67,7 @@ export async function packageCodexRuntime(options, deps = {}) {
     const runner = deps.run ?? run;
     const result = await runner(npmCommand(deps.platform), [
       "pack", packageId, "--pack-destination", temporary, "--json"
-    ], { cwd: temporary, env: deps.env ?? process.env });
+    ], { cwd: temporary, env: normalizedProxyEnv(deps.env ?? process.env) });
     if (result.exitCode !== 0) {
       throw new Error(`npm pack failed for ${packageId}: ${String(result.stderr).trim()}`);
     }

--- a/scripts/package-codex-runtime.mjs
+++ b/scripts/package-codex-runtime.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { constants } from "node:fs";
+import { mkdir, mkdtemp, open, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import spawn from "cross-spawn";
+
+const VERSION = /^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][A-Za-z0-9.-]+)?$/u;
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function npmCommand(platform = process.platform) {
+  return platform === "win32" ? "npm.cmd" : "npm";
+}
+
+function run(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.on("data", (chunk) => { stdout += chunk.toString(); });
+    child.stderr?.on("data", (chunk) => { stderr += chunk.toString(); });
+    child.once("error", reject);
+    child.once("close", (code) => resolve({ exitCode: code ?? 1, stdout, stderr }));
+  });
+}
+
+async function writeExclusive(filePath, bytes) {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  const handle = await open(filePath, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY, 0o600);
+  try {
+    await handle.writeFile(bytes);
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+}
+
+export async function packageCodexRuntime(options, deps = {}) {
+  const version = String(options?.version ?? "").trim();
+  if (!VERSION.test(version)) throw new Error("A concrete Codex --version is required.");
+  const output = path.resolve(String(options?.output ?? ""));
+  if (!options?.output) throw new Error("--output is required.");
+  const temporary = await mkdtemp(path.join(os.tmpdir(), "sigma-codex-runtime-"));
+  try {
+    const packageId = `@openai/codex@${version}-linux-x64`;
+    const runner = deps.run ?? run;
+    const result = await runner(npmCommand(deps.platform), [
+      "pack", packageId, "--pack-destination", temporary, "--json"
+    ], { cwd: temporary, env: deps.env ?? process.env });
+    if (result.exitCode !== 0) {
+      throw new Error(`npm pack failed for ${packageId}: ${String(result.stderr).trim()}`);
+    }
+    let records;
+    try {
+      records = JSON.parse(String(result.stdout));
+    } catch (error) {
+      throw new Error("npm pack did not return JSON metadata.", { cause: error });
+    }
+    if (!Array.isArray(records) || records.length !== 1) {
+      throw new Error("npm pack returned an unexpected package set.");
+    }
+    const record = records[0];
+    const expectedBinary = "vendor/x86_64-unknown-linux-musl/bin/codex";
+    if (record.id !== packageId || record.version !== `${version}-linux-x64`
+      || !Array.isArray(record.files)
+      || !record.files.some((file) => file?.path === expectedBinary && file?.mode === 493)) {
+      throw new Error("The Codex npm archive lacks the expected executable Linux runtime.");
+    }
+    const sourcePath = path.join(temporary, path.basename(String(record.filename ?? "")));
+    const bytes = await readFile(sourcePath);
+    await writeExclusive(output, bytes);
+    const metadata = {
+      schemaVersion: 1,
+      kind: "CodexRuntimeArchive",
+      package: packageId,
+      version,
+      target: "x86_64-unknown-linux-musl",
+      layout: "npm-linux-x64",
+      npm_integrity: record.integrity ?? null,
+      npm_shasum: record.shasum ?? null,
+      bytes: bytes.length,
+      sha256: sha256(bytes),
+      archive: path.basename(output)
+    };
+    if (options.metadataOutput) {
+      await writeExclusive(
+        path.resolve(options.metadataOutput),
+        Buffer.from(`${JSON.stringify(metadata, null, 2)}\n`)
+      );
+    }
+    return { output, metadata };
+  } finally {
+    await rm(temporary, { recursive: true, force: true });
+  }
+}
+
+function cliOptions(argv) {
+  const result = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const name = argv[index];
+    if (!["--version", "--output", "--metadata-output"].includes(name)) {
+      throw new Error(`Unsupported option: ${name}`);
+    }
+    const value = argv[index + 1];
+    if (!value || value.startsWith("--")) throw new Error(`${name} requires a value.`);
+    result[name.slice(2).replace(/-([a-z])/gu, (_match, letter) => letter.toUpperCase())] = value;
+    index += 1;
+  }
+  return result;
+}
+
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) packageCodexRuntime(cliOptions(process.argv.slice(2))).then(({ output, metadata }) => {
+  process.stdout.write(`${JSON.stringify({ output, ...metadata })}\n`);
+}).catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/package-harbor-runtime.mjs
+++ b/scripts/package-harbor-runtime.mjs
@@ -7,6 +7,7 @@ import {
   defaultAgentCliTarballForEnv,
   harborAptNetworkConfigPath as defaultHarborAptNetworkConfigPath,
   harborAptRetryWrapperPath as defaultHarborAptRetryWrapperPath,
+  harborCurlRetryWrapperPath as defaultHarborCurlRetryWrapperPath,
   harborProxyComposePath as defaultHarborProxyComposePath,
   harborRuntimeDir as defaultHarborRuntimeDir,
   harborSandboxComposePath as defaultHarborSandboxComposePath,
@@ -118,6 +119,12 @@ export async function packageHarborRuntime(options = {}) {
   const aptRetryWrapperPath = options.harborRuntimeDir || options.artifactsDir
     ? path.join(harborRuntimeDir, "apt-network-retry")
     : defaultHarborAptRetryWrapperPath;
+  const curlRetryWrapperSourcePath = options.curlRetryWrapperSourcePath
+    ? path.resolve(options.curlRetryWrapperSourcePath)
+    : path.join(rootDir, "portable", "harbor", "curl-network-retry");
+  const curlRetryWrapperPath = options.harborRuntimeDir || options.artifactsDir
+    ? path.join(harborRuntimeDir, "curl-network-retry")
+    : defaultHarborCurlRetryWrapperPath;
   const agentCliTarball = resolveAgentCliTarball(rootDir, artifactsDir, env, options);
 
   if (!existsSync(sourcePath)) {
@@ -138,6 +145,9 @@ export async function packageHarborRuntime(options = {}) {
   if (!existsSync(aptRetryWrapperSourcePath)) {
     throw new Error(`Portable Harbor APT retry wrapper is missing: ${aptRetryWrapperSourcePath}`);
   }
+  if (!existsSync(curlRetryWrapperSourcePath)) {
+    throw new Error(`Portable Harbor curl retry wrapper is missing: ${curlRetryWrapperSourcePath}`);
+  }
   if (options.requireAgentCliTarball !== false && !existsSync(agentCliTarball)) {
     throw new Error(`Packaged agent CLI is missing: ${agentCliTarball}. Run pnpm package:agent-cli first.`);
   }
@@ -148,6 +158,7 @@ export async function packageHarborRuntime(options = {}) {
   const proxyComposeText = await readFile(proxyComposeSourcePath, "utf8");
   const aptNetworkConfigText = await readFile(aptNetworkConfigSourcePath, "utf8");
   const aptRetryWrapperText = await readFile(aptRetryWrapperSourcePath, "utf8");
+  const curlRetryWrapperText = await readFile(curlRetryWrapperSourcePath, "utf8");
   assertNoRemovedHarborAdapter(sourceText, "Portable Harbor runtime source");
   assertNoRemovedHarborAdapter(codexSourceText, "Portable Codex Harbor runtime source");
 
@@ -162,6 +173,7 @@ export async function packageHarborRuntime(options = {}) {
   await writeFile(proxyComposePath, proxyComposeText, "utf8");
   await writeFile(aptNetworkConfigPath, aptNetworkConfigText, "utf8");
   await writeFile(aptRetryWrapperPath, aptRetryWrapperText, { encoding: "utf8", mode: 0o755 });
+  await writeFile(curlRetryWrapperPath, curlRetryWrapperText, { encoding: "utf8", mode: 0o755 });
 
   const readmeText = runtimeReadme(agentCliTarball);
 
@@ -178,6 +190,7 @@ export async function packageHarborRuntime(options = {}) {
     proxyComposePath,
     aptNetworkConfigPath,
     aptRetryWrapperPath,
+    curlRetryWrapperPath,
     agentCliTarball
   };
 }

--- a/scripts/package-harbor-runtime.mjs
+++ b/scripts/package-harbor-runtime.mjs
@@ -5,6 +5,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import {
   defaultAgentCliTarballForEnv,
+  harborAptNetworkConfigPath as defaultHarborAptNetworkConfigPath,
   harborProxyComposePath as defaultHarborProxyComposePath,
   harborRuntimeDir as defaultHarborRuntimeDir,
   harborSandboxComposePath as defaultHarborSandboxComposePath,
@@ -104,6 +105,12 @@ export async function packageHarborRuntime(options = {}) {
   const proxyComposePath = options.harborRuntimeDir || options.artifactsDir
     ? path.join(harborRuntimeDir, "docker-compose-sigma-proxy.yaml")
     : defaultHarborProxyComposePath;
+  const aptNetworkConfigSourcePath = options.aptNetworkConfigSourcePath
+    ? path.resolve(options.aptNetworkConfigSourcePath)
+    : path.join(rootDir, "portable", "harbor", "apt-network-retries.conf");
+  const aptNetworkConfigPath = options.harborRuntimeDir || options.artifactsDir
+    ? path.join(harborRuntimeDir, "apt-network-retries.conf")
+    : defaultHarborAptNetworkConfigPath;
   const agentCliTarball = resolveAgentCliTarball(rootDir, artifactsDir, env, options);
 
   if (!existsSync(sourcePath)) {
@@ -118,6 +125,9 @@ export async function packageHarborRuntime(options = {}) {
   if (!existsSync(proxyComposeSourcePath)) {
     throw new Error(`Portable Harbor proxy Compose overlay is missing: ${proxyComposeSourcePath}`);
   }
+  if (!existsSync(aptNetworkConfigSourcePath)) {
+    throw new Error(`Portable Harbor APT network config is missing: ${aptNetworkConfigSourcePath}`);
+  }
   if (options.requireAgentCliTarball !== false && !existsSync(agentCliTarball)) {
     throw new Error(`Packaged agent CLI is missing: ${agentCliTarball}. Run pnpm package:agent-cli first.`);
   }
@@ -126,6 +136,7 @@ export async function packageHarborRuntime(options = {}) {
   const codexSourceText = await readFile(codexSourcePath, "utf8");
   const sandboxComposeText = await readFile(sandboxComposeSourcePath, "utf8");
   const proxyComposeText = await readFile(proxyComposeSourcePath, "utf8");
+  const aptNetworkConfigText = await readFile(aptNetworkConfigSourcePath, "utf8");
   assertNoRemovedHarborAdapter(sourceText, "Portable Harbor runtime source");
   assertNoRemovedHarborAdapter(codexSourceText, "Portable Codex Harbor runtime source");
 
@@ -138,6 +149,7 @@ export async function packageHarborRuntime(options = {}) {
   await writeFile(codexRuntimePath, codexSourceText, "utf8");
   await writeFile(sandboxComposePath, sandboxComposeText, "utf8");
   await writeFile(proxyComposePath, proxyComposeText, "utf8");
+  await writeFile(aptNetworkConfigPath, aptNetworkConfigText, "utf8");
 
   const readmeText = runtimeReadme(agentCliTarball);
 
@@ -152,6 +164,7 @@ export async function packageHarborRuntime(options = {}) {
     codexRuntimePath,
     sandboxComposePath,
     proxyComposePath,
+    aptNetworkConfigPath,
     agentCliTarball
   };
 }

--- a/scripts/package-harbor-runtime.mjs
+++ b/scripts/package-harbor-runtime.mjs
@@ -5,6 +5,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import {
   defaultAgentCliTarballForEnv,
+  harborProxyComposePath as defaultHarborProxyComposePath,
   harborRuntimeDir as defaultHarborRuntimeDir,
   harborSandboxComposePath as defaultHarborSandboxComposePath,
   portableAgentImportPath,
@@ -97,6 +98,12 @@ export async function packageHarborRuntime(options = {}) {
   const sandboxComposePath = options.harborRuntimeDir || options.artifactsDir
     ? path.join(harborRuntimeDir, "docker-compose-sigma-sandbox.yaml")
     : defaultHarborSandboxComposePath;
+  const proxyComposeSourcePath = options.proxyComposeSourcePath
+    ? path.resolve(options.proxyComposeSourcePath)
+    : path.join(rootDir, "portable", "harbor", "docker-compose-sigma-proxy.yaml");
+  const proxyComposePath = options.harborRuntimeDir || options.artifactsDir
+    ? path.join(harborRuntimeDir, "docker-compose-sigma-proxy.yaml")
+    : defaultHarborProxyComposePath;
   const agentCliTarball = resolveAgentCliTarball(rootDir, artifactsDir, env, options);
 
   if (!existsSync(sourcePath)) {
@@ -108,6 +115,9 @@ export async function packageHarborRuntime(options = {}) {
   if (!existsSync(sandboxComposeSourcePath)) {
     throw new Error(`Portable Harbor sandbox Compose overlay is missing: ${sandboxComposeSourcePath}`);
   }
+  if (!existsSync(proxyComposeSourcePath)) {
+    throw new Error(`Portable Harbor proxy Compose overlay is missing: ${proxyComposeSourcePath}`);
+  }
   if (options.requireAgentCliTarball !== false && !existsSync(agentCliTarball)) {
     throw new Error(`Packaged agent CLI is missing: ${agentCliTarball}. Run pnpm package:agent-cli first.`);
   }
@@ -115,6 +125,7 @@ export async function packageHarborRuntime(options = {}) {
   const sourceText = await readFile(sourcePath, "utf8");
   const codexSourceText = await readFile(codexSourcePath, "utf8");
   const sandboxComposeText = await readFile(sandboxComposeSourcePath, "utf8");
+  const proxyComposeText = await readFile(proxyComposeSourcePath, "utf8");
   assertNoRemovedHarborAdapter(sourceText, "Portable Harbor runtime source");
   assertNoRemovedHarborAdapter(codexSourceText, "Portable Codex Harbor runtime source");
 
@@ -126,6 +137,7 @@ export async function packageHarborRuntime(options = {}) {
   await writeFile(runtimePath, sourceText, "utf8");
   await writeFile(codexRuntimePath, codexSourceText, "utf8");
   await writeFile(sandboxComposePath, sandboxComposeText, "utf8");
+  await writeFile(proxyComposePath, proxyComposeText, "utf8");
 
   const readmeText = runtimeReadme(agentCliTarball);
 
@@ -139,6 +151,7 @@ export async function packageHarborRuntime(options = {}) {
     runtimePath,
     codexRuntimePath,
     sandboxComposePath,
+    proxyComposePath,
     agentCliTarball
   };
 }

--- a/scripts/package-harbor-runtime.mjs
+++ b/scripts/package-harbor-runtime.mjs
@@ -108,7 +108,7 @@ export async function packageHarborRuntime(options = {}) {
   if (!existsSync(sandboxComposeSourcePath)) {
     throw new Error(`Portable Harbor sandbox Compose overlay is missing: ${sandboxComposeSourcePath}`);
   }
-  if (!existsSync(agentCliTarball)) {
+  if (options.requireAgentCliTarball !== false && !existsSync(agentCliTarball)) {
     throw new Error(`Packaged agent CLI is missing: ${agentCliTarball}. Run pnpm package:agent-cli first.`);
   }
 

--- a/scripts/package-harbor-runtime.mjs
+++ b/scripts/package-harbor-runtime.mjs
@@ -6,6 +6,7 @@ import { pathToFileURL } from "node:url";
 import {
   defaultAgentCliTarballForEnv,
   harborAptNetworkConfigPath as defaultHarborAptNetworkConfigPath,
+  harborAptRetryWrapperPath as defaultHarborAptRetryWrapperPath,
   harborProxyComposePath as defaultHarborProxyComposePath,
   harborRuntimeDir as defaultHarborRuntimeDir,
   harborSandboxComposePath as defaultHarborSandboxComposePath,
@@ -111,6 +112,12 @@ export async function packageHarborRuntime(options = {}) {
   const aptNetworkConfigPath = options.harborRuntimeDir || options.artifactsDir
     ? path.join(harborRuntimeDir, "apt-network-retries.conf")
     : defaultHarborAptNetworkConfigPath;
+  const aptRetryWrapperSourcePath = options.aptRetryWrapperSourcePath
+    ? path.resolve(options.aptRetryWrapperSourcePath)
+    : path.join(rootDir, "portable", "harbor", "apt-network-retry");
+  const aptRetryWrapperPath = options.harborRuntimeDir || options.artifactsDir
+    ? path.join(harborRuntimeDir, "apt-network-retry")
+    : defaultHarborAptRetryWrapperPath;
   const agentCliTarball = resolveAgentCliTarball(rootDir, artifactsDir, env, options);
 
   if (!existsSync(sourcePath)) {
@@ -128,6 +135,9 @@ export async function packageHarborRuntime(options = {}) {
   if (!existsSync(aptNetworkConfigSourcePath)) {
     throw new Error(`Portable Harbor APT network config is missing: ${aptNetworkConfigSourcePath}`);
   }
+  if (!existsSync(aptRetryWrapperSourcePath)) {
+    throw new Error(`Portable Harbor APT retry wrapper is missing: ${aptRetryWrapperSourcePath}`);
+  }
   if (options.requireAgentCliTarball !== false && !existsSync(agentCliTarball)) {
     throw new Error(`Packaged agent CLI is missing: ${agentCliTarball}. Run pnpm package:agent-cli first.`);
   }
@@ -137,6 +147,7 @@ export async function packageHarborRuntime(options = {}) {
   const sandboxComposeText = await readFile(sandboxComposeSourcePath, "utf8");
   const proxyComposeText = await readFile(proxyComposeSourcePath, "utf8");
   const aptNetworkConfigText = await readFile(aptNetworkConfigSourcePath, "utf8");
+  const aptRetryWrapperText = await readFile(aptRetryWrapperSourcePath, "utf8");
   assertNoRemovedHarborAdapter(sourceText, "Portable Harbor runtime source");
   assertNoRemovedHarborAdapter(codexSourceText, "Portable Codex Harbor runtime source");
 
@@ -150,6 +161,7 @@ export async function packageHarborRuntime(options = {}) {
   await writeFile(sandboxComposePath, sandboxComposeText, "utf8");
   await writeFile(proxyComposePath, proxyComposeText, "utf8");
   await writeFile(aptNetworkConfigPath, aptNetworkConfigText, "utf8");
+  await writeFile(aptRetryWrapperPath, aptRetryWrapperText, { encoding: "utf8", mode: 0o755 });
 
   const readmeText = runtimeReadme(agentCliTarball);
 
@@ -165,6 +177,7 @@ export async function packageHarborRuntime(options = {}) {
     sandboxComposePath,
     proxyComposePath,
     aptNetworkConfigPath,
+    aptRetryWrapperPath,
     agentCliTarball
   };
 }

--- a/scripts/probe-harbor-timeouts.py
+++ b/scripts/probe-harbor-timeouts.py
@@ -13,6 +13,8 @@ from harbor.job import Job
 from harbor.models.job.config import JobConfig
 from harbor.models.task.config import TaskConfig as TaskDefinitionConfig
 from harbor.models.task.paths import TaskPaths
+from harbor.tasks.client import TaskClient
+from harbor_task_download_retry import install_git_task_download_retry
 
 
 def _number(value: Any) -> float | None:
@@ -101,6 +103,7 @@ def _max_number(records: list[dict[str, Any]], key: str) -> float | None:
 
 
 async def _main(config_path: Path) -> None:
+    install_git_task_download_retry(TaskClient)
     config = JobConfig.model_validate_json(config_path.read_text(encoding="utf-8-sig"))
     job = await Job.create(config)
 

--- a/tests/bench-common.test.ts
+++ b/tests/bench-common.test.ts
@@ -20,6 +20,7 @@ import {
   groupHarborTimeoutProbe,
   assertComparableBenchmarkReports,
   harborEnvForRun,
+  harborProxyComposePath,
   harborTaskExecutionIdentitySha256,
   harborRuntimeDir,
   parseHarborTimeoutProbe,
@@ -919,6 +920,37 @@ describe("Terminal-Bench command construction", () => {
     expect(portableEnv.PYTHONPYCACHEPREFIX).toContain(path.join("runtime-scratch", "pycache"));
   });
 
+  it("maps host loopback proxies into Docker without changing the Harbor controller proxy", () => {
+    const env = harborEnvForRun("run-dir", {
+      HTTP_PROXY: "htpp://127.0.0.1:7890",
+      HTTPS_PROXY: "http://localhost:7890",
+      ALL_PROXY: "socks5://[::1]:7891",
+      NO_PROXY: "localhost,127.0.0.1"
+    });
+
+    expect(env.HTTP_PROXY).toBe("http://127.0.0.1:7890");
+    expect(env.SIGMA_CONTAINER_PROXY_ENABLED).toBe("1");
+    expect(env.SIGMA_CONTAINER_HTTP_PROXY).toBe("http://host.docker.internal:7890");
+    expect(env.SIGMA_CONTAINER_HTTPS_PROXY).toBe("http://host.docker.internal:7890");
+    expect(env.SIGMA_CONTAINER_ALL_PROXY).toBe("socks5://host.docker.internal:7891");
+    expect(env.SIGMA_CONTAINER_NO_PROXY).toBe("localhost,127.0.0.1");
+
+    const config = buildHarborJobConfig({ mode: "batch", tasks: [], env }, "jobs");
+    expect(config.environment.extra_docker_compose).toEqual([
+      expect.stringMatching(/docker-compose-sigma-sandbox\.yaml$/u),
+      harborProxyComposePath
+    ]);
+  });
+
+  it("does not add the container proxy overlay when the host has no proxy", () => {
+    const env = harborEnvForRun("run-dir", {});
+    const config = buildHarborJobConfig({ mode: "batch", tasks: [], env }, "jobs");
+    expect(config.environment.extra_docker_compose).toEqual([
+      expect.stringMatching(/docker-compose-sigma-sandbox\.yaml$/u)
+    ]);
+    expect(env).not.toHaveProperty("SIGMA_CONTAINER_PROXY_ENABLED");
+  });
+
   it("passes only an absolute host credential file path to the Harbor controller", async () => {
     const temporaryDirectory = await mkdtemp(path.join(os.tmpdir(), "sigma-harbor-credential-"));
     try {
@@ -968,6 +1000,9 @@ describe("Terminal-Bench command construction", () => {
 describe("failure classifier", () => {
   it("classifies common setup, API, timeout, and crash failures", () => {
     expect(classifyFailure({ logText: "ValueError: Unknown scheme for proxy URL URL('htpp://127.0.0.1:7890')" })).toBe(
+      "host_proxy_error"
+    );
+    expect(classifyFailure({ logText: "failed to connect: invalid peer certificate: UnknownIssuer" })).toBe(
       "host_proxy_error"
     );
     expect(classifyFailure({ logText: "UnicodeEncodeError: 'gbk' codec can't encode character '\\u2022'" })).toBe(

--- a/tests/bench-common.test.ts
+++ b/tests/bench-common.test.ts
@@ -935,6 +935,7 @@ describe("Terminal-Bench command construction", () => {
     expect(env.SIGMA_CONTAINER_ALL_PROXY).toBe("socks5://host.docker.internal:7891");
     expect(env.SIGMA_CONTAINER_NO_PROXY).toBe("localhost,127.0.0.1");
     expect(env.SIGMA_CONTAINER_APT_CONFIG).toMatch(/apt-network-retries\.conf$/u);
+    expect(env.SIGMA_CONTAINER_APT_RETRY_WRAPPER).toMatch(/apt-network-retry$/u);
 
     const config = buildHarborJobConfig({ mode: "batch", tasks: [], env }, "jobs");
     expect(config.environment.extra_docker_compose).toEqual([

--- a/tests/bench-common.test.ts
+++ b/tests/bench-common.test.ts
@@ -936,6 +936,7 @@ describe("Terminal-Bench command construction", () => {
     expect(env.SIGMA_CONTAINER_NO_PROXY).toBe("localhost,127.0.0.1");
     expect(env.SIGMA_CONTAINER_APT_CONFIG).toMatch(/apt-network-retries\.conf$/u);
     expect(env.SIGMA_CONTAINER_APT_RETRY_WRAPPER).toMatch(/apt-network-retry$/u);
+    expect(env.SIGMA_CONTAINER_CURL_RETRY_WRAPPER).toMatch(/curl-network-retry$/u);
 
     const config = buildHarborJobConfig({ mode: "batch", tasks: [], env }, "jobs");
     expect(config.environment.extra_docker_compose).toEqual([

--- a/tests/bench-common.test.ts
+++ b/tests/bench-common.test.ts
@@ -934,6 +934,7 @@ describe("Terminal-Bench command construction", () => {
     expect(env.SIGMA_CONTAINER_HTTPS_PROXY).toBe("http://host.docker.internal:7890");
     expect(env.SIGMA_CONTAINER_ALL_PROXY).toBe("socks5://host.docker.internal:7891");
     expect(env.SIGMA_CONTAINER_NO_PROXY).toBe("localhost,127.0.0.1");
+    expect(env.SIGMA_CONTAINER_APT_CONFIG).toMatch(/apt-network-retries\.conf$/u);
 
     const config = buildHarborJobConfig({ mode: "batch", tasks: [], env }, "jobs");
     expect(config.environment.extra_docker_compose).toEqual([

--- a/tests/bench-paired-experiment.test.ts
+++ b/tests/bench-paired-experiment.test.ts
@@ -1,0 +1,335 @@
+import { createHash } from "node:crypto";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  buildHarborJobConfig,
+  resolveRunOptions,
+  taskSelectionIdentitySha256
+} from "../scripts/bench-common.mjs";
+import { analyzePairedExperiment } from "../scripts/bench-paired-analysis.mjs";
+import {
+  classifyBlockingCondition,
+  runPairedExperiment
+} from "../scripts/bench-paired-experiment.mjs";
+import {
+  pairedExperimentPreregistration,
+  pairedSha256,
+  validatePairedExperiment
+} from "../scripts/bench-paired-preregistration.mjs";
+import { packageCodexRuntime } from "../scripts/package-codex-runtime.mjs";
+
+const revision = "a".repeat(40);
+
+function draft(taskCount = 10, repetitions = 5) {
+  return {
+    experiment_id: "generic-paired-harness",
+    arms: [
+      {
+        id: "reference",
+        harness: "codex",
+        runtime: {
+          archive_path: "codex.tgz",
+          archive_sha256: "b".repeat(64),
+          version: "0.147.0",
+          layout: "npm-linux-x64"
+        }
+      },
+      {
+        id: "comparison",
+        harness: "sigma",
+        runtime: {
+          archive_path: "sigma.tgz",
+          archive_sha256: "c".repeat(64),
+          version: null,
+          layout: "sigma-agent-cli"
+        }
+      }
+    ],
+    model: {
+      provider: "provider-fixture",
+      name: "model-fixture",
+      reasoning_effort: "max"
+    },
+    task_catalog: {
+      dataset: "fixture/dataset",
+      revision,
+      tasks: Array.from({ length: Math.max(taskCount, 12) }, (_unused, index) => ({
+        path: `tasks/task-${String(index).padStart(2, "0")}`,
+        git_url: "https://example.test/tasks.git",
+        git_commit_id: revision,
+        provenance_source: "frozen-fixture"
+      }))
+    },
+    selection: {
+      method: "sha256_rank_v1",
+      seed: "precommitted-seed",
+      sample_size: taskCount
+    },
+    controls: {
+      benchmark_class: "standard",
+      agent_profile: "standard",
+      max_turns: 200,
+      command_timeout_sec: 180,
+      cleanup_grace_sec: 120,
+      network_mode: "full",
+      execution_mode: "sandboxed",
+      write_scope: "workspace",
+      managed_environment_mode: "disabled",
+      harbor_topology: "main_only"
+    },
+    execution: {
+      repetitions,
+      concurrency: 4,
+      retries: 0,
+      ramp_task_counts: taskCount === 10 ? [1, 4, 10] : [taskCount]
+    }
+  };
+}
+
+function reportFor(manifest: ReturnType<typeof pairedExperimentPreregistration>, context: any, runDir: string) {
+  const arm = context.arm;
+  const task = manifest.selection.selected_tasks[context.pair.task_index];
+  const selectionIdentity = taskSelectionIdentitySha256(task);
+  return {
+    exitCode: 0,
+    runDir,
+    report: {
+      harness: arm.harness,
+      provider: manifest.model.provider,
+      model: manifest.model.name,
+      reasoning_effort: manifest.model.reasoning_effort,
+      dataset: manifest.task_catalog.dataset,
+      runtime_archive_sha256: arm.runtime.archive_sha256,
+      incomplete_reason: null,
+      infra_status: "passed",
+      trial_accounting: { expected: 1, observed: 1, missing: 0 },
+      tasks: [{
+        selection_identity_sha256: selectionIdentity,
+        validity: "valid",
+        verifier_outcome: context.pair.task_index % 2 === 0 ? "passed" : "failed",
+        agent_outcome: "completed",
+        failure_category: context.pair.task_index % 2 === 0 ? null : "verifier_failed",
+        duration_ms: arm.id === "comparison" ? 80 : 100,
+        input_tokens: arm.id === "comparison" ? 80 : 100,
+        cache_read_tokens: 40,
+        output_tokens: 10,
+        reasoning_tokens: 5,
+        commands_executed: arm.id === "comparison" ? 4 : 5,
+        cost_usd: null,
+        trace_path: null,
+        trace_format: null
+      }]
+    }
+  };
+}
+
+async function frozen(directory: string, value: ReturnType<typeof pairedExperimentPreregistration>) {
+  const file = path.join(directory, "preregistration.json");
+  const bytes = `${JSON.stringify(value, null, 2)}\n`;
+  await writeFile(file, bytes, "utf8");
+  return { file, sha256: pairedSha256(bytes) };
+}
+
+describe("paired Harness experiment", () => {
+  it("derives a neutral sample, five repetitions, gradual ramp, and balanced arm order", () => {
+    const value = pairedExperimentPreregistration(draft());
+    expect(value).toMatchObject({
+      kind: "PairedHarnessExperiment",
+      selection: { method: "sha256_rank_v1", sample_size: 10 },
+      execution: { repetitions: 5, concurrency: 4, retries: 0, expected_attempts: 100 },
+      stop_loss: {
+        score_independent: true,
+        verifier_feedback_to_solver: false,
+        retry_consumed_attempts: false
+      }
+    });
+    expect(value.execution.stages.map((stage) => stage.pairs.length)).toEqual([1, 3, 6, 10, 10, 10, 10]);
+    const orders = value.execution.stages.flatMap((stage) => stage.pairs.map((pair) => pair.arms[0]));
+    expect(orders.filter((arm) => arm === "reference")).toHaveLength(25);
+    expect(orders.filter((arm) => arm === "comparison")).toHaveLength(25);
+    expect(validatePairedExperiment(value)).toEqual(value);
+    expect(() => validatePairedExperiment({
+      ...value,
+      execution: { ...value.execution, expected_attempts: 99 }
+    })).toThrow(/stale/iu);
+  });
+
+  it("selects independently of catalog order and prohibits retry controls", () => {
+    const first = pairedExperimentPreregistration(draft());
+    const shuffled = draft();
+    shuffled.task_catalog.tasks.reverse();
+    const second = pairedExperimentPreregistration(shuffled);
+    expect(second.selection.selected_task_identity_sha256)
+      .toBe(first.selection.selected_task_identity_sha256);
+    const invalid = draft();
+    invalid.execution.retries = 1;
+    expect(() => pairedExperimentPreregistration(invalid)).toThrow(/retries=0/u);
+  });
+
+  it("builds Codex Harbor kwargs without Sigma-only controls", () => {
+    const archive = path.resolve("codex.tgz");
+    const digest = "d".repeat(64);
+    const options = resolveRunOptions([
+      "--mode", "task", "--task-id", "fixture-task",
+      "--harness", "codex",
+      "--provider", "provider-fixture",
+      "--model", "model-fixture",
+      "--reasoning-effort", "max",
+      "--runtime-archive", archive,
+      "--runtime-version", "0.147.0",
+      "--runtime-layout", "npm-linux-x64",
+      "--reuse-package",
+      "--expected-archive-sha256", digest
+    ], {});
+    const agent = buildHarborJobConfig(options, "jobs").agents[0];
+    expect(agent.name).toBe("codex_harbor_agent:PortableCodex");
+    expect(agent.kwargs).toMatchObject({
+      codex_cli_tarball: archive,
+      codex_cli_sha256: digest,
+      codex_cli_layout: "npm-linux-x64",
+      version: "0.147.0",
+      model_name: "model-fixture",
+      reasoning_effort: "max"
+    });
+    expect(agent.kwargs).not.toHaveProperty("agent_profile");
+    expect(agent.kwargs).not.toHaveProperty("provider");
+  });
+
+  it("consumes one ramp stage once and never retries its attempts", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "sigma-paired-run-"));
+    try {
+      const manifest = pairedExperimentPreregistration(draft(2, 1), { baseDir: directory });
+      const preregistration = await frozen(directory, manifest);
+      const output = path.join(directory, "output");
+      const calls: string[] = [];
+      const result = await runPairedExperiment([
+        "--preregistration-file", preregistration.file,
+        "--expected-preregistration-sha256", preregistration.sha256,
+        "--output", output,
+        "--stage", "next"
+      ], {
+        assertFrozenArchives: async () => undefined,
+        assertCredentials: async () => undefined,
+        packageHarborRuntime: async () => ({ exitCode: 0, harborRuntimeDir: directory }),
+        runArm: async (_args: string[], context: any) => {
+          await context.beforeHarborDispatch();
+          calls.push(`${context.pair.task_index}:${context.arm.id}`);
+          const runDir = path.join(directory, "runs", calls.at(-1)!.replace(":", "-"));
+          await mkdir(runDir, { recursive: true });
+          return reportFor(manifest, context, runDir);
+        }
+      });
+      expect(result.status).toBe("complete");
+      expect(calls).toHaveLength(4);
+      await expect(runPairedExperiment([
+        "--preregistration-file", preregistration.file,
+        "--expected-preregistration-sha256", preregistration.sha256,
+        "--output", output,
+        "--stage", manifest.execution.stages[0].id
+      ], {
+        assertFrozenArchives: async () => undefined,
+        assertCredentials: async () => undefined
+      })).rejects.toThrow(/next unconsumed stage|already complete/iu);
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("stops on neutral infrastructure failure but not ordinary verifier failure", () => {
+    const base = {
+      incomplete_reason: null,
+      trial_accounting: { expected: 1, observed: 1, missing: 0 },
+      notes: []
+    };
+    expect(classifyBlockingCondition(base, {
+      validity: "valid", failure_category: "verifier_failed", last_error: "tests failed"
+    })).toBeNull();
+    expect(classifyBlockingCondition(base, {
+      validity: "infra_failed", failure_category: "agent_setup_failed"
+    })).toBe("infra_failed_attempt");
+    expect(classifyBlockingCondition(base, {
+      validity: "valid", failure_category: "api_error", last_error: "authentication failed"
+    })).toBe("credential_or_provider_unavailable");
+  });
+
+  it("packages an exact official platform archive and records content identity", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "sigma-codex-package-"));
+    try {
+      const output = path.join(directory, "codex.tgz");
+      const result = await packageCodexRuntime({ version: "0.147.0", output }, {
+        platform: "linux",
+        run: async (_command: string, args: string[]) => {
+          const destination = args[args.indexOf("--pack-destination") + 1];
+          const filename = "openai-codex-0.147.0-linux-x64.tgz";
+          await writeFile(path.join(destination, filename), "archive-bytes", "utf8");
+          return {
+            exitCode: 0,
+            stderr: "",
+            stdout: JSON.stringify([{
+              id: "@openai/codex@0.147.0-linux-x64",
+              version: "0.147.0-linux-x64",
+              filename,
+              integrity: "sha512-fixture",
+              shasum: "fixture",
+              files: [{
+                path: "vendor/x86_64-unknown-linux-musl/bin/codex",
+                mode: 493
+              }]
+            }])
+          };
+        }
+      });
+      expect(result.metadata).toMatchObject({
+        version: "0.147.0",
+        layout: "npm-linux-x64",
+        sha256: createHash("sha256").update("archive-bytes").digest("hex")
+      });
+      await expect(readFile(output, "utf8")).resolves.toBe("archive-bytes");
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("analyzes paired outcomes and efficiency from immutable receipts", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "sigma-paired-analysis-"));
+    try {
+      const manifest = pairedExperimentPreregistration(draft(2, 1), { baseDir: directory });
+      const preregistration = await frozen(directory, manifest);
+      const output = path.join(directory, "output");
+      const runResult = await runPairedExperiment([
+        "--preregistration-file", preregistration.file,
+        "--expected-preregistration-sha256", preregistration.sha256,
+        "--output", output,
+        "--stage", "next"
+      ], {
+        assertFrozenArchives: async () => undefined,
+        assertCredentials: async () => undefined,
+        packageHarborRuntime: async () => ({ exitCode: 0, harborRuntimeDir: directory }),
+        runArm: async (_args: string[], context: any) => {
+          await context.beforeHarborDispatch();
+          const runDir = path.join(directory, "analysis-runs", `${context.pair.task_index}-${context.arm.id}`);
+          await mkdir(runDir, { recursive: true });
+          return reportFor(manifest, context, runDir);
+        }
+      });
+      expect(runResult.status).toBe("complete");
+      const analysis = await analyzePairedExperiment({
+        preregistrationFile: preregistration.file,
+        expectedSha256: preregistration.sha256,
+        experimentOutput: output,
+        allowPartial: false
+      });
+      expect(analysis).toMatchObject({
+        status: "complete",
+        observed_attempts: 4,
+        paired: { complete_pairs: 2 }
+      });
+      expect(analysis.arms.reference.pass_rate).toBe(0.5);
+      expect(analysis.paired.efficiency.duration_ms.joint_success.median_ratio).toBe(0.8);
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/bench-paired-experiment.test.ts
+++ b/tests/bench-paired-experiment.test.ts
@@ -346,6 +346,11 @@ describe("paired Harness experiment", () => {
     expect(classifyBlockingCondition(base, {
       validity: "valid", failure_category: "api_error", last_error: "authentication failed"
     })).toBe("credential_or_provider_unavailable");
+    expect(classifyBlockingCondition(base, {
+      validity: "valid",
+      failure_category: "agent_crashed",
+      last_error: "Optional MCP worker quit with AuthRequired after the model had already started."
+    })).toBeNull();
   });
 
   it("preserves an attested task identity when Harbor fails before producing a trial", () => {

--- a/tests/bench-paired-experiment.test.ts
+++ b/tests/bench-paired-experiment.test.ts
@@ -18,7 +18,7 @@ import {
   pairedSha256,
   validatePairedExperiment
 } from "../scripts/bench-paired-preregistration.mjs";
-import { packageCodexRuntime } from "../scripts/package-codex-runtime.mjs";
+import { normalizedProxyEnv, packageCodexRuntime } from "../scripts/package-codex-runtime.mjs";
 
 const revision = "a".repeat(40);
 
@@ -290,6 +290,16 @@ describe("paired Harness experiment", () => {
     } finally {
       await rm(directory, { recursive: true, force: true });
     }
+  });
+
+  it("repairs malformed proxy schemes before invoking npm", async () => {
+    expect(normalizedProxyEnv({
+      http_proxy: "htpp://127.0.0.1:7890",
+      HTTPS_PROXY: "https://proxy.example"
+    })).toEqual({
+      http_proxy: "http://127.0.0.1:7890",
+      HTTPS_PROXY: "https://proxy.example"
+    });
   });
 
   it("analyzes paired outcomes and efficiency from immutable receipts", async () => {

--- a/tests/bench-paired-experiment.test.ts
+++ b/tests/bench-paired-experiment.test.ts
@@ -280,6 +280,7 @@ describe("paired Harness experiment", () => {
         assertFrozenArchives: async () => undefined,
         assertCredentials: async () => undefined,
         packageHarborRuntime: async () => ({ exitCode: 0, harborRuntimeDir: directory }),
+        prefetchTasks: async () => undefined,
         runArm: async (_args: string[], context: any) => {
           await context.beforeHarborDispatch();
           calls.push(`${context.pair.task_index}:${context.arm.id}`);
@@ -299,6 +300,32 @@ describe("paired Harness experiment", () => {
         assertFrozenArchives: async () => undefined,
         assertCredentials: async () => undefined
       })).rejects.toThrow(/next unconsumed stage|already complete/iu);
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("runs task-cache prefetch before consuming a stage", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "sigma-paired-prefetch-"));
+    try {
+      const manifest = pairedExperimentPreregistration(draft(2, 1), { baseDir: directory });
+      const preregistration = await frozen(directory, manifest);
+      const output = path.join(directory, "output");
+      await expect(runPairedExperiment([
+        "--preregistration-file", preregistration.file,
+        "--expected-preregistration-sha256", preregistration.sha256,
+        "--output", output,
+        "--stage", "next"
+      ], {
+        assertFrozenArchives: async () => undefined,
+        assertCredentials: async () => undefined,
+        packageHarborRuntime: async () => ({ exitCode: 0, harborRuntimeDir: directory }),
+        prefetchTasks: async () => { throw new Error("prefetch fixture failed"); }
+      })).rejects.toThrow("prefetch fixture failed");
+      await expect(readFile(
+        path.join(output, "receipts", manifest.execution.stages[0].id, "stage.started.json"),
+        "utf8"
+      )).rejects.toMatchObject({ code: "ENOENT" });
     } finally {
       await rm(directory, { recursive: true, force: true });
     }
@@ -421,6 +448,7 @@ describe("paired Harness experiment", () => {
         assertFrozenArchives: async () => undefined,
         assertCredentials: async () => undefined,
         packageHarborRuntime: async () => ({ exitCode: 0, harborRuntimeDir: directory }),
+        prefetchTasks: async () => undefined,
         runArm: async (_args: string[], context: any) => {
           await context.beforeHarborDispatch();
           const runDir = path.join(directory, "analysis-runs", `${context.pair.task_index}-${context.arm.id}`);

--- a/tests/bench-paired-experiment.test.ts
+++ b/tests/bench-paired-experiment.test.ts
@@ -10,7 +10,11 @@ import {
   runSlotIntegrityReasons,
   taskSelectionIdentitySha256
 } from "../scripts/bench-common.mjs";
-import { analyzePairedExperiment } from "../scripts/bench-paired-analysis.mjs";
+import {
+  analyzePairedExperiment,
+  bootstrapByTask,
+  semanticToolCategory
+} from "../scripts/bench-paired-analysis.mjs";
 import {
   classifyBlockingCondition,
   runPairedExperiment,
@@ -478,5 +482,26 @@ describe("paired Harness experiment", () => {
     } finally {
       await rm(directory, { recursive: true, force: true });
     }
+  });
+
+  it("cluster-resamples tasks with replacement instead of cycling low PRNG bits", () => {
+    const rows = Array.from({ length: 8 }, (_unused, task_index) => ({ task_index, value: task_index }));
+    const interval = bootstrapByTask(rows, (row) => row.value, "bootstrap-fixture");
+    expect(interval).toMatchObject({ samples: 4_000 });
+    expect(interval!.low).toBeLessThan(interval!.high);
+    expect(interval!.low).toBeLessThan(3.5);
+    expect(interval!.high).toBeGreaterThan(3.5);
+  });
+
+  it("normalizes cross-harness tool aliases into semantic categories", () => {
+    expect(semanticToolCategory("exec")).toBe("command");
+    expect(semanticToolCategory("shell")).toBe("command");
+    expect(semanticToolCategory("read")).toBe("inspect");
+    expect(semanticToolCategory("grep")).toBe("inspect");
+    expect(semanticToolCategory("apply_patch")).toBe("edit");
+    expect(semanticToolCategory("update_plan")).toBe("plan");
+    expect(semanticToolCategory("spawn_agent")).toBe("delegate");
+    expect(semanticToolCategory("join_agent")).toBe("wait");
+    expect(semanticToolCategory("custom-tool")).toBe("other:custom_tool");
   });
 });

--- a/tests/bench-paired-experiment.test.ts
+++ b/tests/bench-paired-experiment.test.ts
@@ -4,8 +4,10 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+  buildHarborArgs,
   buildHarborJobConfig,
   resolveRunOptions,
+  runSlotIntegrityReasons,
   taskSelectionIdentitySha256
 } from "../scripts/bench-common.mjs";
 import { analyzePairedExperiment } from "../scripts/bench-paired-analysis.mjs";
@@ -197,6 +199,69 @@ describe("paired Harness experiment", () => {
     expect(agent.kwargs).not.toHaveProperty("model_name");
     expect(agent.kwargs).not.toHaveProperty("agent_profile");
     expect(agent.kwargs).not.toHaveProperty("provider");
+  });
+
+  it("keeps the Codex model in Harbor's standard field across config and CLI integrity checks", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "sigma-codex-controls-"));
+    try {
+      const archive = path.resolve("codex.tgz");
+      const digest = "d".repeat(64);
+      const options = resolveRunOptions([
+        "--mode", "task", "--task-id", "fixture-task",
+        "--harness", "codex",
+        "--provider", "provider-fixture",
+        "--model", "model-fixture",
+        "--reasoning-effort", "max",
+        "--runtime-archive", archive,
+        "--runtime-version", "0.147.0",
+        "--runtime-layout", "npm-linux-x64",
+        "--reuse-package",
+        "--expected-archive-sha256", digest
+      ], {});
+      const jobConfig = buildHarborJobConfig(options, "jobs");
+      const configPath = path.join(directory, "resolved-job.config.json");
+      const bytes = `${JSON.stringify(jobConfig, null, 2)}\n`;
+      await writeFile(configPath, bytes, "utf8");
+      const config = {
+        mode: "task",
+        harness: "codex",
+        model: "model-fixture",
+        reasoning_effort: "max",
+        runtime_archive_sha256: digest,
+        runtime_layout: "npm-linux-x64",
+        runtime_version: "0.147.0",
+        run_slots: [{
+          run_slot: "slot-one",
+          resolved_job_config_path: "resolved-job.config.json",
+          job_config_sha256: createHash("sha256").update(bytes).digest("hex")
+        }]
+      };
+      await expect(runSlotIntegrityReasons(directory, config)).resolves.toEqual([]);
+
+      const args = buildHarborArgs({
+        ...options,
+        k: 1,
+        capabilities: {
+          agentFlag: "--agent",
+          agentKwargStyle: "plain",
+          taskLimitFlag: "-l",
+          taskSelectionFlag: "--task"
+        }
+      });
+      expect(args.slice(args.indexOf("--model"), args.indexOf("--model") + 2))
+        .toEqual(["--model", "model-fixture"]);
+      expect(args.some((item) => item.includes("model_name"))).toBe(false);
+
+      jobConfig.agents[0].model_name = "drifted-model";
+      const driftedBytes = `${JSON.stringify(jobConfig, null, 2)}\n`;
+      await writeFile(configPath, driftedBytes, "utf8");
+      config.run_slots[0].job_config_sha256 = createHash("sha256").update(driftedBytes).digest("hex");
+      await expect(runSlotIntegrityReasons(directory, config)).resolves.toEqual([
+        "Harbor run slot slot-one agent control model_name does not match its frozen run."
+      ]);
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
   });
 
   it("consumes one ramp stage once and never retries its attempts", async () => {

--- a/tests/bench-paired-experiment.test.ts
+++ b/tests/bench-paired-experiment.test.ts
@@ -11,7 +11,8 @@ import {
 import { analyzePairedExperiment } from "../scripts/bench-paired-analysis.mjs";
 import {
   classifyBlockingCondition,
-  runPairedExperiment
+  runPairedExperiment,
+  summarizePairedAttempt
 } from "../scripts/bench-paired-experiment.mjs";
 import {
   pairedExperimentPreregistration,
@@ -190,9 +191,10 @@ describe("paired Harness experiment", () => {
       codex_cli_sha256: digest,
       codex_cli_layout: "npm-linux-x64",
       version: "0.147.0",
-      model_name: "model-fixture",
       reasoning_effort: "max"
     });
+    expect(agent.model_name).toBe("model-fixture");
+    expect(agent.kwargs).not.toHaveProperty("model_name");
     expect(agent.kwargs).not.toHaveProperty("agent_profile");
     expect(agent.kwargs).not.toHaveProperty("provider");
   });
@@ -252,6 +254,43 @@ describe("paired Harness experiment", () => {
     expect(classifyBlockingCondition(base, {
       validity: "valid", failure_category: "api_error", last_error: "authentication failed"
     })).toBe("credential_or_provider_unavailable");
+  });
+
+  it("preserves an attested task identity when Harbor fails before producing a trial", () => {
+    const manifest = pairedExperimentPreregistration(draft(2, 1));
+    const stage = manifest.execution.stages[0];
+    const pair = stage.pairs[0];
+    const arm = manifest.arms.find((item) => item.id === pair.arms[0])!;
+    const expectedIdentity = taskSelectionIdentitySha256(
+      manifest.selection.selected_tasks[pair.task_index]
+    );
+    const summary = summarizePairedAttempt({
+      manifest,
+      stage,
+      pair,
+      arm,
+      result: {
+        runDir: "failed-run",
+        report: {
+          harness: arm.harness,
+          provider: manifest.model.provider,
+          model: manifest.model.name,
+          reasoning_effort: manifest.model.reasoning_effort,
+          dataset: manifest.task_catalog.dataset,
+          runtime_archive_sha256: arm.runtime.archive_sha256,
+          incomplete_reason: ["No Harbor trial result was produced."],
+          trial_accounting: { expected: 1, observed: 0, missing: 1 },
+          run_slots: [{ selection_identity_sha256: expectedIdentity }],
+          tasks: [{ failure_category: "harbor_cli_error", verifier_outcome: "not_run" }]
+        }
+      }
+    });
+    expect(summary).toMatchObject({
+      valid: false,
+      passed: false,
+      blocking_condition: "missing_or_incomplete_report",
+      task_identity_evidence: "run_slot_attestation"
+    });
   });
 
   it("packages an exact official platform archive and records content identity", async () => {

--- a/tests/bench-terminal-bench.test.ts
+++ b/tests/bench-terminal-bench.test.ts
@@ -187,6 +187,9 @@ describe("Terminal-Bench CLI verifier result handling", () => {
       "--mode", "task", "--task-id", "selected-task", "--reuse-package",
       "--expected-archive-sha256", sha, "--run-label", "reuse-test"
     ], {
+      writeOutput: () => {
+        throw Object.assign(new Error("progress consumer disconnected"), { code: "EPIPE" });
+      },
       resolveHarborCommand: () => ({ command: "harbor", source: "test", exists: true }),
       packageAgentCli: async () => {
         packageCalls += 1;
@@ -215,6 +218,7 @@ describe("Terminal-Bench CLI verifier result handling", () => {
       expect(packageCalls).toBe(0);
       expect(result.report.agent_cli_sha256).toBe(sha);
       expect(result.report.package_reused).toBe(true);
+      expect(result.report.status).toBe("passed");
     } finally {
       await removeRunArtifacts(result.runDir);
       if (previousTarball === undefined) delete process.env.AGENT_CLI_TARBALL;

--- a/tests/package-harbor-runtime.test.ts
+++ b/tests/package-harbor-runtime.test.ts
@@ -19,6 +19,7 @@ describe("package-harbor-runtime", () => {
     const runtimeSource = await readFile(path.join(result.harborRuntimeDir, "sigma_harbor_agent.py"), "utf8");
     const codexRuntimeSource = await readFile(path.join(result.harborRuntimeDir, "codex_harbor_agent.py"), "utf8");
     const sandboxCompose = await readFile(result.sandboxComposePath, "utf8");
+    const proxyCompose = await readFile(result.proxyComposePath, "utf8");
     const readme = await readFile(path.join(result.harborRuntimeDir, "README.md"), "utf8");
     const packagedFiles = await readdir(result.harborRuntimeDir);
 
@@ -30,6 +31,8 @@ describe("package-harbor-runtime", () => {
     expect(runtimeSource).toContain(portableAgentImportPath.split(":")[1]);
     expect(sandboxCompose).toContain("SYS_ADMIN");
     expect(sandboxCompose).toContain("seccomp=unconfined");
+    expect(proxyCompose).toContain("host.docker.internal:host-gateway");
+    expect(proxyCompose).toContain("SIGMA_CONTAINER_HTTPS_PROXY");
     expect(path.isAbsolute(result.agentCliTarball)).toBe(true);
     expect(packagedFiles.some((name) => name.endsWith(".json"))).toBe(false);
     expect(readme).not.toContain(removedHarborPackageName);

--- a/tests/package-harbor-runtime.test.ts
+++ b/tests/package-harbor-runtime.test.ts
@@ -20,6 +20,7 @@ describe("package-harbor-runtime", () => {
     const codexRuntimeSource = await readFile(path.join(result.harborRuntimeDir, "codex_harbor_agent.py"), "utf8");
     const sandboxCompose = await readFile(result.sandboxComposePath, "utf8");
     const proxyCompose = await readFile(result.proxyComposePath, "utf8");
+    const aptNetworkConfig = await readFile(result.aptNetworkConfigPath, "utf8");
     const readme = await readFile(path.join(result.harborRuntimeDir, "README.md"), "utf8");
     const packagedFiles = await readdir(result.harborRuntimeDir);
 
@@ -33,6 +34,8 @@ describe("package-harbor-runtime", () => {
     expect(sandboxCompose).toContain("seccomp=unconfined");
     expect(proxyCompose).toContain("host.docker.internal:host-gateway");
     expect(proxyCompose).toContain("SIGMA_CONTAINER_HTTPS_PROXY");
+    expect(proxyCompose).toContain("80sigma-network-retries");
+    expect(aptNetworkConfig).toContain('Acquire::Retries "5";');
     expect(path.isAbsolute(result.agentCliTarball)).toBe(true);
     expect(packagedFiles.some((name) => name.endsWith(".json"))).toBe(false);
     expect(readme).not.toContain(removedHarborPackageName);

--- a/tests/package-harbor-runtime.test.ts
+++ b/tests/package-harbor-runtime.test.ts
@@ -21,6 +21,7 @@ describe("package-harbor-runtime", () => {
     const sandboxCompose = await readFile(result.sandboxComposePath, "utf8");
     const proxyCompose = await readFile(result.proxyComposePath, "utf8");
     const aptNetworkConfig = await readFile(result.aptNetworkConfigPath, "utf8");
+    const aptRetryWrapper = await readFile(result.aptRetryWrapperPath, "utf8");
     const readme = await readFile(path.join(result.harborRuntimeDir, "README.md"), "utf8");
     const packagedFiles = await readdir(result.harborRuntimeDir);
 
@@ -35,7 +36,11 @@ describe("package-harbor-runtime", () => {
     expect(proxyCompose).toContain("host.docker.internal:host-gateway");
     expect(proxyCompose).toContain("SIGMA_CONTAINER_HTTPS_PROXY");
     expect(proxyCompose).toContain("80sigma-network-retries");
+    expect(proxyCompose).toContain("SIGMA_CONTAINER_APT_RETRY_WRAPPER");
     expect(aptNetworkConfig).toContain('Acquire::Retries "5";');
+    expect(aptRetryWrapper).toContain("Transient APT network failure");
+    expect(aptRetryWrapper).toContain("502[[:space:]]+Bad Gateway");
+    expect(aptRetryWrapper).toContain('exit "$status"');
     expect(path.isAbsolute(result.agentCliTarball)).toBe(true);
     expect(packagedFiles.some((name) => name.endsWith(".json"))).toBe(false);
     expect(readme).not.toContain(removedHarborPackageName);

--- a/tests/package-harbor-runtime.test.ts
+++ b/tests/package-harbor-runtime.test.ts
@@ -45,6 +45,8 @@ describe("package-harbor-runtime", () => {
     expect(aptRetryWrapper).toContain('exit "$status"');
     expect(curlRetryWrapper).toContain("Transient curl network failure");
     expect(curlRetryWrapper).toContain("5|6|7|18|28|35|52|55|56|92");
+    expect(curlRetryWrapper).toContain("max_attempts=8");
+    expect(curlRetryWrapper).toContain("max_delay=30");
     expect(curlRetryWrapper).toContain('cat "$stdout_file"');
     expect(path.isAbsolute(result.agentCliTarball)).toBe(true);
     expect(packagedFiles.some((name) => name.endsWith(".json"))).toBe(false);

--- a/tests/package-harbor-runtime.test.ts
+++ b/tests/package-harbor-runtime.test.ts
@@ -22,6 +22,7 @@ describe("package-harbor-runtime", () => {
     const proxyCompose = await readFile(result.proxyComposePath, "utf8");
     const aptNetworkConfig = await readFile(result.aptNetworkConfigPath, "utf8");
     const aptRetryWrapper = await readFile(result.aptRetryWrapperPath, "utf8");
+    const curlRetryWrapper = await readFile(result.curlRetryWrapperPath, "utf8");
     const readme = await readFile(path.join(result.harborRuntimeDir, "README.md"), "utf8");
     const packagedFiles = await readdir(result.harborRuntimeDir);
 
@@ -37,10 +38,14 @@ describe("package-harbor-runtime", () => {
     expect(proxyCompose).toContain("SIGMA_CONTAINER_HTTPS_PROXY");
     expect(proxyCompose).toContain("80sigma-network-retries");
     expect(proxyCompose).toContain("SIGMA_CONTAINER_APT_RETRY_WRAPPER");
+    expect(proxyCompose).toContain("SIGMA_CONTAINER_CURL_RETRY_WRAPPER");
     expect(aptNetworkConfig).toContain('Acquire::Retries "5";');
     expect(aptRetryWrapper).toContain("Transient APT network failure");
     expect(aptRetryWrapper).toContain("502[[:space:]]+Bad Gateway");
     expect(aptRetryWrapper).toContain('exit "$status"');
+    expect(curlRetryWrapper).toContain("Transient curl network failure");
+    expect(curlRetryWrapper).toContain("5|6|7|18|28|35|52|55|56|92");
+    expect(curlRetryWrapper).toContain('cat "$stdout_file"');
     expect(path.isAbsolute(result.agentCliTarball)).toBe(true);
     expect(packagedFiles.some((name) => name.endsWith(".json"))).toBe(false);
     expect(readme).not.toContain(removedHarborPackageName);

--- a/tests/test_codex_harbor_agent.py
+++ b/tests/test_codex_harbor_agent.py
@@ -116,6 +116,46 @@ class PortableCodexTest(unittest.IsolatedAsyncioTestCase):
                     codex_cli_sha256="0" * 64,
                 )
 
+    async def test_installs_official_npm_linux_archive_layout(self):
+        module, _stub = import_portable_codex_module()
+        with TemporaryDirectory() as tmp:
+            archive = Path(tmp) / "codex-linux-x64.tgz"
+            archive.write_bytes(b"official-platform-runtime")
+            digest = hashlib.sha256(archive.read_bytes()).hexdigest()
+            agent = module.PortableCodex(
+                logs_dir=Path(tmp) / "logs",
+                version="0.146.0",
+                codex_cli_tarball=archive,
+                codex_cli_sha256=digest,
+                codex_cli_layout="npm-linux-x64",
+            )
+            environment = RecordingEnvironment()
+
+            await agent.install(environment)
+
+        commands = "\n".join(command for command, _kwargs in environment.exec_calls)
+        self.assertIn("--strip-components=0", commands)
+        self.assertIn(
+            "/opt/codex-cli/package/vendor/"
+            "x86_64-unknown-linux-musl/bin/codex",
+            commands,
+        )
+
+    async def test_rejects_unknown_archive_layout(self):
+        module, _stub = import_portable_codex_module()
+        with TemporaryDirectory() as tmp:
+            archive = Path(tmp) / "codex-cli.tgz"
+            archive.write_bytes(b"runtime")
+            digest = hashlib.sha256(archive.read_bytes()).hexdigest()
+            with self.assertRaisesRegex(ValueError, "codex_cli_layout"):
+                module.PortableCodex(
+                    logs_dir=Path(tmp) / "logs",
+                    version="0.146.0",
+                    codex_cli_tarball=archive,
+                    codex_cli_sha256=digest,
+                    codex_cli_layout="unknown",
+                )
+
     async def test_rejects_extracted_version_mismatch(self):
         module, _stub = import_portable_codex_module()
         with TemporaryDirectory() as tmp:

--- a/tests/test_harbor_agent.py
+++ b/tests/test_harbor_agent.py
@@ -117,6 +117,19 @@ def managed_doctor_payload() -> str:
     return json.dumps(payload)
 
 
+def transient_doctor_api_failure(category: str = "timeout") -> str:
+    payload = json.loads(current_doctor_payload())
+    payload["status"] = "error"
+    payload["checks"] = [{
+        "name": "api",
+        "status": "error",
+        "message": f"transient {category}",
+        "failure_kind": "network_error" if category in {"network", "timeout"} else "api_error",
+        "error_category": category,
+    }]
+    return json.dumps(payload)
+
+
 class HarborAgentTest(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         self._saved_agent_env = {
@@ -879,12 +892,47 @@ class HarborAgentTest(unittest.IsolatedAsyncioTestCase):
                     "command -v /usr/local/bin/agent >/dev/null 2>&1",
                     "/usr/local/bin/agent --help",
                     "/usr/local/bin/agent doctor --workspace /app --json --strict "
+                    "--provider deepseek --model auto "
                     "--execution-mode sandboxed --network full --read-scope host "
                     "--write-scope workspace "
                     "--managed-environment-mode disabled --reasoning-effort auto "
                     "--max-model-turns 200 "
                     "--command-timeout-sec 180 --check-api",
                 ],
+            )
+
+    async def test_setup_retries_only_transient_api_doctor_failure_for_selected_model(self):
+        module = import_portable_agent_module()
+        with TemporaryDirectory() as tmp:
+            env = SimpleNamespace(exec=AsyncMock(side_effect=[
+                SimpleNamespace(return_code=0, stdout="usage", stderr=""),
+                SimpleNamespace(return_code=1, stdout=transient_doctor_api_failure(), stderr=""),
+                SimpleNamespace(return_code=1, stdout=transient_doctor_api_failure("server"), stderr=""),
+                SimpleNamespace(return_code=0, stdout=current_doctor_payload(), stderr=""),
+            ]))
+            agent = module.SigmaCliHarborAgent(
+                logs_dir=Path(tmp) / "logs",
+                provider="openai-codex",
+                model="gpt-5.6-sol",
+            )
+            agent._workspace = "/app"
+
+            with patch.object(module.asyncio, "sleep", new_callable=AsyncMock) as sleep:
+                await agent._verify_agent_ready(env)
+
+            self.assertEqual([item.args[0] for item in sleep.await_args_list], [1, 2])
+            doctor_commands = [item.args[0] for item in env.exec.await_args_list[1:]]
+            self.assertEqual(len(doctor_commands), 3)
+            self.assertTrue(all(
+                "--provider openai-codex --model gpt-5.6-sol" in command
+                for command in doctor_commands
+            ))
+            record = json.loads((Path(tmp) / "logs" / "setup-check.json").read_text(encoding="utf-8"))
+            attempts = record["checks"][1]["preflight_attempts"]
+            self.assertEqual([item["exit_code"] for item in attempts], [1, 1, 0])
+            self.assertEqual(
+                [item["retryable_api_failure"] for item in attempts],
+                [True, True, False],
             )
 
     async def test_setup_doctor_failure_is_classified_and_persisted(self):

--- a/tests/test_harbor_probe.py
+++ b/tests/test_harbor_probe.py
@@ -1,0 +1,41 @@
+import asyncio
+import subprocess
+import unittest
+from pathlib import Path
+
+from scripts.harbor_task_download_retry import download_git_tasks_with_retry
+
+
+class HarborProbeRetryTest(unittest.TestCase):
+    def test_retries_transient_clone_without_retrying_other_git_failures(self) -> None:
+        calls = []
+        delays = []
+
+        async def original(_client, _url, _configs):
+            calls.append(len(calls) + 1)
+            if len(calls) < 3:
+                raise subprocess.CalledProcessError(128, ["git", "clone"])
+            return {Path("task"): "a" * 40}
+
+        async def sleep(delay):
+            delays.append(delay)
+
+        result = asyncio.run(download_git_tasks_with_retry(
+            object(), original, "https://example.test/repo.git", [], sleep=sleep
+        ))
+        self.assertEqual(result, {Path("task"): "a" * 40})
+        self.assertEqual(calls, [1, 2, 3])
+        self.assertEqual(delays, [1, 2])
+
+        async def checkout_failure(_client, _url, _configs):
+            raise subprocess.CalledProcessError(1, ["git", "checkout"])
+
+        with self.assertRaises(subprocess.CalledProcessError):
+            asyncio.run(download_git_tasks_with_retry(
+                object(), checkout_failure, "https://example.test/repo.git", [], sleep=sleep
+            ))
+        self.assertEqual(delays, [1, 2])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

- add a generic two-arm paired harness experiment controller with immutable preregistration
- support pinned official Codex Linux runtime archives alongside the Sigma Code runtime
- normalize Sigma JSONL and Codex ATIF traces into comparable correctness, efficiency, cost, and behavior metrics
- add append-only receipts, balanced arm order, gradual ramp stages, and score-independent stop-loss
- fix task-cluster bootstrap sampling so confidence intervals actually resample tasks with replacement
- compare cross-harness tool sequences through neutral semantic categories instead of harness-specific tool names
- document the workflow and cover it with unit/integration tests

## Why

The existing benchmark path could run one harness at a time, but it could not execute a fair same-model paired A/B or compare raw trace behavior across harness formats.

## Fairness and safety

- task sampling is a seeded SHA-256 ranking over a complete externally pinned catalog
- no task-name or benchmark-identity branching
- no verifier feedback is exposed to either solving agent
- no consumed attempt is retried
- stop-loss only reacts to blocking infrastructure/control-integrity failures, never scores
- prior stopped experiments remain sealed and are not pooled into the completed result

## Verification

- `pnpm test` — 177 files passed, 1 skipped; 1,614 tests passed, 27 skipped
- `pnpm lint`
- `pnpm test:harbor` — 63 passed
- `pnpm eval:fairness`
- real benchmark-free Harbor `AgentFactory` construction with the pinned Codex archive
- `git diff --check`

## Completed formal experiment

Frozen design:

- experiment: `codex-vs-sigma-gpt56sol-max-tb21-20260814-v12`
- preregistration SHA-256: `144a098161b36df196156942798429575e7a244e3acd1c931f3834aa3494c1d8`
- consumption identity: `f9e079a06f15723dc4559016fe905c262c503519928129977c1ed81263a34e82`
- `openai-codex/gpt-5.6-sol`, reasoning `max`
- Terminal-Bench 2.1 at revision `5c8eadf1f393183288fa08b8f73ca9a469cc5e00`
- 10 neutrally sampled tasks × 5 repetitions × 2 arms; concurrency 4; retries 0
- balanced 25/25 arm order; first-repetition ramp 1 → 4 → 10 tasks
- 100/100 attempts and 50/50 pairs completed; no stop receipt

### Outcome

| metric | Codex | Sigma |
|---|---:|---:|
| attempt pass rate | 80.0% (40/50) | 60.0% (30/50) |
| Wilson 95% interval | 67.0%–88.8% | 46.2%–72.4% |
| tasks passing at least once | 9/10 | 8/10 |
| median wall time | 415,449 ms | 735,000 ms |
| median uncached tokens | 84,645 | 111,529 |
| median output tokens | 9,440 | 16,971 |
| median reasoning tokens | 4,498 | 8,624 |
| median commands | 20 | 32 |
| median normalized tool calls | 20 | 30.5 |

Task pass counts across five repetitions:

| task | Codex | Sigma |
|---|---:|---:|
| tune-mjcf | 5 | 5 |
| code-from-image | 5 | 5 |
| path-tracing-reverse | 5 | 5 |
| reshard-c4-data | 5 | 4 |
| mteb-leaderboard | 5 | 3 |
| multi-source-data-merger | 5 | 5 |
| filter-js-from-html | 1 | 0 |
| caffe-cifar-10 | 4 | 1 |
| sqlite-with-gcov | 0 | 0 |
| fix-ocaml-gc | 5 | 2 |

### Paired statistics

- Codex-only passes: 10; Sigma-only passes: 0; ties: 40
- exact two-sided McNemar p-value: `0.001953125`
- the arm-order strata are consistent: Codex-only 6/25 when Sigma ran first and 4/25 when Codex ran first; Sigma-only 0 in both
- all-valid Sigma/Codex wall-time median ratio: `1.535`, task-cluster bootstrap 95% interval `1.177–2.514`; Sigma was slower in 41/50 pairs
- joint-success wall-time ratio: `1.375` (`1.284–1.775`); Sigma was slower in 26/30 pairs
- all-valid uncached-token ratio: `1.206` (`0.988–1.569`); directional but the cluster interval includes 1
- all-valid output-token ratio: `1.194` (`1.112–1.562`), reasoning-token ratio: `1.247` (`1.194–1.659`)
- all-valid command ratio: `1.267` (`1.000–1.667`); joint-success ratio: `1.394` (`1.158–2.167`)
- raw input-token ratio favors Sigma directionally (`0.566`, `0.396–1.050`), while Sigma emits more output/reasoning tokens; input/cache accounting should not be treated as interchangeable with uncached-token demand

### Trace findings

- trace coverage is 50/50 for each arm
- model turns are similar (median 21 vs 21.5; paired Sigma/Codex median ratio `0.9`)
- Sigma makes more tool calls (paired median ratio `1.233`; worse in 33/50 pairs)
- exact repeated tool-call signatures have median 0 for Codex and 25 for Sigma; Sigma is worse in 50/50 pairs (paired median ratio `8.071`)
- after semantic tool-category normalization, paired sequence edit distance has median `0.667` (P25 `0.538`, P75 `0.815`), showing materially different execution shapes without conflating `exec` and `shell` naming
- cost is intentionally not compared: usable telemetry covers only 10 Codex attempts and 0 Sigma attempts

### Interpretation and limits

Within this preregistered sample, Codex is materially better on correctness and wall time. Sigma's weaker result is accompanied by 8 timeouts (Codex: 0), more tool use, substantially more repeated exact calls, and more output/reasoning tokens. Sigma's main favorable direction is lower raw input-token accounting, but its cluster interval crosses parity and this does not translate into lower uncached-token demand or wall time.

The correctness Wilson intervals and McNemar test operate on the 50 attempt pairs; five repetitions from the same task are not fully independent. Efficiency intervals therefore task-cluster-resample all repetitions together. With only 10 sampled tasks, the result is strong evidence for this frozen experiment, not a universal ranking over Terminal-Bench or every workload.